### PR TITLE
specify correct mypy hash

### DIFF
--- a/mypy/version.py
+++ b/mypy/version.py
@@ -12,8 +12,6 @@ mypy_version = "0.940+dev"
 mypy_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 if __version__.endswith('+dev') and git.is_git_repo(mypy_dir) and git.have_git():
     __version__ += '.' + git.git_revision(mypy_dir).decode('utf-8')
-    mypy_version += '.' + git.git_revision(mypy_dir).decode('utf-8')
     if git.is_dirty(mypy_dir):
         __version__ += '.dirty'
-        mypy_version += '.dirty'
 del mypy_dir


### PR DESCRIPTION
Vented the sus incorrect mypy hash and hardcoded it with the non-imposter one. The mypy hash will still be included on release builds.

resolves #112