### PR TITLE
`default_return` functionality

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,22 +113,23 @@ jobs:
     - name: Test
       run: tox -e ${{ matrix.toxenv }} --skip-pkg-install -- ${{ matrix.tox_extra_args }}
 
-  python-nightly:
-    runs-on: ubuntu-latest
-    name: Test suite with Python nightly
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.11-dev'
-    - name: Install tox
-      run: |
-        pip install -U pip==21.2.3 setuptools
-        pip install --upgrade 'setuptools!=50' virtualenv==20.4.7 tox==3.20.1
-    - name: Setup tox environment
-      run: tox -e py --notest
-    - name: Test
-      run: tox -e py --skip-pkg-install -- "-n 2"
-      continue-on-error: true
-    - name: Mark as a success
-      run: exit 0
+# TODO: re-enable when `typed-ast` will be fixed for `python==3.11`
+#   python-nightly:
+#     runs-on: ubuntu-latest
+#     name: Test suite with Python nightly
+#     steps:
+#     - uses: actions/checkout@v2
+#     - uses: actions/setup-python@v2
+#       with:
+#         python-version: '3.11-dev'
+#     - name: Install tox
+#       run: |
+#         pip install -U pip==21.2.3 setuptools
+#         pip install --upgrade 'setuptools!=50' virtualenv==20.4.7 tox==3.20.1
+#     - name: Setup tox environment
+#       run: tox -e py --notest
+#     - name: Test
+#       run: tox -e py --skip-pkg-install -- "-n 2"
+#       continue-on-error: true
+#     - name: Mark as a success
+#       run: exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- `default_return` option to imply unannotated return type as `None`.
 
 ## [1.2.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ compatability with the cringe parts of pep 484.
 Based features include:
 - Typesafe by default (optional and dynamic typing still supported)
 - Baseline functionality
+- Default return type of `None` instead of `Any`
 
 See the [changelog](CHANGELOG.md) for a comprehensive list.
 

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -512,6 +512,10 @@ def process_options(args: List[str],
     based_group.add_argument(
         '--legacy', action='store_true',
         help="Disable all based functionality")
+    add_invertible_flag(
+        '--default-return', default=False, dest="default_return",
+        help="Assume implicit default return type of None",
+        group=based_group)
 
     config_group = parser.add_argument_group(
         title='Config file',

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -27,6 +27,7 @@ PER_MODULE_OPTIONS: Final = {
     "always_true",
     "check_untyped_defs",
     "debug_cache",
+    "default_return",
     "disallow_any_decorated",
     "disallow_any_explicit",
     "disallow_any_expr",
@@ -116,6 +117,7 @@ class Options:
         self.legacy = False
         self.write_baseline = False
         self.baseline_file = defaults.BASELINE_FILE
+        self.default_return = False
 
         # disallow_any options
         self.disallow_any_generics = flip_if_not_based(True)

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -25,6 +25,7 @@ from mypy.semanal_main import core_modules
 # List of files that contain test case descriptions.
 typecheck_files = [
     'check-basic.test',
+    'check-based-default-return.test',
     'check-union-or-syntax.test',
     'check-callable.test',
     'check-classes.test',
@@ -163,7 +164,7 @@ class TypeCheckSuite(DataSuite):
 
         # set mypy to legacy mode
         from mypy import options as mypy_options
-        mypy_options._based = False
+        mypy_options._based = 'based' in testcase.file.rsplit(os.sep)[-1]
         # Parse options after moving files (in case mypy.ini is being moved).
         options = parse_options(original_program_text, testcase, incremental_step)
         options.use_builtins_fixtures = True

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -29,3 +29,9 @@ no_warn_no_ignore_code = True
 no_warn_unreachable = True
 implicit_reexport = True
 disallow_redefinition = True
+
+[mypy-mypy]
+default_return = True
+
+[mypy-mypyc]
+default_return = True

--- a/mypy_self_check_strict.ini
+++ b/mypy_self_check_strict.ini
@@ -21,3 +21,9 @@ plugins = misc/proper_plugin.py
 python_version = 3.6
 exclude = mypy/typeshed/|mypyc/test-data/|mypyc/lib-rt/
 disallow_redefinition = True
+
+[mypy-mypy]
+default_return = True
+
+[mypy-mypyc]
+default_return = True

--- a/test-data/unit/check-based-default-return.test
+++ b/test-data/unit/check-based-default-return.test
@@ -1,0 +1,114 @@
+-- Type checker test cases for default return type.
+
+
+[case testSimple]
+# flags: --default-return
+def f(): ...
+reveal_type(f)  # N: Revealed type is "def ()"
+
+def g(i: int): ...
+reveal_type(g)  # N: Revealed type is "def (i: builtins.int)"
+
+class A:
+    def f(self): ...
+    def g(self, i: int): ...
+
+reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A)"
+reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: builtins.int)"
+
+
+[case testUntypedDefs]
+# flags: --default-return --allow-untyped-defs --allow-any-expr
+
+def f(): ...
+reveal_type(f)  # N: Revealed type is "def () -> Any"
+
+def g(i: int): ...
+reveal_type(g)  # N: Revealed type is "def (i: builtins.int)"
+
+def h(i: int, j): ... # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]
+
+class A:
+    def f(self): ...
+    def g(self, i): ...
+    def h(self, i: int): ...
+    def i(self, i: int, j): ... # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]
+
+reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A) -> Any"
+reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: Any) -> Any"
+reveal_type(A.h)  # N: Revealed type is "def (self: __main__.A, i: builtins.int)"
+
+
+[case testIncompleteDefs]
+# flags: --default-return --allow-incomplete-defs --allow-untyped-defs --allow-any-expr
+
+def f(i): ...
+reveal_type(f)  # N: Revealed type is "def (i: Any) -> Any"
+
+def g(i: int, j): ...
+reveal_type(g)  # N: Revealed type is "def (i: builtins.int, j: Any)"
+
+class A:
+    def f(self): ...
+    def g(self, i): ...
+    def h(self, i: int): ...
+    def i(self, i: int, j): ...
+
+reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A) -> Any"
+reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: Any) -> Any"
+reveal_type(A.h)  # N: Revealed type is "def (self: __main__.A, i: builtins.int)"
+reveal_type(A.i)  # N: Revealed type is "def (self: __main__.A, i: builtins.int, j: Any)"
+
+
+[case testGenerator]
+# flags: --default-return
+
+def f():  # E: The return type of a generator function should be "Generator" or one of its supertypes  [misc]
+    yield
+
+def g(i: int):  # E: The return type of a generator function should be "Generator" or one of its supertypes  [misc]
+    yield
+
+class A:
+    def f(self): # E: The return type of a generator function should be "Generator" or one of its supertypes  [misc]
+        yield
+    def g(self, i: int): # E: The return type of a generator function should be "Generator" or one of its supertypes  [misc]
+        yield
+
+
+[case testLambda]
+# flags: --default-return --allow-any-expr
+
+f = lambda x: x
+g = lambda: ...
+reveal_type(f)  # N: Revealed type is "def (x: Any) -> Any"
+reveal_type(g)  # N: Revealed type is "def () -> builtins.ellipsis"
+
+
+[case testExplicitAny]
+# flags: --default-return --allow-any-expr  --allow-any-explicit
+from typing import Any
+
+def f() -> Any: ...
+def g(i: int) -> Any: ...
+reveal_type(f)  # N: Revealed type is "def () -> Any"
+reveal_type(g)  # N: Revealed type is "def (i: builtins.int) -> Any"
+
+class A:
+    def f(self) -> Any: ...
+    def g(self, i: int) -> Any: ...
+reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A) -> Any"
+reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: builtins.int) -> Any"
+
+
+[case testNoDefaultReturn]
+# flags: --allow-any-expr
+
+def f(i): ...  # E: Function is missing a type annotation  [no-untyped-def]
+def g(i: int, j): ...  # E: Function is missing a return type annotation  [no-untyped-def] \
+    # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]
+
+class A:
+    def f(self, i): ...  # E: Function is missing a type annotation  [no-untyped-def]
+    def g(self, i: int, j): ...  # E: Function is missing a return type annotation  [no-untyped-def] \
+        # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]


### PR DESCRIPTION
Returning `None` is an impostor

closes #3


When disallow-untyped-defs, it's always `None`
When allow-untyped-defs, and untyped it's always it's `Any`
When allow-incomplete-defs and it's partially typed, it's `None`, when it's not typed, it's `Any`