### PR TITLE
Render unions with new union syntax in output messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Basedmypy Changelog
 
 ## [Unreleased]
+### Added
+- Unions in output messages show with new syntax
 
 ## [1.0.0]
 ### Added

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -1772,6 +1772,9 @@ class UnionType(ProperType):
     def __hash__(self) -> int:
         return hash(frozenset(self.items))
 
+    def __repr__(self):
+        return " | ".join(map(repr, self.items))
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, UnionType):
             return NotImplemented


### PR DESCRIPTION
I think it's really 'sus' to show cringe old `Union` syntax

closes #63