### PR TITLE
Allow literal types without `Literal`

### DIFF
--- a/.mypy/baseline.json
+++ b/.mypy/baseline.json
@@ -11914,7 +11914,7 @@
         "code": "no-any-expr",
         "column": 66,
         "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
-        "offset": 184,
+        "offset": 187,
         "target": "mypy.main.process_options"
       },
       {
@@ -13460,7 +13460,7 @@
         "code": "no-any-expr",
         "column": 30,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 277,
+        "offset": 266,
         "target": "mypy.messages.format_type_inner"
       },
       {
@@ -14324,7 +14324,7 @@
         "code": "no-any-unimported",
         "column": 8,
         "message": "Type of variable becomes \"set[Any (from unimported type)]\" due to an unfollowed import",
-        "offset": 217,
+        "offset": 218,
         "target": "mypy.options.Options.__init__"
       },
       {
@@ -16291,7 +16291,7 @@
         "code": "truthy-bool",
         "column": 15,
         "message": "\"call\" has type \"CallExpr\" which does not implement __bool__ or __len__ so it could always be true in boolean context",
-        "offset": 938,
+        "offset": 946,
         "target": "mypy.semanal.SemanticAnalyzer.extract_typevarlike_name"
       },
       {
@@ -25052,7 +25052,7 @@
         "code": "no-any-expr",
         "column": 31,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 971,
+        "offset": 988,
         "target": "mypy.typeanal.TypeAnalyser.analyze_callable_type"
       },
       {
@@ -25399,7 +25399,7 @@
         "code": "no-any-expr",
         "column": 62,
         "message": "Expression has type \"Any\"",
-        "offset": 69,
+        "offset": 73,
         "target": "mypy.types.UnboundType.copy_modified"
       },
       {
@@ -26540,14 +26540,14 @@
         "code": "no-any-return",
         "column": 8,
         "message": "Returning Any from function declared to return \"T\"",
-        "offset": 116,
+        "offset": 118,
         "target": "mypy.types.RawExpressionType.accept"
       },
       {
         "code": "no-any-expr",
         "column": 15,
         "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
-        "offset": 92,
+        "offset": 93,
         "target": "mypy.types.LiteralType.serialize"
       },
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Basedmypy Changelog
 
 ## [Unreleased]
+### Added
+- Allow literal `int`, `bool` and `Enum`s without `Literal`
 ### Enhancements
 - Render Literal types better in output messages
 

--- a/mypy/defaults.py
+++ b/mypy/defaults.py
@@ -3,7 +3,7 @@ import os
 from typing_extensions import Final
 
 PYTHON2_VERSION: Final = (2, 7)
-PYTHON3_VERSION: Final = (3, 6)
+PYTHON3_VERSION: Final = (3, 7)
 PYTHON3_VERSION_MIN: Final = (3, 4)
 CACHE_DIR: Final = ".mypy_cache"
 BASELINE_FILE: Final = ".mypy/baseline.json"

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -1,5 +1,4 @@
 """Translate an Expression to a Type value."""
-
 from typing import Optional
 
 from mypy.nodes import (
@@ -48,15 +47,18 @@ def expr_to_unanalyzed_type(expr: Expression,
     if isinstance(expr, NameExpr):
         name = expr.name
         if name == 'True':
-            return RawExpressionType(True, 'builtins.bool', line=expr.line, column=expr.column)
+            return RawExpressionType(True, 'builtins.bool', line=expr.line, column=expr.column,
+                                     expression=not allow_new_syntax)
         elif name == 'False':
-            return RawExpressionType(False, 'builtins.bool', line=expr.line, column=expr.column)
+            return RawExpressionType(False, 'builtins.bool', line=expr.line, column=expr.column,
+                                     expression=not allow_new_syntax)
         else:
             return UnboundType(name, line=expr.line, column=expr.column)
     elif isinstance(expr, MemberExpr):
         fullname = get_member_expr_fullname(expr)
         if fullname:
-            return UnboundType(fullname, line=expr.line, column=expr.column)
+            return UnboundType(fullname, line=expr.line, column=expr.column,
+                               expression=True)
         else:
             raise TypeTranslationError()
     elif isinstance(expr, IndexExpr):
@@ -152,7 +154,8 @@ def expr_to_unanalyzed_type(expr: Expression,
                 return typ
         raise TypeTranslationError()
     elif isinstance(expr, IntExpr):
-        return RawExpressionType(expr.value, 'builtins.int', line=expr.line, column=expr.column)
+        return RawExpressionType(expr.value, 'builtins.int', line=expr.line, column=expr.column,
+                                 expression=not allow_new_syntax)
     elif isinstance(expr, FloatExpr):
         # Floats are not valid parameters for RawExpressionType , so we just
         # pass in 'None' for now. We'll report the appropriate error at a later stage.

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -555,6 +555,9 @@ def process_options(args: List[str],
         '--incomplete-is-typed', group=based_group, default=False,
         help="Partially typed/incomplete functions in this module are considered typed"
              " for untyped call errors.")
+    add_invertible_flag(
+        '--bare-literals', default=True,
+        help="Allow bare literals.", group=based_group)
 
     config_group = parser.add_argument_group(
         title='Config file',

--- a/mypy/message_registry.py
+++ b/mypy/message_registry.py
@@ -22,6 +22,9 @@ class ErrorMessage(NamedTuple):
 
 # Invalid types
 INVALID_TYPE_RAW_ENUM_VALUE: Final = "Invalid type: try using Literal[{}.{}] instead?"
+INVALID_BARE_LITERAL: Final = (
+    '"{0}" is a bare literal and cannot be used here, try Literal[{0}] instead?'
+)
 
 # Type checker error message constants
 NO_RETURN_VALUE_EXPECTED: Final = ErrorMessage("No return value expected", codes.RETURN_VALUE)

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -130,6 +130,7 @@ class Options:
         self.targets: List[str] = []
         self.ignore_any_from_error = True
         self.incomplete_is_typed = flip_if_not_based(False)
+        self.bare_literals = flip_if_not_based(True)
 
         # disallow_any options
         self.disallow_any_generics = flip_if_not_based(True)

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -3341,7 +3341,13 @@ class SemanticAnalyzer(NodeVisitor[None],
                     upper_bound = get_proper_type(analyzed)
                     if isinstance(upper_bound, AnyType) and upper_bound.is_from_error:
                         self.fail(message_registry.TYPEVAR_BOUND_MUST_BE_TYPE, param_value)
-                        # Note: we do not return 'None' here -- we want to continue
+                    elif isinstance(upper_bound, LiteralType) and upper_bound.bare_literal:
+                        self.fail(
+                            message_registry.INVALID_BARE_LITERAL.format(upper_bound.value_repr()),
+                            param_value, code=codes.VALID_TYPE,
+                        )
+
+                    # Note: we do not return 'None' here -- we want to continue
                         # using the AnyType as the upper bound.
                 except TypeTranslationError:
                     self.fail(message_registry.TYPEVAR_BOUND_MUST_BE_TYPE, param_value)

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -553,23 +553,31 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         # a "Literal[...]" type. So, if `defining_literal` is not set,
         # we bail out early with an error.
         #
-        # If, in the distant future, we decide to permit things like
-        # `def foo(x: Color.RED) -> None: ...`, we can remove that
-        # check entirely.
+        # Based: we permit things like `def foo(x: Color.RED) -> None: ...`
         if isinstance(sym.node, Var) and sym.node.info and sym.node.info.is_enum:
             value = sym.node.name
-            base_enum_short_name = sym.node.info.name
+            # it's invalid to use in an expression, ie: a TypeAlias
             if not defining_literal:
-                msg = message_registry.INVALID_TYPE_RAW_ENUM_VALUE.format(
-                    base_enum_short_name, value)
-                self.fail(msg, t)
-                return AnyType(TypeOfAny.from_error)
-            return LiteralType(
+                if not self.options.bare_literals:
+                    base_enum_short_name = sym.node.info.name
+                    msg = message_registry.INVALID_TYPE_RAW_ENUM_VALUE.format(
+                        base_enum_short_name, value)
+                    self.fail(msg, t)
+                if t.expression:
+                    base_enum_short_name = sym.node.info.name
+                    name = f"{base_enum_short_name}.{value}"
+                    msg = message_registry.INVALID_BARE_LITERAL.format(name)
+                    self.fail(msg, t)
+            result = LiteralType(
                 value=value,
                 fallback=Instance(sym.node.info, [], line=t.line, column=t.column),
                 line=t.line,
                 column=t.column,
+                bare_literal=True,
             )
+            if t.expression:
+                return result
+            return result.accept(self)
 
         # None of the above options worked. We parse the args (if there are any)
         # to make sure there are no remaining semanal-only types, then give up.
@@ -780,16 +788,18 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
         # "fake literals" should always be wrapped in an UnboundType
         # corresponding to 'Literal'.
         #
-        # Note: if at some point in the distant future, we decide to
-        # make signatures like "foo(x: 20) -> None" legal, we can change
-        # this method so it generates and returns an actual LiteralType
-        # instead.
+        # Based: signatures like "foo(x: 20) -> None" are legal, this method
+        # generates and returns an actual LiteralType instead.
 
         if self.report_invalid_types:
+            msg = None
             if t.base_type_name in ('builtins.int', 'builtins.bool'):
-                # The only time it makes sense to use an int or bool is inside of
-                # a literal type.
-                msg = f"Invalid type: try using Literal[{repr(t.literal_value)}] instead?"
+                if not self.options.bare_literals:
+                    # The only time it makes sense to use an int or bool is inside of
+                    # a literal type.
+                    msg = f"Invalid type: try using Literal[{repr(t.literal_value)}] instead?"
+                if t.expression:
+                    msg = message_registry.INVALID_BARE_LITERAL.format(t.literal_value)
             elif t.base_type_name in ('builtins.float', 'builtins.complex'):
                 # We special-case warnings for floats and complex numbers.
                 msg = f"Invalid type: {t.simple_name()} literals cannot be used as a type"
@@ -800,14 +810,34 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
                 # string, it's unclear if the user meant to construct a literal type
                 # or just misspelled a regular type. So we avoid guessing.
                 msg = 'Invalid type comment or annotation'
-
-            self.fail(msg, t, code=codes.VALID_TYPE)
-            if t.note is not None:
-                self.note(t.note, t, code=codes.VALID_TYPE)
-
+            if msg:
+                self.fail(msg, t, code=codes.VALID_TYPE)
+                if t.note is not None:
+                    self.note(t.note, t, code=codes.VALID_TYPE)
+        if t.base_type_name in ('builtins.int', 'builtins.bool'):
+            v = t.literal_value
+            assert v is not None
+            result = LiteralType(
+                v,
+                fallback=self.named_type(t.base_type_name),
+                line=t.line,
+                column=t.column,
+                bare_literal=True
+            )
+            if t.expression:
+                return result
+            return result.accept(self)
         return AnyType(TypeOfAny.from_error, line=t.line, column=t.column)
 
     def visit_literal_type(self, t: LiteralType) -> Type:
+        if (
+            self.nesting_level
+            and t.bare_literal
+            and not self.api.is_future_flag_set("annotations")
+            and self.options.bare_literals
+        ):
+            self.fail(f'"{t}" is a bare literal and shouldn\'t be used in a type operation without'
+                      ' "__future__.annotations"', t, code=codes.VALID_TYPE)
         return t
 
     def visit_star_type(self, t: StarType) -> Type:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -718,7 +718,7 @@ class UnboundType(ProperType):
     """Instance type that has not been bound during semantic analysis."""
 
     __slots__ = ('name', 'args', 'optional', 'empty_tuple_index',
-                 'original_str_expr', 'original_str_fallback')
+                 'original_str_expr', 'original_str_fallback', "expression")
 
     def __init__(self,
                  name: Optional[str],
@@ -729,6 +729,7 @@ class UnboundType(ProperType):
                  empty_tuple_index: bool = False,
                  original_str_expr: Optional[str] = None,
                  original_str_fallback: Optional[str] = None,
+                 expression=False,
                  ) -> None:
         super().__init__(line, column)
         if not args:
@@ -755,6 +756,9 @@ class UnboundType(ProperType):
         # so we don't have to try and recompute it later
         self.original_str_expr = original_str_expr
         self.original_str_fallback = original_str_fallback
+
+        self.expression = expression
+        """This is used to ban bare Enum literals from expressions like ``TypeAlias``es"""
 
     def copy_modified(self,
                       args: Bogus[Optional[Sequence[Type]]] = _dummy,
@@ -2228,7 +2232,7 @@ class RawExpressionType(ProperType):
         )
     """
 
-    __slots__ = ('literal_value', 'base_type_name', 'note')
+    __slots__ = ('literal_value', 'base_type_name', 'note', 'expression')
 
     def __init__(self,
                  literal_value: Optional[LiteralValue],
@@ -2236,11 +2240,13 @@ class RawExpressionType(ProperType):
                  line: int = -1,
                  column: int = -1,
                  note: Optional[str] = None,
+                 expression=False,
                  ) -> None:
         super().__init__(line, column)
         self.literal_value = literal_value
         self.base_type_name = base_type_name
         self.note = note
+        self.expression = expression
 
     def simple_name(self) -> str:
         return self.base_type_name.replace("builtins.", "")
@@ -2278,14 +2284,15 @@ class LiteralType(ProperType):
     As another example, `Literal[Color.RED]` (where Color is an enum) is
     represented as `LiteralType(value="RED", fallback=instance_of_color)'.
     """
-    __slots__ = ('value', 'fallback', '_hash')
+    __slots__ = ('value', 'fallback', '_hash', 'bare_literal')
 
     def __init__(self, value: LiteralValue, fallback: Instance,
-                 line: int = -1, column: int = -1) -> None:
+                 line: int = -1, column: int = -1, bare_literal=False) -> None:
         self.value = value
         super().__init__(line, column)
         self.fallback = fallback
         self._hash = -1  # Cached hash value
+        self.bare_literal = bare_literal
 
     def can_be_false_default(self) -> bool:
         return not self.value

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -33,6 +33,7 @@ disable_error_code = truthy-bool, redundant-expr, ignore-without-code, no-untype
 
 [mypy-mypy.*,mypyc.*]
 default_return = True
+infer_function_types = True
 
 [mypy-_pytest.*,pytest.*]
 incomplete_is_typed = True

--- a/test-data/unit/check-based-bare-literals.test
+++ b/test-data/unit/check-based-bare-literals.test
@@ -1,0 +1,103 @@
+[case testBareLiteralLiterals]
+from __future__ import annotations
+
+a: 1
+reveal_type(a)  # N: Revealed type is "1"
+a2: 1 | str
+reveal_type(a2)  # N: Revealed type is "1 | str"
+a3: "1 | str"
+reveal_type(a3)  # N: Revealed type is "1 | str"
+
+b: True
+reveal_type(b)  # N: Revealed type is "True"
+b2: True | str
+reveal_type(b2)  # N: Revealed type is "True | str"
+
+c: False
+reveal_type(c)  # N: Revealed type is "False"
+c2: False | str
+reveal_type(c2)  # N: Revealed type is "False | str"
+
+d: 1.1  # E: Invalid type: float literals cannot be used as a type  [valid-type]
+d2: 1.1 | str  # E: Invalid type: float literals cannot be used as a type  [valid-type]
+
+e: 1j  # E: Invalid type: complex literals cannot be used as a type  [valid-type]
+e2: 1j | str  # E: Invalid type: complex literals cannot be used as a type  [valid-type]
+[builtins fixtures/tuple.pyi]
+
+
+[case testNoBareLiteralLiterals]
+# flags: --python-version 3.10
+
+a1: 1
+a2: 1 | str  # E: "1" is a bare literal and shouldn't be used in a type operation without "__future__.annotations"  [valid-type]
+
+b1: True
+b2: True | str  # E: "True" is a bare literal and shouldn't be used in a type operation without "__future__.annotations"  [valid-type]
+
+c1: False
+c2: False | str  # E: "False" is a bare literal and shouldn't be used in a type operation without "__future__.annotations"  [valid-type]
+
+d1: 1.1  # E: Invalid type: float literals cannot be used as a type  [valid-type]
+d2: 1.1 | str  # E: Invalid type: float literals cannot be used as a type  [valid-type]
+
+e1: 1j  # E: Invalid type: complex literals cannot be used as a type  [valid-type]
+e2: 1j | str  # E: Invalid type: complex literals cannot be used as a type  [valid-type]
+
+
+[case testBareLiteralEnum]
+# flags: --python-version 3.10
+from __future__ import annotations
+from enum import Enum
+
+class E(Enum):
+    A = 1
+
+a: E.A
+a2: E.A | str
+reveal_type(a)  # N: Revealed type is "__main__.E.A"
+[builtins fixtures/tuple.pyi]
+
+
+[case testNoBareLiteralEnum]
+# flags: --python-version 3.10
+from enum import Enum
+
+class E(Enum):
+    A = 1
+
+a: E.A
+b: E.A | str  # E: "__main__.E.A" is a bare literal and shouldn't be used in a type operation without "__future__.annotations"  [valid-type]
+[builtins fixtures/tuple.pyi]
+
+
+[case testNoBareLiteralTypeAlias]
+from __future__ import annotations
+from typing_extensions import TypeAlias
+from enum import Enum
+
+class E(Enum):
+    A = 1
+
+A: TypeAlias = 1  # E: "1" is a bare literal and cannot be used here, try Literal[1] instead?  [valid-type]
+B: TypeAlias = True  # E: "True" is a bare literal and cannot be used here, try Literal[True] instead?  [valid-type]
+C: TypeAlias = False  # E: "False" is a bare literal and cannot be used here, try Literal[False] instead?  [valid-type]
+D: TypeAlias = E.A  # E: "E.A" is a bare literal and cannot be used here, try Literal[E.A] instead?  [misc]
+A2 = str | 2  # E: Unsupported left operand type for | ("type[str]")  [operator]
+a2: A2  # E: Variable "__main__.A2" is not valid as a type  [valid-type] \
+       # N: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
+[builtins fixtures/tuple.pyi]
+
+
+[case testBareLiteralTypeVarBound]
+# flags: --python-version 3.10
+
+from typing import TypeVar
+T1 = TypeVar("T1", bound=list[1])  # E: "1" is a bare literal and cannot be used here, try Literal[1] instead?  [valid-type]
+T2 = TypeVar("T2", str, list[1])  # E: "1" is a bare literal and cannot be used here, try Literal[1] instead?  [valid-type]
+
+
+[case testBareLiteralGeneric]
+# flags: --python-version 3.10
+l1: list[1]  # E: "1" is a bare literal and shouldn't be used in a type operation without "__future__.annotations"  [valid-type]
+l1 = list[1]()  # E: "1" is a bare literal and cannot be used here, try Literal[1] instead?  [valid-type]

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -1763,7 +1763,7 @@ def WrongArg(x, y): return y
 # something else sensible, because other tests require the stub not have anything
 # that looks like a function call.
 F = Callable[[WrongArg(int, 'x')], int] # E: Invalid argument constructor "__main__.WrongArg"
-G = Callable[[Arg(1, 'x')], int] # E: Invalid type: try using Literal[1] instead?
+G = Callable[[Arg(1, 'x')], int] # E: "1" is a bare literal and cannot be used here, try Literal[1] instead?
 H = Callable[[VarArg(int, 'x')], int] # E: VarArg arguments should not have names
 I = Callable[[VarArg(int)], int] # ok
 J = Callable[[VarArg(), KwArg()], int] # ok

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -3744,7 +3744,7 @@ import b
 [file b.py]
 -- This is a heinous hack, but we simulate having a invalid cache by clobbering
 -- the proto deps file with something with mtime mismatches.
-[file ../.mypy_cache/3.6/@deps.meta.json.2]
+[file ../.mypy_cache/3.7/@deps.meta.json.2]
 {"snapshot": {"__main__": "a7c958b001a45bd6a2a320f4e53c4c16", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "c532c89da517a4b779bcf7a964478d67"}, "deps_meta": {"@root": {"path": "@root.deps.json", "mtime": 0}, "__main__": {"path": "__main__.deps.json", "mtime": 0}, "a": {"path": "a.deps.json", "mtime": 0}, "b": {"path": "b.deps.json", "mtime": 0}, "builtins": {"path": "builtins.deps.json", "mtime": 0}}}
 [file ../.mypy_cache/.gitignore]
 # Another hack to not trigger a .gitignore creation failure "false positive"
@@ -3779,7 +3779,7 @@ import b
 [file b.py]
 -- This is a heinous hack, but we simulate having a invalid cache by deleting
 -- the proto deps file.
-[delete ../.mypy_cache/3.6/@deps.meta.json.2]
+[delete ../.mypy_cache/3.7/@deps.meta.json.2]
 [file b.py.2]
 # uh
 -- Every file should get reloaded, since the cache was invalidated

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2277,7 +2277,7 @@ class C(Sequence[T], Generic[T]): pass
 C[0] = 0
 [out]
 main:4: error: Unsupported target for indexed assignment ("Type[C[Any]]")
-main:4: error: Invalid type: try using Literal[0] instead?
+main:4: error: "0" is a bare literal and cannot be used here, try Literal[0] instead?
 
 [case testNoCrashOnPartialMember]
 class C:

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -64,7 +64,7 @@ def g(x):
 x = None  # type: Optional[1]   # E: Invalid type: try using Literal[1] instead?
 y = None  # type: Optional[Literal[1]]
 
-reveal_type(x)  # N: Revealed type is "Union[Any, None]"
+reveal_type(x)  # N: Revealed type is "Union[Literal[1], None]"
 reveal_type(y)  # N: Revealed type is "Union[Literal[1], None]"
 [out]
 
@@ -77,7 +77,7 @@ def foo(x: Tuple[1]) -> None: ...   # E: Invalid type: try using Literal[1] inst
 
 y: Tuple[Literal[2]]
 def bar(x: Tuple[Literal[2]]) -> None: ...
-reveal_type(x)                      # N: Revealed type is "Tuple[Any]"
+reveal_type(x)                      # N: Revealed type is "Tuple[Literal[1]]"
 reveal_type(y)                      # N: Revealed type is "Tuple[Literal[2]]"
 reveal_type(bar)                    # N: Revealed type is "def (x: Tuple[Literal[2]])"
 [builtins fixtures/tuple.pyi]
@@ -97,7 +97,7 @@ y = None  # type: Optional[Tuple[Literal[2]]]
 def bar(x):
     # type: (Tuple[Literal[2]]) -> None
     pass
-reveal_type(x)                      # N: Revealed type is "Union[Tuple[Any], None]"
+reveal_type(x)                      # N: Revealed type is "Union[Tuple[Literal[1]], None]"
 reveal_type(y)                      # N: Revealed type is "Union[Tuple[Literal[2]], None]"
 reveal_type(bar)                    # N: Revealed type is "def (x: Tuple[Literal[2]])"
 [out]
@@ -116,7 +116,7 @@ y = None  # type: Optional[Tuple[Literal[2]]]
 def bar(x):
     # type: (Tuple[Literal[2]]) -> None
     pass
-reveal_type(x)                      # N: Revealed type is "Union[Tuple[Any], None]"
+reveal_type(x)                      # N: Revealed type is "Union[Tuple[Literal[1]], None]"
 reveal_type(y)                      # N: Revealed type is "Union[Tuple[Literal[2]], None]"
 reveal_type(bar)                    # N: Revealed type is "def (x: Tuple[Literal[2]])"
 [builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-newtype.test
+++ b/test-data/unit/check-newtype.test
@@ -270,7 +270,7 @@ tmp/m.py:14: note: Revealed type is "builtins.int"
 from typing import NewType
 
 a = NewType('b', int)  # E: String argument 1 "b" to NewType(...) does not match variable name "a"
-b = NewType('b', 3)    # E: Argument 2 to NewType(...) must be a valid type
+b = NewType('b', 3)    # E: "3" is a bare literal and cannot be used here, try Literal[3] instead?
 c = NewType(2, int)    # E: Argument 1 to NewType(...) must be a string literal
 foo = "d"
 d = NewType(foo, int)  # E: Argument 1 to NewType(...) must be a string literal

--- a/test-data/unit/check-typeddict.test
+++ b/test-data/unit/check-typeddict.test
@@ -1273,7 +1273,7 @@ Point = TypedDict('Point', {int: int, int: int})  # E: Invalid TypedDict() field
 
 [case testCannotCreateTypedDictTypeWithInvalidItemType]
 from mypy_extensions import TypedDict
-Point = TypedDict('Point', {'x': 1, 'y': 1})  # E: Invalid type: try using Literal[1] instead?
+Point = TypedDict('Point', {'x': 1, 'y': 1})  # E: "1" is a bare literal and cannot be used here, try Literal[1] instead?
 [builtins fixtures/dict.pyi]
 
 [case testCannotCreateTypedDictTypeWithInvalidName2]

--- a/test-data/unit/fine-grained-cache-incremental.test
+++ b/test-data/unit/fine-grained-cache-incremental.test
@@ -202,7 +202,7 @@ a.py:8: note:     x: expected "int", got "str"
 [file b.py]
 -- This is a heinous hack, but we simulate having a invalid cache by clobbering
 -- the proto deps file with something with mtime mismatches.
-[file ../.mypy_cache/3.6/@deps.meta.json.2]
+[file ../.mypy_cache/3.7/@deps.meta.json.2]
 {"snapshot": {"__main__": "a7c958b001a45bd6a2a320f4e53c4c16", "a": "d41d8cd98f00b204e9800998ecf8427e", "b": "d41d8cd98f00b204e9800998ecf8427e", "builtins": "c532c89da517a4b779bcf7a964478d67"}, "deps_meta": {"@root": {"path": "@root.deps.json", "mtime": 0}, "__main__": {"path": "__main__.deps.json", "mtime": 0}, "a": {"path": "a.deps.json", "mtime": 0}, "b": {"path": "b.deps.json", "mtime": 0}, "builtins": {"path": "builtins.deps.json", "mtime": 0}}}
 
 [file b.py.2]
@@ -234,8 +234,8 @@ x = 10
 [file p/c.py]
 class C: pass
 
-[delete ../.mypy_cache/3.6/b.meta.json.2]
-[delete ../.mypy_cache/3.6/p/c.meta.json.2]
+[delete ../.mypy_cache/3.7/b.meta.json.2]
+[delete ../.mypy_cache/3.7/p/c.meta.json.2]
 
 [out]
 ==

--- a/test-data/unit/fine-grained-modules.test
+++ b/test-data/unit/fine-grained-modules.test
@@ -2198,11 +2198,11 @@ import waitress
 [file a.py.3]
 import requests
 [out]
-a.py:1: error: Library stubs not installed for "waitress" (or incompatible with Python 3.6)
+a.py:1: error: Library stubs not installed for "waitress" (or incompatible with Python 3.7)
 a.py:1: note: Hint: "python3 -m pip install types-waitress"
 a.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 ==
 ==
-a.py:1: error: Library stubs not installed for "requests" (or incompatible with Python 3.6)
+a.py:1: error: Library stubs not installed for "requests" (or incompatible with Python 3.7)
 a.py:1: note: Hint: "python3 -m pip install types-requests"
 a.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1553,7 +1553,7 @@ from scribe import x
 import maxminddb  # Python 3 stubs available for maxminddb
 import foobar_asdf
 [out]
-_testIgnoreImportIfNoPython3StubAvailable.py:4: error: Library stubs not installed for "maxminddb" (or incompatible with Python 3.6)
+_testIgnoreImportIfNoPython3StubAvailable.py:4: error: Library stubs not installed for "maxminddb" (or incompatible with Python 3.7)
 _testIgnoreImportIfNoPython3StubAvailable.py:4: note: Hint: "python3 -m pip install types-maxminddb"
 _testIgnoreImportIfNoPython3StubAvailable.py:4: note: (or run "mypy --install-types" to install all missing stub packages)
 _testIgnoreImportIfNoPython3StubAvailable.py:4: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
@@ -1565,7 +1565,7 @@ import maxminddb
 [out]
 _testNoPython3StubAvailable.py:1: error: Cannot find implementation or library stub for module named "scribe"
 _testNoPython3StubAvailable.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
-_testNoPython3StubAvailable.py:3: error: Library stubs not installed for "maxminddb" (or incompatible with Python 3.6)
+_testNoPython3StubAvailable.py:3: error: Library stubs not installed for "maxminddb" (or incompatible with Python 3.7)
 _testNoPython3StubAvailable.py:3: note: Hint: "python3 -m pip install types-maxminddb"
 _testNoPython3StubAvailable.py:3: note: (or run "mypy --install-types" to install all missing stub packages)
 

--- a/test-data/unit/semanal-errors.test
+++ b/test-data/unit/semanal-errors.test
@@ -845,7 +845,7 @@ assert_type(1, type=int) # E: "assert_type" must be called with 2 positional arg
 assert_type(1, *int) # E: "assert_type" must be called with 2 positional arguments
 assert_type() # E: "assert_type" expects 2 arguments
 assert_type(1, int, "hello") # E: "assert_type" expects 2 arguments
-assert_type(int, 1)  # E: Invalid type: try using Literal[1] instead?
+assert_type(int, 1)  # E: "1" is a bare literal and cannot be used here, try Literal[1] instead?
 assert_type(1, int[int])  # E: "int" expects no type arguments, but 1 given
 
 [case testInvalidAnyCall]
@@ -931,7 +931,7 @@ A[TypeVar] # E: Variable "typing.TypeVar" is not valid as a type \
 from typing import TypeVar, Generic
 t = TypeVar('t')
 class A(Generic[t]): pass
-A[1] # E: Invalid type: try using Literal[1] instead?
+A[1] # E: "1" is a bare literal and cannot be used here, try Literal[1] instead?
 [out]
 
 [case testVariableDeclWithInvalidNumberOfTypes]
@@ -1044,7 +1044,7 @@ e = TypeVar('e', int, str, x=1)   # E: Unexpected argument to "TypeVar()": "x"
 f = TypeVar('f', (int, str), int) # E: Type expected
 g = TypeVar('g', int)             # E: TypeVar cannot have only a single constraint
 h = TypeVar('h', x=(int, str))    # E: Unexpected argument to "TypeVar()": "x"
-i = TypeVar('i', bound=1)         # E: TypeVar "bound" must be a type
+i = TypeVar('i', bound=1)         # E: "1" is a bare literal and cannot be used here, try Literal[1] instead?
 j = TypeVar('j', covariant=None)  # E: TypeVar "covariant" may only be a literal bool
 k = TypeVar('k', contravariant=1) # E: TypeVar "contravariant" may only be a literal bool
 [out]
@@ -1059,7 +1059,7 @@ S = TypeVar('S', covariant=True, contravariant=True) \
 [case testInvalidTypevarValues]
 from typing import TypeVar
 b = TypeVar('b', *[int]) # E: Unexpected argument to "TypeVar()"
-c = TypeVar('c', int, 2) # E: Invalid type: try using Literal[2] instead?
+c = TypeVar('c', int, 2) # E: "2" is a bare literal and cannot be used here, try Literal[2] instead?
 [out]
 
 [case testObsoleteTypevarValuesSyntax]


### PR DESCRIPTION
`Literal` is literally an impostor.

- partially resolves:  #1