### PR TITLE
baseline: fix issue where file not in existing baseline

### DIFF
--- a/mypy/errors.py
+++ b/mypy/errors.py
@@ -814,7 +814,9 @@ class Errors:
 
         self.all_errors = self.error_info_map.copy()
         for file, errors in self.error_info_map.items():
-            baseline_errors = self.baseline[file.removeprefix(os.getcwd())]
+            baseline_errors = self.baseline.get(file.removeprefix(os.getcwd()))
+            if not baseline_errors:
+                return
             new_errors = []
             for error in errors:
                 for baseline_error in baseline_errors:


### PR DESCRIPTION
There was a sus bug imposting on the baseline functionality where you run mypy and a currently checked file does not have any errors in the baseline.