### PR TITLE
Infer function types

### DIFF
--- a/.mypy/baseline.json
+++ b/.mypy/baseline.json
@@ -2482,7 +2482,7 @@
         "code": "attr-defined",
         "column": 0,
         "message": "Module \"mypy.semanal\" does not explicitly export attribute \"set_callable_name\"; implicit reexport disabled",
-        "offset": 73,
+        "offset": 74,
         "target": "mypy.checker"
       },
       {
@@ -2522,16 +2522,275 @@
       },
       {
         "code": "no-any-expr",
+        "column": 53,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 234,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 53,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 53,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 53,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 53,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 53,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 53,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 53,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "truthy-bool",
+        "column": 16,
+        "message": "Member \"unanalyzed_type\" has type \"ProperType\" which does not implement __bool__ or __len__ so it could always be true in boolean context",
+        "offset": 3,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "truthy-bool",
+        "column": 16,
+        "message": "Member \"unanalyzed_type\" has type \"ProperType\" which does not implement __bool__ or __len__ so it could always be true in boolean context",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "truthy-bool",
+        "column": 16,
+        "message": "Member \"unanalyzed_type\" has type \"ProperType\" which does not implement __bool__ or __len__ so it could always be true in boolean context",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "truthy-bool",
+        "column": 16,
+        "message": "Member \"unanalyzed_type\" has type \"ProperType\" which does not implement __bool__ or __len__ so it could always be true in boolean context",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 74,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 74,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 74,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 74,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 54,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 29,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 60,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 14,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 49,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 1,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 41,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 3,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 41,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 8,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 45,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 8,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 60,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 3,
+        "target": "mypy.checker.TypeChecker.visit_func_def"
+      },
+      {
+        "code": "no-any-expr",
         "column": 31,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 296,
+        "offset": 91,
         "target": "mypy.checker.TypeChecker.check_func_item"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 48,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 24,
+        "target": "mypy.checker.TypeChecker.check_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 48,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.check_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 48,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.check_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 48,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.check_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 46,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 7,
+        "target": "mypy.checker.TypeChecker.check_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 46,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.check_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 46,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 10,
+        "target": "mypy.checker.TypeChecker.check_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 46,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.check_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 46,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.check_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 46,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.check_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 57,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 7,
+        "target": "mypy.checker.TypeChecker.check_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 57,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.check_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 49,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 7,
+        "target": "mypy.checker.TypeChecker.check_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 49,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.checker.TypeChecker.check_func_def"
       },
       {
         "code": "no-any-expr",
         "column": 63,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 47,
+        "offset": 51,
         "target": "mypy.checker.TypeChecker.check_func_def"
       },
       {
@@ -2545,7 +2804,7 @@
         "code": "no-any-expr",
         "column": 57,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 214,
+        "offset": 210,
         "target": "mypy.checker.TypeChecker.check_for_missing_annotations"
       },
       {
@@ -2559,28 +2818,14 @@
         "code": "no-any-expr",
         "column": 39,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 22,
-        "target": "mypy.checker.TypeChecker.check_for_missing_annotations"
-      },
-      {
-        "code": "no-any-expr",
-        "column": 35,
-        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
         "offset": 16,
-        "target": "mypy.checker.TypeChecker.check_for_missing_annotations"
-      },
-      {
-        "code": "no-any-expr",
-        "column": 35,
-        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 0,
         "target": "mypy.checker.TypeChecker.check_for_missing_annotations"
       },
       {
         "code": "redundant-expr",
         "column": 11,
         "message": "Left operand of \"and\" is always true",
-        "offset": 11,
+        "offset": 19,
         "target": "mypy.checker.TypeChecker.check___new___signature"
       },
       {
@@ -3077,16 +3322,9 @@
       },
       {
         "code": "no-any-expr",
-        "column": 40,
-        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 0,
-        "target": "mypy.checkexpr.ExpressionChecker.visit_call_expr_inner"
-      },
-      {
-        "code": "no-any-expr",
         "column": 35,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 68,
+        "offset": 88,
         "target": "mypy.checkexpr.ExpressionChecker.method_fullname"
       },
       {
@@ -11970,7 +12208,7 @@
         "code": "no-any-expr",
         "column": 66,
         "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
-        "offset": 177,
+        "offset": 184,
         "target": "mypy.main.process_options"
       },
       {
@@ -13299,7 +13537,7 @@
         "code": "no-any-expr",
         "column": 36,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 230,
+        "offset": 237,
         "target": "mypy.messages.MessageBuilder.incompatible_argument_note"
       },
       {
@@ -14478,7 +14716,7 @@
         "code": "no-any-unimported",
         "column": 8,
         "message": "Type of variable becomes \"set[Any]\" due to an unfollowed import",
-        "offset": 206,
+        "offset": 212,
         "target": "mypy.options.Options.__init__"
       },
       {
@@ -14527,7 +14765,7 @@
         "code": "no-any-expr",
         "column": 21,
         "message": "Expression has type \"Any\"",
-        "offset": 105,
+        "offset": 108,
         "target": "mypy.options.Options.select_options_affecting_cache"
       }
     ],
@@ -16314,7 +16552,7 @@
         "code": "no-any-expr",
         "column": 41,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 643,
+        "offset": 645,
         "target": "mypy.semanal.SemanticAnalyzer.analyze_func_def"
       },
       {
@@ -16326,14 +16564,28 @@
       },
       {
         "code": "no-any-expr",
-        "column": 45,
+        "column": 49,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 9,
+        "offset": 10,
         "target": "mypy.semanal.SemanticAnalyzer.analyze_func_def"
       },
       {
         "code": "no-any-expr",
-        "column": 45,
+        "column": 49,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.semanal.SemanticAnalyzer.analyze_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 49,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 12,
+        "target": "mypy.semanal.SemanticAnalyzer.analyze_func_def"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 49,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
         "offset": 0,
         "target": "mypy.semanal.SemanticAnalyzer.analyze_func_def"
@@ -16342,7 +16594,7 @@
         "code": "no-any-expr",
         "column": 45,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 9,
+        "offset": 18,
         "target": "mypy.semanal.SemanticAnalyzer.analyze_func_def"
       },
       {
@@ -16391,7 +16643,7 @@
         "code": "no-any-expr",
         "column": 31,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 192,
+        "offset": 187,
         "target": "mypy.semanal.SemanticAnalyzer.check_classvar_in_signature"
       },
       {
@@ -16722,6 +16974,55 @@
         "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.semanal.apply_semantic_analyzer_patches"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 43,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 70,
+        "target": "mypy.semanal.infer_fdef_types_from_defaults"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 43,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.semanal.infer_fdef_types_from_defaults"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 37,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 28,
+        "target": "mypy.semanal.infer_fdef_types_from_defaults"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 45,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 2,
+        "target": "mypy.semanal.infer_fdef_types_from_defaults"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 45,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.semanal.infer_fdef_types_from_defaults"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 45,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.semanal.infer_fdef_types_from_defaults"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 45,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "target": "mypy.semanal.infer_fdef_types_from_defaults"
       }
     ],
     "mypy/semanal_infer.py": [
@@ -23346,7 +23647,7 @@
         "code": "no-any-expr",
         "column": 7,
         "message": "Expression has type \"Any\"",
-        "offset": 20,
+        "offset": 26,
         "target": "mypy.test.helpers.parse_options"
       },
       {
@@ -23436,14 +23737,14 @@
         "code": "no-any-expr",
         "column": 33,
         "message": "Expression type contains \"Any\" (has type \"str | Any\")",
-        "offset": 133,
+        "offset": 135,
         "target": "mypy.test.testcheck.TypeCheckSuite.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 11,
         "message": "Expression type contains \"Any\" (has type \"Literal[False] | Any\")",
-        "offset": 101,
+        "offset": 105,
         "target": "mypy.test.testcheck.TypeCheckSuite.run_case_once"
       },
       {
@@ -25319,6 +25620,20 @@
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
         "offset": 0,
         "target": "mypy.typeops.custom_special_method"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 53,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 62,
+        "target": "mypy.typeops.infer_impl_from_parts"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 42,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 1,
+        "target": "mypy.typeops.infer_impl_from_parts"
       }
     ],
     "mypy/types.py": [
@@ -25599,7 +25914,7 @@
         "code": "no-any-explicit",
         "column": 4,
         "message": "Explicit \"Any\" is not allowed",
-        "offset": 71,
+        "offset": 72,
         "target": "mypy.types.CallableType.__init__"
       },
       {
@@ -25641,7 +25956,7 @@
         "code": "no-any-explicit",
         "column": 4,
         "message": "Explicit \"Any\" is not allowed",
-        "offset": 11,
+        "offset": 14,
         "target": "mypy.types.CallableType.copy_modified"
       },
       {
@@ -26348,7 +26663,7 @@
         "code": "truthy-bool",
         "column": 11,
         "message": "Member \"partial_fallback\" has type \"Instance\" which does not implement __bool__ or __len__ so it could always be true in boolean context",
-        "offset": 79,
+        "offset": 83,
         "target": "mypy.types.TypeStrVisitor.visit_tuple_type"
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 ### Added
 - `ignore_any_from_errors` option to suppress `no-any-expr` messages from other errors
+- Function types are inferred from Overloads, overrides and default values.
+- Calls to incomplete functions are an error (configurable with `incomplete_is_typed`)
 ### Enhancements
 - Render types a lot better in output messages
 

--- a/misc/upload-pypi.py
+++ b/misc/upload-pypi.py
@@ -111,7 +111,8 @@ def upload_dist(dist: Path, dry_run: bool = True) -> None:
 
 
 def upload_to_pypi(version: str, dry_run: bool = True) -> None:
-    assert re.match(r"v?\d+\.\d+\.\d+(\+\S+)?(a|b|rc)\d+$", version)
+    # Verify `version` is a valid version, eg: 1.3.1rc2
+    assert re.match(r"v?\d+\.\d+\.\d+(\+dev\.\S+|(a|b|rc)\d+)?$", version)
     if "dev" in version:
         assert dry_run, "Must use --dry-run with dev versions of mypy"
     if version.startswith("v"):

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -37,7 +37,8 @@ from mypy.types import (
     UnionType, TypeVarId, TypeVarType, PartialType, DeletedType, UninhabitedType,
     is_named_instance, union_items, TypeQuery, LiteralType,
     is_optional, remove_optional, TypeTranslator, StarType, get_proper_type, ProperType,
-    get_proper_types, is_literal_type, TypeAliasType, TypeGuardedType, ParamSpecType
+    get_proper_types, is_literal_type, TypeAliasType, TypeGuardedType, ParamSpecType,
+    is_unannotated_any,
 )
 from mypy.sametypes import is_same_type
 from mypy.messages import (
@@ -771,6 +772,104 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
     def visit_func_def(self, defn: FuncDef) -> None:
         if not self.recurse_into_functions:
             return
+        # If possible, transform def into an overload from super information
+        if defn.info and not defn.is_overload and (
+            # if it's fully annotated then we allow the invalid override
+            not (defn.type and isinstance(defn.type, CallableType) and defn.type.fully_typed)
+            or not defn.unanalyzed_type
+
+            or (defn.unanalyzed_type and isinstance(defn.unanalyzed_type, CallableType) and (
+                is_unannotated_any(defn.unanalyzed_type.ret_type)
+                or any(is_unannotated_any(typ) for typ in defn.unanalyzed_type.arg_types[1:])
+            ))
+        ) and self.options.infer_function_types:
+            for base in defn.info.mro[1:]:
+                super_ = base.names.get(defn.name)
+                if not super_ or not isinstance(super_.node, OverloadedFuncDef):
+                    continue
+                super_type = get_proper_type(super_.type)
+                assert isinstance(super_type, Overloaded)
+                if super_.node.impl:
+                    super_types = {
+                        arg: arg_type
+                        for arg, arg_type in zip(
+                            (
+                                super_.node.impl
+                                if isinstance(super_.node.impl, FuncDef)
+                                else super_.node.impl.func
+                            ).arg_names,
+                            cast(CallableType, super_.node.impl.type).arg_types,
+                        )
+                    }
+                else:
+                    super_types = {}
+                item_arg_types: Dict[str, List[Type]] = defaultdict(list)
+                item_ret_types = []
+                for item in super_.node.items:
+                    assert isinstance(item, Decorator)
+                    assert isinstance(item.func.type, CallableType)
+                    for arg, arg_type in zip(item.func.arg_names, item.func.type.arg_types):
+                        if not arg:
+                            continue
+                        if arg not in super_types and arg in defn.arg_names:
+                            if arg_type not in item_arg_types[arg]:
+                                item_arg_types[arg].append(arg_type)
+                    if item.func.type.ret_type not in item_ret_types:
+                        item_ret_types.append(item.func.type.ret_type)
+                super_types.update({
+                    arg: UnionType.make_union(arg_type) for arg, arg_type in item_arg_types.items()
+                })
+                any_ = AnyType(TypeOfAny.unannotated)
+                if defn.unanalyzed_type:
+                    assert isinstance(defn.unanalyzed_type, CallableType)
+                    assert isinstance(defn.type, CallableType)
+                    assert super_.node.impl
+                    t = get_proper_type(super_.node.impl.type)
+                    assert isinstance(t, CallableType)
+                    ret_type = (
+                        defn.type.ret_type
+                        if not is_unannotated_any(defn.unanalyzed_type.ret_type)
+                        else t.ret_type
+                    )
+                elif super_.node.impl:
+                    t = get_proper_type(super_.node.impl.type)
+                    assert isinstance(t, CallableType)
+                    ret_type = t.ret_type
+                elif item_ret_types:
+                    ret_type = UnionType.make_union(item_ret_types)
+                else:
+                    ret_type = any_
+                if not defn.type:
+                    defn.type = self.function_type(defn)
+                assert isinstance(defn.type, CallableType)
+                arg_types = [defn.type.arg_types[0]]
+                if defn.unanalyzed_type:
+                    assert isinstance(defn.unanalyzed_type, CallableType)
+                    arg_types.extend([
+                        arg_type
+                        if not is_unannotated_any(unanalyzed)
+                        else super_types.get(arg, any_)
+                        for arg, arg_type, unanalyzed in zip(
+                            defn.arg_names[1:],
+                            defn.type.arg_types[1:],
+                            defn.unanalyzed_type.arg_types[1:]
+                        )
+                    ])
+                else:
+                    arg_types.extend([super_types.get(arg, any_) for arg in defn.arg_names[1:]])
+                defn.type = defn.type.copy_modified(arg_types=arg_types, ret_type=ret_type)
+                new = OverloadedFuncDef(super_.node.items)
+                # the TypeInfo isn't set on each part, but idc
+                new.info = defn.info
+                new.impl = defn
+                new.type = Overloaded([item.copy_modified() for item in super_type.items])
+                if not defn.is_static:
+                    for new_item in new.type.items:
+                        new_item.arg_types[0] = defn.type.arg_types[0]
+                defn.is_overload = True
+                self.visit_overloaded_func_def(new)
+                defn.type = new.type
+                return
         with self.tscope.function_scope(defn):
             self._visit_func_def(defn)
 
@@ -857,6 +956,65 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
     def check_func_def(self, defn: FuncItem, typ: CallableType, name: Optional[str]) -> None:
         """Type check a function definition."""
+
+        # Infer argument types from base class
+        if defn.info and self.options.infer_function_types and not (
+            defn.type and isinstance(defn.type, CallableType) and defn.type.fully_typed
+        ):
+            for base in defn.info.mro[1:]:
+                super_ = base.names.get(defn.name)
+                if not super_ or not super_.type:
+                    continue
+                super_type = get_proper_type(super_.type)
+                if not isinstance(super_type, CallableType):
+                    continue
+
+                arg_types: List[Type] = []
+                for arg_i, arg_name in enumerate(defn.arg_names):
+                    # skip self/class
+                    if arg_i == 0 and not defn.is_static:
+                        arg_types.append(typ.arg_types[0])
+                        continue
+                    if (
+                        isinstance(defn.type, CallableType)
+                        and not isinstance(get_proper_type(defn.type.arg_types[arg_i]), AnyType)
+                    ):
+                        continue
+                    if arg_name in super_type.arg_names:
+                        super_i = super_type.arg_names.index(arg_name)
+                        if defn.type:
+                            assert isinstance(defn.type, CallableType)
+                            defn.type.arg_types[arg_i] = super_type.arg_types[super_i]
+                        else:
+                            arg_types.append(super_type.arg_types[super_i])
+                    elif not defn.type:
+                        arg_types.append(AnyType(TypeOfAny.unannotated))
+                if defn.type:
+                    assert isinstance(defn.type, CallableType)
+                    if isinstance(get_proper_type(defn.type.ret_type), AnyType):
+                        defn.type.ret_type = super_type.ret_type
+                else:
+                    typ = defn.type = CallableType(
+                        arg_types,
+                        defn.arg_kinds,
+                        defn.arg_names,
+                        super_type.ret_type
+                        if defn.name != "__new__"
+                        else fill_typevars_with_any(defn.info),
+                        self.named_type('builtins.function'))
+                break
+
+        # Infer argument types from default values,
+        #  this is done in semanal for literals, but done again here for some reason
+        if self.options.infer_function_types and not typ.fully_typed:
+            arg_types = []
+            for arg, arg_type in zip(defn.arguments, typ.arg_types):
+                if arg.initializer and is_unannotated_any(arg_type):
+                    arg_types.append(self.expr_checker.accept(arg.initializer))
+                else:
+                    arg_types.append(arg_type)
+            typ.arg_types = arg_types
+
         # Expand type variables with value restrictions to ordinary types.
         expanded = self.expand_typevars(defn, typ)
         for item, typ in expanded:
@@ -876,12 +1034,12 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                             not self.dynamic_funcs[-1]):
                         self.fail(message_registry.MUST_HAVE_NONE_RETURN_TYPE.format(fdef.name),
                                   item)
-                    self.check_for_missing_annotations(fdef, typ)
 
                     # Check validity of __new__ signature
                     if fdef.info and fdef.name == '__new__':
                         self.check___new___signature(fdef, typ)
 
+                    self.check_for_missing_annotations(fdef)
                     if self.options.disallow_any_unimported:
                         if fdef.type and isinstance(fdef.type, CallableType):
                             ret_type = fdef.type.ret_type
@@ -1090,12 +1248,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         else:
             return method_name in operators.reverse_op_method_set
 
-    def check_for_missing_annotations(self, fdef: FuncItem, typ: CallableType) -> None:
+    def check_for_missing_annotations(self, fdef: FuncItem) -> None:
         # Check for functions with unspecified/not fully specified types.
-        def is_unannotated_any(t: Type) -> bool:
-            if not isinstance(t, ProperType):
-                return False
-            return isinstance(t, AnyType) and t.type_of_any == TypeOfAny.unannotated
 
         has_explicit_annotation = (isinstance(fdef.type, CallableType)
                                    and any(not is_unannotated_any(t)
@@ -1105,27 +1259,18 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         check_incomplete_defs = self.options.disallow_incomplete_defs and has_explicit_annotation
         if show_untyped and (self.options.disallow_untyped_defs or check_incomplete_defs):
             if fdef.type is None and self.options.disallow_untyped_defs:
-                if self.options.default_return:
-                    typ.implicit = False
-                    typ.ret_type = NoneType()
-                    # fully unannotated fdef needs to be assigned a type
-                    fdef.type = typ
+                if (not fdef.arguments or (len(fdef.arguments) == 1 and
+                        (fdef.arg_names[0] in ('self', 'cls')))):
+                    self.fail(message_registry.RETURN_TYPE_EXPECTED, fdef)
+                    if not has_return_statement(fdef) and not fdef.is_generator:
+                        self.note('Use "-> None" if function does not return a value', fdef,
+                                  code=codes.NO_UNTYPED_DEF)
                 else:
-                    if (not fdef.arguments or (len(fdef.arguments) == 1 and
-                            (fdef.arg_names[0] == 'self' or fdef.arg_names[0] == 'cls'))):
-                        self.fail(message_registry.RETURN_TYPE_EXPECTED, fdef)
-                        if not has_return_statement(fdef) and not fdef.is_generator:
-                            self.note('Use "-> None" if function does not return a value', fdef,
-                                      code=codes.NO_UNTYPED_DEF)
-                    else:
-                        self.fail(message_registry.FUNCTION_TYPE_EXPECTED, fdef)
+                    self.fail(message_registry.FUNCTION_TYPE_EXPECTED, fdef)
             elif isinstance(fdef.type, CallableType):
                 ret_type = get_proper_type(fdef.type.ret_type)
                 if is_unannotated_any(ret_type):
-                    if self.options.default_return:
-                        fdef.type.ret_type = NoneType()
-                    else:
-                        self.fail(message_registry.RETURN_TYPE_EXPECTED, fdef)
+                    self.fail(message_registry.RETURN_TYPE_EXPECTED, fdef)
                 elif fdef.is_generator:
                     if is_unannotated_any(self.get_generator_return_type(ret_type,
                                                                          fdef.is_coroutine)):
@@ -1135,11 +1280,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         self.fail(message_registry.RETURN_TYPE_EXPECTED, fdef)
                 if any(is_unannotated_any(t) for t in fdef.type.arg_types):
                     self.fail(message_registry.ARGUMENT_TYPE_EXPECTED, fdef)
-        elif isinstance(fdef.type, CallableType) and self.options.default_return:
-            # we always want to override '-> Any' if default_return
-            ret_type = get_proper_type(fdef.type.ret_type)
-            if is_unannotated_any(ret_type):
-                fdef.type.ret_type = NoneType()
 
     def check___new___signature(self, fdef: FuncDef, typ: CallableType) -> None:
         self_type = fill_typevars_with_any(fdef.info)

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -342,9 +342,29 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             e.callee.type_guard = callee_type.type_guard
         if (self.chk.options.disallow_untyped_calls and
                 self.chk.in_checked_function() and
-                isinstance(callee_type, CallableType)
-                and callee_type.implicit):
-            self.msg.untyped_function_call(callee_type, e)
+                isinstance(callee_type, CallableType)):
+            if callee_type.implicit:
+                self.msg.untyped_function_call(callee_type, e)
+            elif not callee_type.fully_typed:
+                # check for partially typed defs
+                if isinstance(callee_type.definition, FuncDef):
+                    if callee_type.definition.info:
+                        callee_module = callee_type.definition.info.module_name
+                    else:
+                        callee_module = callee_type.definition.fullname.rpartition(".")[0]
+                elif isinstance(e.callee, NameExpr):
+                    assert e.callee.fullname
+                    callee_module = e.callee.fullname.rpartition(".")[0]
+                elif isinstance(e.callee, MemberExpr) and isinstance(e.callee.expr, NameExpr):
+                    assert e.callee.expr.fullname
+                    callee_module = e.callee.expr.fullname.rpartition(".")[0]
+                else:
+                    # If this branch gets hit then look for a new way to get the module name
+                    callee_module = None
+                if callee_module:
+                    callee_options = self.chk.options.per_module(callee_module)
+                    if not callee_options.incomplete_is_typed:
+                        self.msg.partially_typed_function_call(callee_type, e)
 
         # Figure out the full name of the callee for plugin lookup.
         object_type = None

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -548,6 +548,13 @@ def process_options(args: List[str],
     add_invertible_flag(
         '--ignore-any-from-error', default=False, dest="ignore_any_from_error",
         help="Don't include Any type from errors in no-any-expr messages.", group=based_group)
+    add_invertible_flag(
+        '--no-infer-function-types', group=based_group, dest="infer_function_types",
+        default=True, help="Don't infer the type annotations of functions.")
+    add_invertible_flag(
+        '--incomplete-is-typed', group=based_group, default=False,
+        help="Partially typed/incomplete functions in this module are considered typed"
+             " for untyped call errors.")
 
     config_group = parser.add_argument_group(
         title='Config file',

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -416,6 +416,13 @@ class MessageBuilder:
                   code=codes.NO_UNTYPED_CALL)
         return AnyType(TypeOfAny.from_error)
 
+    def partially_typed_function_call(self, callee: CallableType, context: Context) -> Type:
+        name = callable_name(callee) or '(unknown)'
+        self.fail(f'Call to incomplete function {name} in typed context', context,
+                  code=codes.NO_UNTYPED_CALL)
+        self.note(f'Type is "{callee}"', context)
+        return AnyType(TypeOfAny.from_error)
+
     def incompatible_argument(self,
                               n: int,
                               m: int,

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -43,9 +43,11 @@ PER_MODULE_OPTIONS: Final = {
     "ignore_errors",
     "ignore_missing_imports",
     "implicit_reexport",
+    "infer_function_types",
     "mypyc",
     "no_implicit_optional",
     "nonlocal_partial_types",
+    "incomplete_is_typed",
     "show_none_errors",
     "strict_equality",
     "strict_optional",
@@ -77,6 +79,8 @@ class Options:
     def __init__(self) -> None:
         # Cache for clone_for_module()
         self._per_module_cache: Optional[Dict[str, Options]] = None
+        # Despite the warnings about _per_module_cache being slow, this one might be good
+        self._final_per_module_cache: Dict[str, Options] = {}
 
         # -- build options --
         self.build_type = BuildType.STANDARD
@@ -120,8 +124,10 @@ class Options:
         self.baseline_format = "default"
         self.auto_baseline = True
         self.default_return = False
+        self.infer_function_types = flip_if_not_based(True)
         self.targets: List[str] = []
         self.ignore_any_from_error = True
+        self.incomplete_is_typed = flip_if_not_based(False)
 
         # disallow_any options
         self.disallow_any_generics = flip_if_not_based(True)
@@ -422,7 +428,9 @@ class Options:
         # If the module just directly has a config entry, use it.
         if module in self._per_module_cache:
             self.unused_configs.discard(module)
-            return self._per_module_cache[module]
+            result = self._per_module_cache[module]
+            self._final_per_module_cache[module] = result
+            return result
 
         # If not, search for glob paths at all the parents. So if we are looking for
         # options for foo.bar.baz, we search foo.bar.baz.*, foo.bar.*, foo.*,
@@ -449,7 +457,8 @@ class Options:
         # We could update the cache to directly point to modules once
         # they have been looked up, but in testing this made things
         # slower and not faster, so we don't bother.
-
+        # BASED: We cache it anyway, so.
+        self._final_per_module_cache[module] = options
         return options
 
     def compile_glob(self, s: str) -> Pattern[str]:
@@ -464,3 +473,6 @@ class Options:
 
     def select_options_affecting_cache(self) -> Mapping[str, object]:
         return {opt: getattr(self, opt) for opt in OPTIONS_AFFECTING_CACHE}
+
+    def per_module(self, module: str) -> 'Options':
+        return self._final_per_module_cache.get(module, self)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -85,7 +85,7 @@ from mypy.patterns import (
     StarredPattern, MappingPattern, ClassPattern,
 )
 from mypy.tvar_scope import TypeVarLikeScope
-from mypy.typevars import fill_typevars
+from mypy.typevars import fill_typevars, fill_typevars_with_any
 from mypy.visitor import NodeVisitor
 from mypy.errors import Errors, report_internal_error
 from mypy.messages import (
@@ -99,9 +99,9 @@ from mypy.types import (
     TypeTranslator, TypeOfAny, TypeType, NoneType, PlaceholderType, TPDICT_NAMES, ProperType,
     get_proper_type, get_proper_types, TypeAliasType, TypeVarLikeType,
     PROTOCOL_NAMES, TYPE_ALIAS_NAMES, FINAL_TYPE_NAMES, FINAL_DECORATOR_NAMES, REVEAL_TYPE_NAMES,
-    is_named_instance,
+    is_named_instance, is_unannotated_any,
 )
-from mypy.typeops import function_type, get_type_vars
+from mypy.typeops import function_type, get_type_vars, infer_impl_from_parts
 from mypy.type_visitor import TypeQuery
 from mypy.typeanal import (
     TypeAnalyser, analyze_type_alias, no_subscript_builtin_alias,
@@ -611,6 +611,8 @@ class SemanticAnalyzer(NodeVisitor[None],
     def visit_func_def(self, defn: FuncDef) -> None:
         self.statement = defn
 
+        infer_fdef_types_from_defaults(defn, self)
+
         # Visit default values because they may contain assignment expressions.
         for arg in defn.arguments:
             if arg.initializer:
@@ -648,10 +650,32 @@ class SemanticAnalyzer(NodeVisitor[None],
             # Method definition
             assert self.type is not None
             defn.info = self.type
-            if defn.type is not None and defn.name in ('__init__', '__init_subclass__'):
-                assert isinstance(defn.type, CallableType)
-                if isinstance(get_proper_type(defn.type.ret_type), AnyType):
-                    defn.type = defn.type.copy_modified(ret_type=NoneType())
+            if defn.name in ('__init__', '__init_subclass__'):
+                if defn.type:
+                    assert isinstance(defn.type, CallableType)
+                    if isinstance(get_proper_type(defn.type.ret_type), AnyType):
+                        defn.type = defn.type.copy_modified(ret_type=NoneType())
+                elif self.options.infer_function_types:
+                    defn.type = CallableType(
+                        [AnyType(TypeOfAny.unannotated) for _ in defn.arg_kinds],
+                        defn.arg_kinds,
+                        defn.arg_names,
+                        NoneType(),
+                        self.named_type('builtins.function'))
+            if defn.name == "__new__" and self.options.infer_function_types:
+                if defn.type:
+                    assert isinstance(defn.type, CallableType)
+                    if isinstance(get_proper_type(defn.type.ret_type), (AnyType, NoneType)):
+                        self_type = fill_typevars_with_any(defn.info)
+                        defn.type = defn.type.copy_modified(ret_type=self_type)
+                elif self.options.disallow_untyped_defs:
+                    self_type = fill_typevars_with_any(defn.info)
+                    defn.type = CallableType(
+                        [AnyType(TypeOfAny.unannotated) for _ in defn.arg_kinds],
+                        defn.arg_kinds,
+                        defn.arg_names,
+                        self_type,
+                        self.named_type('builtins.function'))
             self.prepare_method_signature(defn, self.type)
 
         # Analyze function signature
@@ -837,7 +861,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 assert isinstance(callable, CallableType)
                 # overloads ignore the rule regarding default return and untyped defs
                 if item.type is None and self.options.default_return:
-                    if isinstance(get_proper_type(callable.ret_type), AnyType):
+                    if is_unannotated_any(callable.ret_type):
                         callable.ret_type = NoneType()
                 if not any(refers_to_fullname(dec, 'typing.overload')
                            for dec in item.decorators):
@@ -857,6 +881,8 @@ class SemanticAnalyzer(NodeVisitor[None],
                     impl = item
                 else:
                     non_overload_indexes.append(i)
+        if self.options.infer_function_types and impl and not non_overload_indexes:
+            infer_impl_from_parts(impl, types, self.named_type("builtins.function"))
         return types, impl, non_overload_indexes
 
     def handle_missing_overload_decorators(self,
@@ -5573,3 +5599,54 @@ def is_same_symbol(a: Optional[SymbolNode], b: Optional[SymbolNode]) -> bool:
             or (isinstance(a, PlaceholderNode)
                 and isinstance(b, PlaceholderNode))
             or is_same_var_from_getattr(a, b))
+
+
+def infer_fdef_types_from_defaults(defn: Union[FuncDef, Decorator], self: SemanticAnalyzer):
+    def is_unannotated_any(typ_: Type) -> bool:
+        return isinstance(get_proper_type(typ_), AnyType)
+    if isinstance(defn, Decorator):
+        defn = defn.func
+
+    if defn.type and isinstance(defn.type, CallableType) and defn.type.fully_typed:
+        return
+
+    if not defn.type and (
+        self.options.default_return
+        or (self.options.infer_function_types and any(arg.initializer for arg in defn.arguments))
+    ):
+        arg_types = []
+        if self.options.infer_function_types:
+            for arg in defn.arguments:
+                typ = None
+                if arg.variable.is_inferred and arg.initializer:
+                    arg.initializer.accept(self)
+                    typ = self.analyze_simple_literal_type(arg.initializer, False)
+                arg_types.append(typ or AnyType(TypeOfAny.unannotated))
+        ret_type = None
+        if self.options.default_return and self.options.disallow_untyped_defs:
+            ret_type = NoneType()
+        if any(not isinstance(get_proper_type(t), AnyType) for t in arg_types) or ret_type:
+            defn.type = CallableType(arg_types
+                                     or [AnyType(TypeOfAny.unannotated) for _ in defn.arg_kinds],
+                                     defn.arg_kinds,
+                                     defn.arg_names,
+                                     ret_type or AnyType(TypeOfAny.unannotated),
+                                     self.named_type('builtins.function'),
+                                     line=defn.line,
+                                     column=defn.column)
+    elif defn.type:
+        assert isinstance(defn.type, CallableType)
+        if self.options.default_return and is_unannotated_any(defn.type.ret_type) and (
+            isinstance(defn.unanalyzed_type, CallableType)
+            and not self.options.disallow_untyped_defs
+            and any(defn.unanalyzed_type.arg_types)
+            or self.options.disallow_untyped_defs
+        ):
+            defn.type.ret_type = NoneType()
+        if self.options.infer_function_types:
+            for i, arg in enumerate(defn.arguments):
+                if is_unannotated_any(defn.type.arg_types[i]):
+                    if arg.variable.is_inferred and arg.initializer:
+                        ret = self.analyze_simple_literal_type(arg.initializer, False)
+                        if ret:
+                            defn.type.arg_types[i] = ret

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -835,16 +835,9 @@ class SemanticAnalyzer(NodeVisitor[None],
             if isinstance(item, Decorator):
                 callable = function_type(item.func, self.named_type('builtins.function'))
                 assert isinstance(callable, CallableType)
-                if (
-                    item.type is None
-                    and self.options.default_return
-                    and self.options.disallow_untyped_defs
-                ):
-                    ret_type = get_proper_type(callable.ret_type)
-                    if (
-                        isinstance(ret_type, AnyType)
-                        and ret_type.type_of_any == TypeOfAny.unannotated
-                    ):
+                # overloads ignore the rule regarding default return and untyped defs
+                if item.type is None and self.options.default_return:
+                    if isinstance(get_proper_type(callable.ret_type), AnyType):
                         callable.ret_type = NoneType()
                 if not any(refers_to_fullname(dec, 'typing.overload')
                            for dec in item.decorators):

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -365,7 +365,7 @@ def assert_type(typ: type, value: object) -> None:
 
 
 def parse_options(program_text: str, testcase: DataDrivenTestCase,
-                  incremental_step: int) -> Options:
+                  incremental_step: int, based: bool = False) -> Options:
     """Parse comments like '# flags: --foo' in a test case."""
     options = Options()
     flags = re.search('# flags: (.*)$', program_text, flags=re.MULTILINE)
@@ -377,6 +377,8 @@ def parse_options(program_text: str, testcase: DataDrivenTestCase,
 
     if flags:
         flag_list: List[str] = flags.group(1).split()
+        if based:
+            flag_list.insert(0, '--default-return')
         flag_list.append('--no-site-packages')  # the tests shouldn't need an installed Python
         if "--local-partial-types" in flag_list:
             flag_list.remove("--local-partial-types")
@@ -388,8 +390,12 @@ def parse_options(program_text: str, testcase: DataDrivenTestCase,
     else:
         flag_list = []
         options = Options()
-        # TODO: Enable strict optional in test cases by default (requires *many* test case changes)
-        options.strict_optional = False
+        if based:
+            options.default_return = True
+        else:
+            # TODO: Enable strict optional in test cases by default
+            #  (requires *many* test case changes)
+            options.strict_optional = False
         options.error_summary = False
 
     # Allow custom python version to override testcase_pyversion.

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -170,7 +170,9 @@ class TypeCheckSuite(DataSuite):
         from mypy import options as mypy_options
         mypy_options._based = 'based' in testcase.file.rsplit(os.sep)[-1]
         # Parse options after moving files (in case mypy.ini is being moved).
-        options = parse_options(original_program_text, testcase, incremental_step)
+        options = parse_options(
+            original_program_text, testcase, incremental_step, based=mypy_options._based
+        )
         options.use_builtins_fixtures = True
         options.show_traceback = True
 

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -28,6 +28,8 @@ typecheck_files = [
     'check-based-default-return.test',
     'check-based-ignore-any-from-error.test',
     'check-based-type-render.test',
+    'check-based-infer-function-types.test',
+    'check-based-incomplete-defs.test',
     'check-union-or-syntax.test',
     'check-callable.test',
     'check-classes.test',
@@ -173,6 +175,8 @@ class TypeCheckSuite(DataSuite):
         options.show_traceback = True
 
         # Enable some options automatically based on test file name.
+        if mypy_options._based:
+            options.show_column_numbers = False
         if 'optional' in testcase.file:
             options.strict_optional = True
         if 'columns' in testcase.file:

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -4,7 +4,7 @@ NOTE: These must not be accessed from mypy.nodes or mypy.types to avoid import
       cycles. These must not be called from the semantic analysis main pass
       since these may assume that MROs are ready.
 """
-
+from collections import defaultdict
 from typing import cast, Optional, List, Sequence, Set, Iterable, TypeVar, Dict, Tuple, Any
 from typing_extensions import Type as TypingType
 import itertools
@@ -15,11 +15,11 @@ from mypy.types import (
     TypeVarType, UninhabitedType, FormalArgument, UnionType, NoneType,
     AnyType, TypeOfAny, TypeType, ProperType, LiteralType, get_proper_type, get_proper_types,
     copy_type, TypeAliasType, TypeQuery, ParamSpecType,
-    ENUM_REMOVED_PROPS
+    ENUM_REMOVED_PROPS, is_unannotated_any
 )
 from mypy.nodes import (
     FuncBase, FuncItem, FuncDef, OverloadedFuncDef, TypeInfo, ARG_STAR, ARG_STAR2, ARG_POS,
-    Expression, StrExpr, Var, Decorator, SYMBOL_FUNCBASE_TYPES
+    Expression, StrExpr, Var, Decorator, SYMBOL_FUNCBASE_TYPES, OverloadPart
 )
 from mypy.maptype import map_instance_to_supertype
 from mypy.expandtype import expand_type_by_instance, expand_type
@@ -865,3 +865,58 @@ def separate_union_literals(t: UnionType) -> Tuple[Sequence[LiteralType], Sequen
             union_items.append(item)
 
     return literal_items, union_items
+
+
+def infer_impl_from_parts(impl: OverloadPart, types: List[CallableType], fallback: Instance):
+    impl_func = impl if isinstance(impl, FuncDef) else impl.func
+    # infer the types of the impl from the overload types
+    arg_types: Dict[str, List[Type]] = defaultdict(list)
+    ret_types = []
+    for tp in types:
+        for arg_type, arg_name, impl_kind in zip(tp.arg_types, tp.arg_names, tp.arg_kinds):
+            if arg_name in impl_func.arg_names:
+                if arg_name and arg_name in impl_func.arg_names:
+                    if arg_type not in arg_types[arg_name]:
+                        arg_types[arg_name].append(arg_type)
+        if tp.ret_type not in ret_types:
+            ret_types.append(tp.ret_type)
+    arg_types2 = {
+        name: UnionType.make_union(it)
+        for name, it in arg_types.items()
+    }
+    res_arg_types = [
+        arg_types2[arg_name]
+        if arg_name in arg_types2 and arg_kind not in (ARG_STAR, ARG_STAR2)
+        else AnyType(TypeOfAny.unannotated)
+        for arg_name, arg_kind in zip(impl_func.arg_names, impl_func.arg_kinds)
+    ]
+    ret_type = UnionType.make_union(ret_types)
+    # use unanalyzed_type because we would have already tried to infer from defaults
+    if impl_func.unanalyzed_type:
+        assert isinstance(impl_func.unanalyzed_type, CallableType)
+        assert isinstance(impl_func.type, CallableType)
+        impl_func.type = impl_func.type.copy_modified(
+            arg_types=[
+                i if not is_unannotated_any(u) else r
+                for i, u, r
+                in zip(
+                    impl_func.type.arg_types,
+                    impl_func.unanalyzed_type.arg_types,
+                    res_arg_types
+                )
+            ],
+            ret_type=ret_type
+            if isinstance(
+                get_proper_type(impl_func.unanalyzed_type.ret_type),
+                (AnyType, NoneType),
+            )
+            else impl_func.type.ret_type
+        )
+    else:
+        impl_func.type = CallableType(
+            res_arg_types,
+            impl_func.arg_kinds,
+            impl_func.arg_names,
+            ret_type,
+            fallback,
+        )

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1212,6 +1212,7 @@ class CallableType(FunctionLike):
                  'def_extras',  # Information about original definition we want to serialize.
                                 # This is used for more detailed error messages.
                  'type_guard',  # T, if -> TypeGuard[T] (ret_type is bool in this case).
+                 'fully_typed',  # If all type positions are filled.
                  )
 
     def __init__(self,
@@ -1274,6 +1275,9 @@ class CallableType(FunctionLike):
         else:
             self.def_extras = {}
         self.type_guard = type_guard
+        self.fully_typed = not (
+            any(is_unannotated_any(arg) for arg in arg_types) or is_unannotated_any(ret_type)
+        )
 
     def copy_modified(self,
                       arg_types: Bogus[Sequence[Type]] = _dummy,
@@ -2763,3 +2767,9 @@ def callable_with_ellipsis(any_type: AnyType,
                         ret_type=ret_type,
                         fallback=fallback,
                         is_ellipsis_args=True)
+
+
+def is_unannotated_any(t: Type) -> bool:
+    if not isinstance(t, ProperType):
+        return False
+    return isinstance(t, AnyType) and t.type_of_any == TypeOfAny.unannotated

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -36,3 +36,7 @@ default_return = True
 
 [mypy-mypyc.*]
 default_return = True
+
+[mypy-_pytest.*,pytest.*]
+incomplete_is_typed = True
+infer_function_types = False

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -31,10 +31,7 @@ implicit_reexport = True
 disallow_redefinition = True
 disable_error_code = truthy-bool, redundant-expr, ignore-without-code
 
-[mypy-mypy.*]
-default_return = True
-
-[mypy-mypyc.*]
+[mypy-mypy.*,mypyc.*]
 default_return = True
 
 [mypy-_pytest.*,pytest.*]

--- a/mypy_self_check_strict.ini
+++ b/mypy_self_check_strict.ini
@@ -27,3 +27,7 @@ default_return = True
 
 [mypy-mypyc.*]
 default_return = True
+
+[mypy-_pytest.*,pytest.*]
+incomplete_is_typed = True
+infer_function_types = False

--- a/mypy_self_check_strict.ini
+++ b/mypy_self_check_strict.ini
@@ -22,10 +22,7 @@ python_version = 3.7
 exclude = mypy/typeshed/|mypyc/test-data/|mypyc/lib-rt/
 disallow_redefinition = True
 
-[mypy-mypy.*]
-default_return = True
-
-[mypy-mypyc.*]
+[mypy-mypy.*,mypyc.*]
 default_return = True
 
 [mypy-_pytest.*,pytest.*]

--- a/runtests.py
+++ b/runtests.py
@@ -44,7 +44,10 @@ MYPYC_OPT_IN = [MYPYC_RUN, MYPYC_RUN_MULTI]
 # time to run.
 cmds = {
     # Self type check
-    'self': [executable, '-m', 'mypy', '--config-file', 'mypy_self_check.ini', '-p', 'mypy'],
+    'self': [executable, '-m', 'mypy', '--config-file', 'mypy_self_check.ini', "--baseline-file=",
+             '-p', 'mypy'],
+    'self_strict': [executable, '-m', 'mypy', '--config-file', 'mypy_self_check_strict.ini', '-p',
+                    'mypy'],
     # Lint
     'lint': ['flake8', '-j0'],
     # Fast test cases only (this is the bulk of the test suite)

--- a/test-data/unit/check-based-default-return.test
+++ b/test-data/unit/check-based-default-return.test
@@ -2,52 +2,52 @@
 
 
 [case testSimple]
-# flags: --default-return
 def f(): ...
-reveal_type(f)  # N:13: Revealed type is "def ()"
-reveal_type(f())  # N:13: Revealed type is "None"
+reveal_type(f)  # N: Revealed type is "def ()"
+reveal_type(f())  # N: Revealed type is "None"
 
 def g(i: int): ...
-reveal_type(g)  # N:13: Revealed type is "def (i: int)"
+reveal_type(g)  # N: Revealed type is "def (i: int)"
 
 class A:
     def f(self): ...
     def g(self, i: int): ...
 
-reveal_type(A.f)  # N:13: Revealed type is "def (self: __main__.A)"
-reveal_type(A.g)  # N:13: Revealed type is "def (self: __main__.A, i: int)"
+reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A)"
+reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: int)"
 
 
 [case testUntypedDefs]
-# flags: --default-return --allow-untyped-defs --allow-any-expr
+# flags: --allow-untyped-defs --allow-any-expr
 
 def f(): ...
-reveal_type(f)  # N:13: Revealed type is "def () -> Any"
+reveal_type(f)  # N: Revealed type is "def () -> Any"
 
 def g(i: int): ...
-reveal_type(g)  # N:13: Revealed type is "def (i: int)"
+reveal_type(g)  # N: Revealed type is "def (i: int)"
 
-def h(i: int, j): ... # E:1: Function is missing a type annotation for one or more arguments  [no-untyped-def]
+def h(i: int, j): ...  # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]
 
 class A:
     def f(self): ...
     def g(self, i): ...
     def h(self, i: int): ...
-    def i(self, i: int, j): ... # E:5: Function is missing a type annotation for one or more arguments  [no-untyped-def]
+    def i(self, i: int, j): ... # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]
 
-reveal_type(A.f)  # N:13: Revealed type is "def (self: __main__.A) -> Any"
-reveal_type(A.g)  # N:13: Revealed type is "def (self: __main__.A, i: Any) -> Any"
-reveal_type(A.h)  # N:13: Revealed type is "def (self: __main__.A, i: int)"
+reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A) -> Any"
+reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: Any) -> Any"
+reveal_type(A.h)  # N: Revealed type is "def (self: __main__.A, i: int)"
+reveal_type(A.i)  # N: Revealed type is "def (self: __main__.A, i: int, j: Any)"
 
 
 [case testIncompleteDefs]
-# flags: --default-return --allow-incomplete-defs --allow-untyped-defs --allow-any-expr
+# flags: --allow-incomplete-defs --allow-untyped-defs --allow-any-expr
 
 def f(i): ...
-reveal_type(f)  # N:13: Revealed type is "def (i: Any) -> Any"
+reveal_type(f)  # N: Revealed type is "def (i: Any) -> Any"
 
 def g(i: int, j): ...
-reveal_type(g)  # N:13: Revealed type is "def (i: int, j: Any)"
+reveal_type(g)  # N: Revealed type is "def (i: int, j: Any)"
 
 class A:
     def f(self): ...
@@ -55,68 +55,86 @@ class A:
     def h(self, i: int): ...
     def i(self, i: int, j): ...
 
-reveal_type(A.f)  # N:13: Revealed type is "def (self: __main__.A) -> Any"
-reveal_type(A.g)  # N:13: Revealed type is "def (self: __main__.A, i: Any) -> Any"
-reveal_type(A.h)  # N:13: Revealed type is "def (self: __main__.A, i: int)"
-reveal_type(A.i)  # N:13: Revealed type is "def (self: __main__.A, i: int, j: Any)"
+reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A) -> Any"
+reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: Any) -> Any"
+reveal_type(A.h)  # N: Revealed type is "def (self: __main__.A, i: int)"
+reveal_type(A.i)  # N: Revealed type is "def (self: __main__.A, i: int, j: Any)"
 
 
 [case testGenerator]
-# flags: --default-return
-
-def f():  # E:1: The return type of a generator function should be "Generator" or one of its supertypes  [misc]
+def f():  # E: The return type of a generator function should be "Generator" or one of its supertypes  [misc]
     yield
 
 def g(i: int):  # E: The return type of a generator function should be "Generator" or one of its supertypes  [misc]
     yield
 
 class A:
-    def f(self): # E:5: The return type of a generator function should be "Generator" or one of its supertypes  [misc]
+    def f(self): # E: The return type of a generator function should be "Generator" or one of its supertypes  [misc]
         yield
     def g(self, i: int): # E: The return type of a generator function should be "Generator" or one of its supertypes  [misc]
         yield
 
 
+[case testAsync]
+async def f1():
+    ...
+async def f2():  # E: The return type of an async generator function should be "AsyncGenerator" or one of its supertypes  [misc]
+    yield
+
+async def g1(i: int):
+    ...
+async def g2(i: int):  # E: The return type of an async generator function should be "AsyncGenerator" or one of its supertypes  [misc]
+    yield
+
+class A:
+    async def f1(self):
+        ...
+    async def f2(self): # E: The return type of an async generator function should be "AsyncGenerator" or one of its supertypes  [misc]
+        yield
+    async def g1(self, i: int):
+        ...
+    async def g2(self, i: int): # E: The return type of an async generator function should be "AsyncGenerator" or one of its supertypes  [misc]
+        yield
+
 [case testLambda]
-# flags: --default-return --allow-any-expr
+# flags: --allow-any-expr
 
 f = lambda x: x
 g = lambda: ...
-reveal_type(f)  # N:13: Revealed type is "def (x: Any) -> Any"
-reveal_type(g)  # N:13: Revealed type is "def () -> ellipsis"
+reveal_type(f)  # N: Revealed type is "def (x: Any) -> Any"
+reveal_type(g)  # N: Revealed type is "def () -> ellipsis"
 
 
 [case testExplicitAny]
-# flags: --default-return --allow-any-expr  --allow-any-explicit
+# flags: --allow-any-expr  --allow-any-explicit
 from typing import Any
 
 def f() -> Any: ...
 def g(i: int) -> Any: ...
-reveal_type(f)  # N:13: Revealed type is "def () -> Any"
-reveal_type(g)  # N:13: Revealed type is "def (i: int) -> Any"
+reveal_type(f)  # N: Revealed type is "def () -> Any"
+reveal_type(g)  # N: Revealed type is "def (i: int) -> Any"
 
 class A:
     def f(self) -> Any: ...
     def g(self, i: int) -> Any: ...
-reveal_type(A.f)  # N:13: Revealed type is "def (self: __main__.A) -> Any"
-reveal_type(A.g)  # N:13: Revealed type is "def (self: __main__.A, i: int) -> Any"
+reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A) -> Any"
+reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: int) -> Any"
 
 
 [case testNoDefaultReturn]
-# flags: --allow-any-expr
+# flags: --no-default-return --allow-any-expr
 
-def f(i): ...  # E:1: Function is missing a type annotation  [no-untyped-def]
-def g(i: int, j): ...  # E:1: Function is missing a return type annotation  [no-untyped-def] \
-                       # E:1: Function is missing a type annotation for one or more arguments  [no-untyped-def]
+def f(i): ...  # E: Function is missing a type annotation  [no-untyped-def]
+def g(i: int, j): ...  # E: Function is missing a return type annotation  [no-untyped-def] \
+                       # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]
 
 class A:
-    def f(self, i): ...  # E:5: Function is missing a type annotation  [no-untyped-def]
-    def g(self, i: int, j): ...  # E:5: Function is missing a return type annotation  [no-untyped-def] \
-                                 # E:5: Function is missing a type annotation for one or more arguments  [no-untyped-def]
+    def f(self, i): ...  # E: Function is missing a type annotation  [no-untyped-def]
+    def g(self, i: int, j): ...  # E: Function is missing a return type annotation  [no-untyped-def] \
+                                 # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]
 
 
 [case testOverload]
-# flags: --default-return
 from typing import overload
 
 class A:
@@ -126,7 +144,7 @@ class A:
     def f(self, i: int): ...
     def f(self, i: int = 0): ...
 
-reveal_type(A.f)  # N:13: Revealed type is "Overload(def (self: __main__.A), def (self: __main__.A, i: int))"
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A), def (self: __main__.A, i: int))"
 
 @overload
 def f(): ...
@@ -134,11 +152,11 @@ def f(): ...
 def f(i: int): ...
 def f(i: int = 0): ...
 
-reveal_type(f)  # N:13: Revealed type is "Overload(def (), def (i: int))"
+reveal_type(f)  # N: Revealed type is "Overload(def (), def (i: int))"
 
 
 [case testOverloadIncomplete]
-# flags: --default-return --allow-incomplete-defs --allow-untyped-defs --allow-any-expr
+# flags: --allow-incomplete-defs --allow-untyped-defs --allow-any-expr
 from typing import overload
 
 class A:
@@ -150,7 +168,7 @@ class A:
     def f(self, i, j: int): ...
     def f(self, i: int = 0, j: int = 0): ...
 
-reveal_type(A.f)  # N:13: Revealed type is "Overload(def (self: __main__.A) -> Any, def (self: __main__.A, i: Any) -> Any, def (self: __main__.A, i: Any, j: int))"
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A), def (self: __main__.A, i: Any), def (self: __main__.A, i: Any, j: int))"
 
 @overload
 def f(): ...
@@ -160,11 +178,11 @@ def f(i): ...
 def f(i, j: int): ...
 def f(i: int = 0, j: int = 0): ...
 
-reveal_type(f)  # N:13: Revealed type is "Overload(def () -> Any, def (i: Any) -> Any, def (i: Any, j: int))"
+reveal_type(f)  # N: Revealed type is "Overload(def (), def (i: Any), def (i: Any, j: int))"
 
 
 [case testOverloadUntyped]
-# flags: --default-return --allow-untyped-defs --allow-any-expr
+# flags: --allow-untyped-defs --allow-any-expr
 from typing import overload
 
 class A:
@@ -176,7 +194,7 @@ class A:
     def f(self, *, j: int): ...
     def f(self, i: int = 0, j: int = 0): ...
 
-reveal_type(A.f)  # N:13: Revealed type is "Overload(def (self: __main__.A) -> Any, def (self: __main__.A, i: Any) -> Any, def (self: __main__.A, *, j: int))"
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A), def (self: __main__.A, i: Any), def (self: __main__.A, *, j: int))"
 
 @overload
 def f(): ...
@@ -186,10 +204,10 @@ def f(i): ...
 def f(*, j: int): ...
 def f(i: int = 0, j: int = 0): ...
 
-reveal_type(f)  # N:13: Revealed type is "Overload(def () -> Any, def (i: Any) -> Any, def (*, j: int))"
+reveal_type(f)  # N: Revealed type is "Overload(def (), def (i: Any), def (*, j: int))"
 
 [case testOverloadOther]
-# flags: --default-return --allow-untyped-defs --allow-incomplete-defs --allow-any-expr
+# flags: --allow-untyped-defs --allow-incomplete-defs --allow-any-expr
 from typing import overload
 
 class A:
@@ -201,7 +219,7 @@ class A:
     def f(self, i, j: int): ...
     def f(self, i: int = 0, j: int = 0) -> object: ...
 
-reveal_type(A.f)  # N:13: Revealed type is "Overload(def (self: __main__.A) -> int, def (self: __main__.A, i: Any) -> Any, def (self: __main__.A, i: Any, j: int))"
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A) -> int, def (self: __main__.A, i: Any), def (self: __main__.A, i: Any, j: int))"
 
 class B:
     @overload
@@ -212,12 +230,12 @@ class B:
     def f(self, i, j: int) -> int: ...
     def f(self, i: int = 0, j: int = 0) -> object: ...
 
-reveal_type(B.f)  # N:13: Revealed type is "Overload(def (self: __main__.B) -> str, def (self: __main__.B, i: Any) -> Any, def (self: __main__.B, i: Any, j: int) -> int)"
+reveal_type(B.f)  # N: Revealed type is "Overload(def (self: __main__.B) -> str, def (self: __main__.B, i: Any), def (self: __main__.B, i: Any, j: int) -> int)"
 
 
 [case testNewHasError]
-# flags: --default-return
+# flags: --no-infer-function-types
 class A:
-    def __new__(cls): ...  # E:5: "__new__" must return a class instance (got "None")  [misc]
+    def __new__(cls): ...  # E: "__new__" must return a class instance (got "None")  [misc]
 
-reveal_type(A.__new__)  # N:13: Revealed type is "def (cls: type[__main__.A])"
+reveal_type(A.__new__)  # N: Revealed type is "def (cls: type[__main__.A])"

--- a/test-data/unit/check-based-ignore-any-from-error.test
+++ b/test-data/unit/check-based-ignore-any-from-error.test
@@ -1,25 +1,25 @@
 [case testIgnoreAnyFromError]
 from typing import Any
-a = AMONGUS  # E:5: Name "AMONGUS" is not defined  [name-defined]
+a = AMONGUS  # E: Name "AMONGUS" is not defined  [name-defined]
 b = a + 1
 c = b()
 d = [c]
 e = d[0].d
 e + 1
-f: Any  # E:1: Explicit "Any" is not allowed  [no-any-explicit]
-g = f + 1  # E:5: Expression has type "Any"  [no-any-expr]
+f: Any  # E: Explicit "Any" is not allowed  [no-any-explicit]
+g = f + 1  # E: Expression has type "Any"  [no-any-expr]
 
 [case testIncludeAnyFromError]
 # flags: --no-ignore-any-from-error
 from typing import Any
-a = AMONGUS  # E:5: Name "AMONGUS" is not defined  [name-defined] \
-             # E:5: Expression has type "Any"  [no-any-expr]
-b = a + 1  # E:5: Expression has type "Any"  [no-any-expr]
-c = b()  # E:5: Expression has type "Any"  [no-any-expr]
-d = [c]  # E:5: Expression type contains "Any" (has type "list[Any]")  [no-any-expr] \
-         # E:6: Expression has type "Any"  [no-any-expr]
-e = d[0].d  # E:5: Expression type contains "Any" (has type "list[Any]")  [no-any-expr] \
-            # E:5: Expression has type "Any"  [no-any-expr]
-e + 1  # E:1: Expression has type "Any"  [no-any-expr]
-f: Any  # E:1: Explicit "Any" is not allowed  [no-any-explicit]
-g = f + 1  # E:5: Expression has type "Any"  [no-any-expr]
+a = AMONGUS  # E: Name "AMONGUS" is not defined  [name-defined] \
+             # E: Expression has type "Any"  [no-any-expr]
+b = a + 1  # E: Expression has type "Any"  [no-any-expr]
+c = b()  # E: Expression has type "Any"  [no-any-expr]
+d = [c]  # E: Expression type contains "Any" (has type "list[Any]")  [no-any-expr] \
+         # E: Expression has type "Any"  [no-any-expr]
+e = d[0].d  # E: Expression type contains "Any" (has type "list[Any]")  [no-any-expr] \
+            # E: Expression has type "Any"  [no-any-expr]
+e + 1  # E: Expression has type "Any"  [no-any-expr]
+f: Any  # E: Explicit "Any" is not allowed  [no-any-explicit]
+g = f + 1  # E: Expression has type "Any"  [no-any-expr]

--- a/test-data/unit/check-based-incomplete-defs.test
+++ b/test-data/unit/check-based-incomplete-defs.test
@@ -1,0 +1,33 @@
+[case testCallingIncomplete]
+# flags: --config-file tmp/mypy.ini
+from b import foo
+foo(1, 2)  # E: Call to incomplete function "foo" in typed context  [no-untyped-call] \
+           # N: Type is "def (a: int, b: Any)"
+
+[file b.py]
+def foo(a: int, b): ...
+
+[file mypy.ini]
+\[mypy]
+incomplete_is_typed = True
+allow_incomplete_defs = True
+allow_untyped_defs = True
+\[mypy-b]
+incomplete_is_typed = False
+
+
+[case testCallingIncompleteAsTyped]
+# flags: --config-file tmp/mypy.ini
+from b import foo
+foo(1, 2)
+
+[file b.py]
+def foo(a: int, b): ...
+
+[file mypy.ini]
+\[mypy]
+incomplete_is_typed = False
+allow_incomplete_defs = True
+allow_untyped_defs = True
+\[mypy-b]
+incomplete_is_typed = True

--- a/test-data/unit/check-based-infer-function-types.test
+++ b/test-data/unit/check-based-infer-function-types.test
@@ -1,0 +1,269 @@
+-- Type checker test cases for infer-function-types.
+
+[case testInferFunctionTypesUntyped]
+# flags: --allow-untyped-defs --allow-incomplete-defs --allow-any-expr
+
+def f(): ...
+reveal_type(f)  # N: Revealed type is "def () -> Any"
+
+def g(i=1, b=""): ...
+reveal_type(g)  # N: Revealed type is "def (i: int =, b: str =) -> Any"
+
+class A1:
+    def __new__(cls): ...
+    def __init__(self): ...
+class B1(A1):
+    def __new__(cls): ...
+    def __init__(self): ...
+
+reveal_type(A1.__new__)  # N: Revealed type is "def (cls: type[__main__.A1]) -> Any"
+reveal_type(B1.__new__)  # N: Revealed type is "def (cls: type[__main__.B1]) -> Any"
+reveal_type(A1.__init__)  # N: Revealed type is "def (self: __main__.A1)"
+reveal_type(B1.__init__)  # N: Revealed type is "def (self: __main__.B1)"
+
+class A2:
+    def __new__(cls, a: int): ...
+    def __init__(self, a: int): ...
+class B2(A2):
+    def __new__(cls, a): ...
+    def __init__(self, a): ...
+
+reveal_type(A2.__new__)  # N: Revealed type is "def (cls: type[__main__.A2], a: int) -> __main__.A2"
+reveal_type(B2.__new__)  # N: Revealed type is "def (cls: type[__main__.B2], a: int) -> __main__.B2"
+reveal_type(A2.__init__)  # N: Revealed type is "def (self: __main__.A2, a: int)"
+reveal_type(B2.__init__)  # N: Revealed type is "def (self: __main__.B2, a: int)"
+
+
+[case testInferFunctionTypesComplete]
+class A1:
+    def __new__(cls): ...
+    def __init__(self): ...
+class B1(A1):
+    def __new__(cls): ...
+    def __init__(self): ...
+
+reveal_type(A1.__new__)  # N: Revealed type is "def (cls: type[__main__.A1]) -> __main__.A1"
+reveal_type(B1.__new__)  # N: Revealed type is "def (cls: type[__main__.B1]) -> __main__.B1"
+reveal_type(A1.__init__)  # N: Revealed type is "def (self: __main__.A1)"
+reveal_type(B1.__init__)  # N: Revealed type is "def (self: __main__.B1)"
+
+class A2:
+    def __new__(cls, a: int): ...
+    def __init__(self, a: int): ...
+class B2(A2):
+    def __new__(cls, a): ...
+    def __init__(self, a): ...
+
+reveal_type(A2.__new__)  # N: Revealed type is "def (cls: type[__main__.A2], a: int) -> __main__.A2"
+reveal_type(B2.__new__)  # N: Revealed type is "def (cls: type[__main__.B2], a: int) -> __main__.B2"
+reveal_type(A2.__init__)  # N: Revealed type is "def (self: __main__.A2, a: int)"
+reveal_type(B2.__init__)  # N: Revealed type is "def (self: __main__.B2, a: int)"
+
+
+[case testDefaultInstance]
+class A: ...
+def f(a=A()): ...
+reveal_type(f)  # N: Revealed type is "def (a: __main__.A =)"
+
+class B:
+    def foo(self, a: object): ...
+class C(B):
+    def foo(self, a=A()): ...
+
+reveal_type(C.foo)  # N: Revealed type is "def (self: __main__.C, a: object =)"
+
+
+[case testDontInferFunctionTypes]
+# flags: --no-infer-function-types --allow-untyped-defs --allow-incomplete-defs --allow-any-expr --no-default-return
+
+def f(): ...
+reveal_type(f)  # N: Revealed type is "def () -> Any"
+
+def g(i=1, b=""): ...
+reveal_type(g)  # N: Revealed type is "def (i: Any =, b: Any =) -> Any"
+
+class A1:
+    def __new__(cls): ...
+    def __init__(self): ...
+class B1(A1):
+    def __new__(cls): ...
+    def __init__(self): ...
+
+reveal_type(A1.__new__)  # N: Revealed type is "def (cls: type[__main__.A1]) -> Any"
+reveal_type(B1.__new__)  # N: Revealed type is "def (cls: type[__main__.B1]) -> Any"
+reveal_type(A1.__init__)  # N: Revealed type is "def (self: __main__.A1) -> Any"
+reveal_type(B1.__init__)  # N: Revealed type is "def (self: __main__.B1) -> Any"
+
+class A2:
+    def __new__(cls, a: int): ...
+    def __init__(self, a: int): ...
+class B2(A2):
+    def __new__(cls, a): ...
+    def __init__(self, a): ...
+
+reveal_type(A2.__new__)  # N: Revealed type is "def (cls: type[__main__.A2], a: int) -> Any"
+reveal_type(B2.__new__)  # N: Revealed type is "def (cls: type[__main__.B2], a: Any) -> Any"
+reveal_type(A2.__init__)  # N: Revealed type is "def (self: __main__.A2, a: int)"
+reveal_type(B2.__init__)  # N: Revealed type is "def (self: __main__.B2, a: Any) -> Any"
+
+
+[case testSimpleOverload]
+from typing import overload
+
+@overload
+def f(i: int) -> int: ...
+@overload
+def f(i: str) -> str: ...
+
+def f(i):
+    reveal_type(i)  # N: Revealed type is "int | str"
+    reveal_type(f)  # N: Revealed type is "Overload(def (i: int) -> int, def (i: str) -> str)"
+    if i:
+        return "asdf"
+    elif i:
+        return 100
+    return None  # E: Incompatible return value type (got "None", expected "int | str")  [return-value]
+
+
+[case testPartialOverload]
+from typing import overload
+
+@overload
+def f(*, i: int, j: int) -> int: ...
+@overload
+def f(*, j: str) -> str: ...
+
+def f(i: object = 1, j = "1"):
+    reveal_type(i)  # N: Revealed type is "object"
+    reveal_type(j)  # N: Revealed type is "int | str"
+    if j:
+        return "asdf"
+    elif j:
+        return 100
+    return None  # E: Incompatible return value type (got "None", expected "int | str")  [return-value]
+
+
+[case testInvalidOverload]
+@overload  # E: Name "overload" is not defined  [name-defined]
+def a(x: int): ...
+@overload  # E: Name "a" already defined on line 1  [no-redef] \
+           # E: Name "overload" is not defined  [name-defined]
+def a(x: str): ...
+def a(x: object): ...  # E: Name "a" already defined on line 1  [no-redef]
+
+def b(): ...
+def b(x: str): ...  # E: Name "b" already defined on line 7  [no-redef]
+
+
+[case testOverloadAndDefault]
+from typing import overload
+
+@overload
+def foo(a: int) -> None:
+    ...
+@overload
+def foo(a='1') -> None:
+    ...
+def foo(a="1") -> None:
+    reveal_type(a)  # N: Revealed type is "int | str"
+
+reveal_type(foo)  # N: Revealed type is "Overload(def (a: int), def (a: str =))"
+
+
+[case testVariadic]
+# flags: --allow-any-expr --disable-error-code truthy-bool --implicit-optional
+from typing import overload
+
+@overload
+def f(__a: str): ...
+@overload
+def f(__a: int): ...
+
+def f(*args):  # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]
+    reveal_type(args)  # N: Revealed type is "tuple[Any, ...]"
+    if args:
+        return "asdf"  # E: No return value expected  [return-value]
+[builtins fixtures/tuple.pyi]
+
+
+[case testKariadic]
+# flags: --allow-any-expr
+from typing import overload
+
+@overload
+def f(*, kwargs: str): ...
+@overload
+def f(*, kwargs: int): ...
+
+def f(**kwargs):  # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]
+    reveal_type(kwargs)  # N: Revealed type is "dict[str, Any]"
+    return 1 # E: No return value expected  [return-value]
+[builtins fixtures/dict.pyi]
+
+
+[case testOverrideOverload]
+from typing import overload, Union
+from s import S
+
+class A:
+    @overload
+    def f(self, f: int) -> str: ...
+    @overload
+    def f(self, f: str) -> int: ...
+    def f(self, f): ...
+
+class B(A):
+    def f(self, f):
+        reveal_type(self)  # N: Revealed type is "__main__.B"
+        reveal_type(f)  # N: Revealed type is "int | str"
+        return None  # E: Incompatible return value type (got "None", expected "str | int")  [return-value]
+class C(A):
+    def f(self, f: Union[int, str]):
+        reveal_type(self)  # N: Revealed type is "__main__.C"
+        reveal_type(f)  # N: Revealed type is "int | str"
+        return None  # E: Incompatible return value type (got "None", expected "str | int")  [return-value]
+class D(A):
+    def f(self, f: str):  # E: Overloaded function implementation does not accept all possible arguments of signature 1  [misc]
+        reveal_type(self)  # N: Revealed type is "__main__.D"
+        reveal_type(f)  # N: Revealed type is "str"
+        return None  # E: Incompatible return value type (got "None", expected "str | int")  [return-value]
+class E(A):
+    def f(self, f: str) -> None:  # E: Signature of "f" incompatible with supertype "A"  [override] \
+                                  # N:      Superclass: \
+                                  # N:          @overload \
+                                  # N:          def f(self, f: int) -> str \
+                                  # N:          @overload \
+                                  # N:          def f(self, f: str) -> int \
+                                  # N:      Subclass: \
+                                  # N:          def f(self, f: str) -> None
+        reveal_type(self)  # N: Revealed type is "__main__.E"
+        reveal_type(f)  # N: Revealed type is "str"
+        return None
+class F(A):
+    def f(self, f="") -> Union[str, int]:
+        reveal_type(self)  # N: Revealed type is "__main__.F"
+        reveal_type(f)  # N: Revealed type is "int | str"
+        return None  # E: Incompatible return value type (got "None", expected "str | int")  [return-value]
+class G(S):
+    def f(self, f=""):
+        reveal_type(self)  # N: Revealed type is "__main__.G"
+        reveal_type(f)  # N: Revealed type is "int | str"
+        return None  # E: Incompatible return value type (got "None", expected "str | int")  [return-value]
+
+
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A, f: int) -> str, def (self: __main__.A, f: str) -> int)"
+reveal_type(B.f)  # N: Revealed type is "Overload(def (self: __main__.B, f: int) -> str, def (self: __main__.B, f: str) -> int)"
+reveal_type(C.f)  # N: Revealed type is "Overload(def (self: __main__.C, f: int) -> str, def (self: __main__.C, f: str) -> int)"
+reveal_type(D.f)  # N: Revealed type is "Overload(def (self: __main__.D, f: int) -> str, def (self: __main__.D, f: str) -> int)"
+reveal_type(E.f)  # N: Revealed type is "def (self: __main__.E, f: str)"
+reveal_type(F.f)  # N: Revealed type is "Overload(def (self: __main__.F, f: int) -> str, def (self: __main__.F, f: str) -> int)"
+reveal_type(G.f)  # N: Revealed type is "Overload(def (self: __main__.G, f: int) -> str, def (self: __main__.G, f: str) -> int)"
+
+[file s.pyi]
+from typing import overload
+
+class S:
+    @overload
+    def f(self, f: int) -> str: ...
+    @overload
+    def f(self, f: str) -> int: ...

--- a/test-data/unit/check-based-type-render.test
+++ b/test-data/unit/check-based-type-render.test
@@ -6,9 +6,9 @@ T2 = TypeVar('T2')
 
 class A(Generic[T2]):
     def f(self, t: T, t2: T2) -> Union[List[int], str]:
-        reveal_type(t)  # N:21: Revealed type is "T@f"
-        reveal_type(t2)  # N:21: Revealed type is "T2@A"
+        reveal_type(t)  # N: Revealed type is "T@f"
+        reveal_type(t2)  # N: Revealed type is "T2@A"
         return ""
 
-reveal_type(A.f)  # N:13: Revealed type is "def [T2 (from A), T] (self: __main__.A[T2], t: T, t2: T2) -> list[int] | str"
-reveal_type(A[int]().f)  # N:13: Revealed type is "def [T] (t: T, t2: int) -> list[int] | str"
+reveal_type(A.f)  # N: Revealed type is "def [T2 (from A), T] (self: __main__.A[T2], t: T, t2: T2) -> list[int] | str"
+reveal_type(A[int]().f)  # N: Revealed type is "def [T] (t: T, t2: int) -> list[int] | str"


### PR DESCRIPTION
annotations on overload impls are imposters

Changes:
- infer annotations on overload implementations
- infer annotations from super on overrides
- infer annotations from default values
- refactor `default_return`
- add `incomplete_is_typed` option.

Todo:
- documentation (after merged)

closes #149
closes  #141
closes  #157
closes  #228
closes  #253
closes #266