### PR TITLE
Allow typing members in annotations without imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - Unions in output messages show with new syntax
+- When `__future__.annotations`, all `typing`s are usable without imports 
 
 ## [1.0.0]
 ### Added

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -500,13 +500,21 @@ def process_options(args: List[str],
         help="Show program's version number and exit",
         stdout=stdout)
 
-    general_group.add_argument(
+    based_group = parser.add_argument_group(
+        title='Based functionality arguments')
+    based_group.add_argument(
         '--write-baseline', action="store_true",
         help="Create an error baseline from the result of this execution")
-    general_group.add_argument(
+    based_group.add_argument(
         '--baseline-file', action='store',
         help="Use baseline info in the given file"
              "(defaults to '{}')".format(defaults.BASELINE_FILE))
+    based_group.add_argument(
+        '--disable-implicit-typing-globals', action="store_false",
+        dest="implicit_typing_globals",
+        help="Disallow using members from `typing` in annotations without imports."
+    )
+
     config_group = parser.add_argument_group(
         title='Config file',
         description="Use a config file instead of command line arguments. "

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -103,8 +103,10 @@ class Options:
         # File names, directory names or subpaths to avoid checking
         self.exclude: List[str] = []
 
+        # Based options
         self.write_baseline = False
         self.baseline_file = defaults.BASELINE_FILE
+        self.implicit_typing_globals = True
 
         # disallow_any options
         self.disallow_any_generics = True

--- a/mypy/semanal_shared.py
+++ b/mypy/semanal_shared.py
@@ -34,7 +34,8 @@ class SemanticAnalyzerCoreInterface:
 
     @abstractmethod
     def lookup_qualified(self, name: str, ctx: Context,
-                         suppress_errors: bool = False) -> Optional[SymbolTableNode]:
+                         suppress_errors: bool = False
+                         , annotation: bool = False) -> Optional[SymbolTableNode]:
         raise NotImplementedError
 
     @abstractmethod

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -169,7 +169,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         return typ
 
     def visit_unbound_type_nonoptional(self, t: UnboundType, defining_literal: bool) -> Type:
-        sym = self.lookup_qualified(t.name, t)
+        sym = self.lookup_qualified(t.name, t, annotation=True)
         if sym is not None:
             node = sym.node
             if isinstance(node, PlaceholderNode):
@@ -565,7 +565,7 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
 
     def anal_type_guard(self, t: Type) -> Optional[Type]:
         if isinstance(t, UnboundType):
-            sym = self.lookup_qualified(t.name, t)
+            sym = self.lookup_qualified(t.name, t, annotation=True)
             if sym is not None and sym.node is not None:
                 return self.anal_type_guard_arg(t, sym.node.fullname)
         # TODO: What if it's an Instance? Then use t.type.fullname?
@@ -1260,7 +1260,7 @@ class TypeVarLikeQuery(TypeQuery[TypeVarLikeList]):
                     node = n
                     name = base
         if node is None:
-            node = self.lookup(name, t)
+            node = self.lookup(name, t, annotation=True)
         if node and isinstance(node.node, TypeVarLikeExpr) and (
                 self.include_bound_tvars or self.scope.get_binding(node) is None):
             assert isinstance(node.node, TypeVarLikeExpr)


### PR DESCRIPTION
```py
from typing import A, B, C, D, E, F, G, H, ..., AMONGUS, ..., X, Y, X
```
NO THANKS!