### PR TITLE
Fixup `default_return` for overloads

### DIFF
--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -1100,18 +1100,19 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         check_incomplete_defs = self.options.disallow_incomplete_defs and has_explicit_annotation
         if show_untyped and (self.options.disallow_untyped_defs or check_incomplete_defs):
             if fdef.type is None and self.options.disallow_untyped_defs:
-                if (not fdef.arguments or (len(fdef.arguments) == 1 and
-                        (fdef.arg_names[0] == 'self' or fdef.arg_names[0] == 'cls'))):
-                    if self.options.default_return:
-                        typ.ret_type = NoneType()
-                        fdef.type = typ
-                    else:
+                if self.options.default_return:
+                    typ.ret_type = NoneType()
+                    # fully unannotated fdef needs to be assigned a type
+                    fdef.type = typ
+                else:
+                    if (not fdef.arguments or (len(fdef.arguments) == 1 and
+                            (fdef.arg_names[0] == 'self' or fdef.arg_names[0] == 'cls'))):
                         self.fail(message_registry.RETURN_TYPE_EXPECTED, fdef)
                         if not has_return_statement(fdef) and not fdef.is_generator:
                             self.note('Use "-> None" if function does not return a value', fdef,
                                       code=codes.NO_UNTYPED_DEF)
-                else:
-                    self.fail(message_registry.FUNCTION_TYPE_EXPECTED, fdef)
+                    else:
+                        self.fail(message_registry.FUNCTION_TYPE_EXPECTED, fdef)
             elif isinstance(fdef.type, CallableType):
                 ret_type = get_proper_type(fdef.type.ret_type)
                 if is_unannotated_any(ret_type):

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -821,6 +821,17 @@ class SemanticAnalyzer(NodeVisitor[None],
             if isinstance(item, Decorator):
                 callable = function_type(item.func, self.named_type('builtins.function'))
                 assert isinstance(callable, CallableType)
+                if (
+                    item.type is None
+                    and self.options.default_return
+                    and self.options.disallow_untyped_defs
+                ):
+                    ret_type = get_proper_type(callable.ret_type)
+                    if (
+                        isinstance(ret_type, AnyType)
+                        and ret_type.type_of_any == TypeOfAny.unannotated
+                    ):
+                        callable.ret_type = NoneType()
                 if not any(refers_to_fullname(dec, 'typing.overload')
                            for dec in item.decorators):
                     if i == len(defn.items) - 1 and not self.is_stub_file:

--- a/test-data/unit/check-based-default-return.test
+++ b/test-data/unit/check-based-default-return.test
@@ -16,7 +16,6 @@ class A:
 reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A)"
 reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: builtins.int)"
 
-
 [case testUntypedDefs]
 # flags: --default-return --allow-untyped-defs --allow-any-expr
 
@@ -112,3 +111,103 @@ class A:
     def f(self, i): ...  # E: Function is missing a type annotation  [no-untyped-def]
     def g(self, i: int, j): ...  # E: Function is missing a return type annotation  [no-untyped-def] \
         # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]
+
+
+[case testOverload]
+# flags: --default-return
+from typing import overload
+
+class A:
+    @overload
+    def f(self): ...
+    @overload
+    def f(self, i: int): ...
+    def f(self, i: int = 0): ...
+
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A), def (self: __main__.A, i: builtins.int))"
+
+@overload
+def f(): ...
+@overload
+def f(i: int): ...
+def f(i: int = 0): ...
+
+reveal_type(f)  # N: Revealed type is "Overload(def (), def (i: builtins.int))"
+
+
+[case testOverloadIncomplete]
+# flags: --default-return --allow-incomplete-defs --allow-untyped-defs --allow-any-expr
+from typing import overload
+
+class A:
+    @overload
+    def f(self): ...
+    @overload
+    def f(self, i): ...
+    @overload
+    def f(self, i, j: int): ...
+    def f(self, i: int = 0, j: int = 0): ...
+
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A) -> Any, def (self: __main__.A, i: Any) -> Any, def (self: __main__.A, i: Any, j: builtins.int))"
+
+@overload
+def f(): ...
+@overload
+def f(i): ...
+@overload
+def f(i, j: int): ...
+def f(i: int = 0, j: int = 0): ...
+
+reveal_type(f)  # N: Revealed type is "Overload(def () -> Any, def (i: Any) -> Any, def (i: Any, j: builtins.int))"
+
+
+[case testOverloadUntyped]
+# flags: --default-return --allow-untyped-defs --allow-any-expr
+from typing import overload
+
+class A:
+    @overload
+    def f(self): ...
+    @overload
+    def f(self, i): ...
+    @overload
+    def f(self, *, j: int): ...
+    def f(self, i: int = 0, j: int = 0): ...
+
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A) -> Any, def (self: __main__.A, i: Any) -> Any, def (self: __main__.A, *, j: builtins.int))"
+
+@overload
+def f(): ...
+@overload
+def f(i): ...
+@overload
+def f(*, j: int): ...
+def f(i: int = 0, j: int = 0): ...
+
+reveal_type(f)  # N: Revealed type is "Overload(def () -> Any, def (i: Any) -> Any, def (*, j: builtins.int))"
+
+[case testOverloadOther]
+# flags: --default-return --allow-untyped-defs --allow-incomplete-defs --allow-any-expr
+from typing import overload
+
+class A:
+    @overload
+    def f(self) -> int: ...
+    @overload
+    def f(self, i): ...
+    @overload
+    def f(self, i, j: int): ...
+    def f(self, i: int = 0, j: int = 0) -> object: ...
+
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A) -> builtins.int, def (self: __main__.A, i: Any) -> Any, def (self: __main__.A, i: Any, j: builtins.int))"
+
+class B:
+    @overload
+    def f(self) -> str: ...
+    @overload
+    def f(self, i): ...
+    @overload
+    def f(self, i, j: int) -> int: ...
+    def f(self, i: int = 0, j: int = 0) -> object: ...
+
+reveal_type(B.f)  # N: Revealed type is "Overload(def (self: __main__.B) -> builtins.str, def (self: __main__.B, i: Any) -> Any, def (self: __main__.B, i: Any, j: builtins.int) -> builtins.int)"


### PR DESCRIPTION
Default return wasn't applying to overloads (or to methods that didn't have "self" as a first argument name 😳, which is """""sus"""""(I think))
