### PR TITLE
Support `basedtyping.Untyped`

### DIFF
--- a/.mypy/baseline.json
+++ b/.mypy/baseline.json
@@ -13,28 +13,28 @@
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any, Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any (special form), Any (special form)]]\")",
         "offset": 24,
         "target": "mypy.bogus_type"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any, Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any (special form), Any (special form)]]\")",
         "offset": 0,
         "target": "mypy.bogus_type"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any, Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any (special form), Any (special form)]]\")",
         "offset": 0,
         "target": "mypy.bogus_type"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any, Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any (special form), Any (special form)]]\")",
         "offset": 0,
         "target": "mypy.bogus_type"
       }
@@ -43,28 +43,28 @@
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression type contains \"Any\" (has type \"set[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"set[Any (from unimported type)]\")",
         "offset": 235,
         "target": "mypy.build._build"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression type contains \"Any\" (has type \"set[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"set[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypy.build._build"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression type contains \"Any\" (has type \"set[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"set[Any (from unimported type)]\")",
         "offset": 1,
         "target": "mypy.build._build"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression type contains \"Any\" (has type \"set[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"set[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypy.build._build"
       },
@@ -281,7 +281,7 @@
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression type contains \"Any\" (has type \"list[str | Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[str | Any (from a limitation)]\")",
         "offset": 0,
         "target": "mypy.build.cache_meta_from_dict"
       },
@@ -358,7 +358,7 @@
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression type contains \"Any\" (has type \"list[str | Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[str | Any (from a limitation)]\")",
         "offset": 0,
         "target": "mypy.build.cache_meta_from_dict"
       },
@@ -393,7 +393,7 @@
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"list[int | Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[int | Any (from a limitation)]\")",
         "offset": 0,
         "target": "mypy.build.cache_meta_from_dict"
       },
@@ -414,7 +414,7 @@
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"list[int | Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[int | Any (from a limitation)]\")",
         "offset": 0,
         "target": "mypy.build.cache_meta_from_dict"
       },
@@ -820,14 +820,14 @@
       {
         "code": "no-any-expr",
         "column": 7,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 13,
         "target": "mypy.build.load_baseline"
       },
       {
         "code": "no-any-expr",
         "column": 9,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 3,
         "target": "mypy.build.load_baseline"
       },
@@ -2255,14 +2255,14 @@
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 288,
         "target": "mypy.build.log_configuration"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.build.log_configuration"
       },
@@ -2360,7 +2360,7 @@
       {
         "code": "no-any-expr",
         "column": 52,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> int\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> int\")",
         "offset": 3,
         "target": "mypy.build.process_graph"
       },
@@ -2416,63 +2416,63 @@
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> int\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> int\")",
         "offset": 107,
         "target": "mypy.build.order_ascc"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> int\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> int\")",
         "offset": 115,
         "target": "mypy.build.sorted_components"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> int\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> int\")",
         "offset": 0,
         "target": "mypy.build.sorted_components"
       },
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.build.sorted_components"
       },
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.build.sorted_components"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.build.sorted_components"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.build.sorted_components"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.build.sorted_components"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.build.sorted_components"
       }
@@ -2482,7 +2482,7 @@
         "code": "attr-defined",
         "column": 0,
         "message": "Module \"mypy.semanal\" does not explicitly export attribute \"set_callable_name\"; implicit reexport disabled",
-        "offset": 74,
+        "offset": 75,
         "target": "mypy.checker"
       },
       {
@@ -2965,7 +2965,7 @@
         "code": "truthy-bool",
         "column": 23,
         "message": "\"signature\" has type \"Type\" which does not implement __bool__ or __len__ so it could always be true in boolean context",
-        "offset": 232,
+        "offset": 263,
         "target": "mypy.checker.TypeChecker.check_assignment"
       },
       {
@@ -3165,10 +3165,17 @@
         "target": "mypy.checker.TypeChecker.check_member_assignment"
       },
       {
+        "code": "ignore-without-code",
+        "column": -1,
+        "message": "\"type: ignore\" comment without error code (consider \"type: ignore[attr-defined]\" instead)",
+        "offset": 565,
+        "target": null
+      },
+      {
         "code": "no-any-expr",
         "column": 33,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 1881,
+        "offset": 1319,
         "target": "mypy.checker.TypeChecker.check_subtype"
       },
       {
@@ -3244,21 +3251,21 @@
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 344,
         "target": "mypy.checker.group_comparison_operands"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.checker.group_comparison_operands"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.checker.group_comparison_operands"
       },
@@ -3519,14 +3526,14 @@
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression type contains \"Any\" (has type \"set[Any]\")",
-        "offset": 919,
+        "message": "Expression type contains \"Any\" (has type \"set[Any (from unimported type)]\")",
+        "offset": 921,
         "target": "mypy.checkexpr.ExpressionChecker.check_boolean_op"
       },
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression type contains \"Any\" (has type \"set[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"set[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypy.checkexpr.ExpressionChecker.check_boolean_op"
       },
@@ -3596,14 +3603,14 @@
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression type contains \"Any\" (has type \"set[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"set[Any (from unimported type)]\")",
         "offset": 269,
         "target": "mypy.checkexpr.ExpressionChecker.check_for_comp"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression type contains \"Any\" (has type \"set[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"set[Any (from unimported type)]\")",
         "offset": 13,
         "target": "mypy.checkexpr.ExpressionChecker.visit_conditional_expr"
       },
@@ -3611,7 +3618,7 @@
         "code": "no-any-expr",
         "column": 27,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 150,
+        "offset": 151,
         "target": "mypy.checkexpr.ExpressionChecker.has_member"
       },
       {
@@ -3625,7 +3632,7 @@
         "code": "no-any-expr",
         "column": 26,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 379,
+        "offset": 393,
         "target": "mypy.checkexpr.arg_approximate_similarity"
       },
       {
@@ -3655,7 +3662,7 @@
         "code": "redundant-expr",
         "column": 15,
         "message": "Left operand of \"and\" is always true",
-        "offset": 218,
+        "offset": 221,
         "target": "mypy.checkmember.analyze_instance_member_access"
       },
       {
@@ -4904,21 +4911,21 @@
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"(str, (Any) -> Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, (Any (special form)) -> Any (special form))\")",
         "offset": 67,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form)) -> Any (special form)\")",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
@@ -4932,231 +4939,231 @@
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 3,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 40,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 40,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 60,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 9,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 45,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 50,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 50,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 4,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> (int, int)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (int, int)\")",
         "offset": 6,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 17,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> list[str]\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> list[str]\")",
         "offset": 2,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> list[str]\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> list[str]\")",
         "offset": 1,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> str\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> str\")",
         "offset": 1,
         "target": "mypy.config_parser"
       },
@@ -5177,7 +5184,7 @@
       {
         "code": "no-any-expr",
         "column": 50,
-        "message": "Expression type contains \"Any\" (has type \"dict[str | Any, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str | Any (from a limitation), Any]\")",
         "offset": 0,
         "target": "mypy.config_parser.parse_config_file"
       },
@@ -7297,7 +7304,7 @@
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (unannotated)\"",
         "offset": 24,
         "target": "mypy.dmypy_server.Server.cmd_recheck"
       },
@@ -7493,28 +7500,28 @@
       {
         "code": "no-any-expr",
         "column": 18,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 5,
         "target": "mypy.dmypy_server.get_meminfo"
       },
       {
         "code": "no-any-expr",
         "column": 18,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.dmypy_server.get_meminfo"
       },
       {
         "code": "no-any-expr",
         "column": 18,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.dmypy_server.get_meminfo"
       },
       {
         "code": "no-any-expr",
         "column": 18,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.dmypy_server.get_meminfo"
       },
@@ -7528,21 +7535,21 @@
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.dmypy_server.get_meminfo"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.dmypy_server.get_meminfo"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.dmypy_server.get_meminfo"
       },
@@ -7556,21 +7563,21 @@
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.dmypy_server.get_meminfo"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.dmypy_server.get_meminfo"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.dmypy_server.get_meminfo"
       },
@@ -7707,28 +7714,28 @@
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> (Any, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (Any (special form), Any (special form))\")",
         "offset": 31,
         "target": "mypy.errors.Errors.sort_messages"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression type contains \"Any\" (has type \"(Any, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), Any (special form))\")",
         "offset": 0,
         "target": "mypy.errors.Errors.sort_messages"
       },
       {
         "code": "no-any-expr",
         "column": 52,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.errors.Errors.sort_messages"
       },
       {
         "code": "no-any-expr",
         "column": 60,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.errors.Errors.sort_messages"
       }
@@ -8964,7 +8971,7 @@
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_NamedExpr"
       },
@@ -8978,7 +8985,7 @@
       {
         "code": "no-any-expr",
         "column": 60,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_NamedExpr"
       },
@@ -9223,7 +9230,7 @@
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 3,
         "target": "mypy.fastparse.ASTConverter.visit_Call"
       },
@@ -9237,7 +9244,7 @@
       {
         "code": "no-any-expr",
         "column": 14,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
@@ -9251,154 +9258,154 @@
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 69,
-        "message": "Expression type contains \"Any\" (has type \"type[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[Any (special form)]\")",
         "offset": 3,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 69,
-        "message": "Expression type contains \"Any\" (has type \"type[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 69,
-        "message": "Expression type contains \"Any\" (has type \"type[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 69,
-        "message": "Expression type contains \"Any\" (has type \"type[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
@@ -9636,14 +9643,14 @@
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
@@ -9657,28 +9664,28 @@
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 57,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
@@ -9692,56 +9699,56 @@
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 57,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 76,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
@@ -9755,21 +9762,21 @@
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchValue"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 4,
         "target": "mypy.fastparse.ASTConverter.visit_MatchSingleton"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 4,
         "target": "mypy.fastparse.ASTConverter.visit_MatchSequence"
       },
@@ -9790,14 +9797,14 @@
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchSequence"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchSequence"
       },
@@ -9832,21 +9839,21 @@
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 4,
         "target": "mypy.fastparse.ASTConverter.visit_MatchStar"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 3,
         "target": "mypy.fastparse.ASTConverter.visit_MatchStar"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 5,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
@@ -9867,21 +9874,21 @@
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
       {
         "code": "no-any-expr",
         "column": 17,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
@@ -9902,28 +9909,28 @@
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 3,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
@@ -9951,7 +9958,7 @@
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
@@ -9965,7 +9972,7 @@
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
@@ -9986,28 +9993,28 @@
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
@@ -10028,14 +10035,14 @@
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
@@ -10049,7 +10056,7 @@
       {
         "code": "no-any-expr",
         "column": 52,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
@@ -10063,14 +10070,14 @@
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 5,
         "target": "mypy.fastparse.ASTConverter.visit_MatchAs"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 3,
         "target": "mypy.fastparse.ASTConverter.visit_MatchAs"
       },
@@ -10084,14 +10091,14 @@
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchAs"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 5,
         "target": "mypy.fastparse.ASTConverter.visit_MatchOr"
       },
@@ -10105,14 +10112,14 @@
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchOr"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchOr"
       },
@@ -10224,140 +10231,140 @@
       {
         "code": "no-any-expr",
         "column": 14,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 4,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 3,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"Any | bool\")",
+        "message": "Expression type contains \"Any\" (has type \"Any (special form) | bool\")",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"Any | bool\")",
+        "message": "Expression type contains \"Any\" (has type \"Any (special form) | bool\")",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 77,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 3,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 73,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 3,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 3,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 83,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
@@ -11932,7 +11939,7 @@
       {
         "code": "no-any-return",
         "column": 8,
-        "message": "Returning Any from function declared to return \"tuple[Any, ...]\"",
+        "message": "Returning Any from function declared to return \"tuple[Any (special form), ...]\"",
         "offset": 1,
         "target": "mypy.literals._Hasher.visit_comparison_expr"
       },
@@ -11981,7 +11988,7 @@
       {
         "code": "no-any-return",
         "column": 12,
-        "message": "Returning Any from function declared to return \"Optional[tuple[Any, ...]]\"",
+        "message": "Returning Any from function declared to return \"Optional[tuple[Any (special form), ...]]\"",
         "offset": 1,
         "target": "mypy.literals._Hasher.seq_expr"
       },
@@ -12030,7 +12037,7 @@
       {
         "code": "no-any-return",
         "column": 12,
-        "message": "Returning Any from function declared to return \"Optional[tuple[Any, ...]]\"",
+        "message": "Returning Any from function declared to return \"Optional[tuple[Any (special form), ...]]\"",
         "offset": 3,
         "target": "mypy.literals._Hasher.visit_dict_expr"
       },
@@ -12592,7 +12599,7 @@
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression type contains \"Any\" (has type \"set[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"set[Any (from unimported type)]\")",
         "offset": 32,
         "target": "mypy.main.process_options"
       },
@@ -13415,21 +13422,21 @@
       {
         "code": "no-any-expr",
         "column": 45,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 18,
         "target": "mypy.memprofile.print_memory_profile"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.memprofile.print_memory_profile"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.memprofile.print_memory_profile"
       },
@@ -13488,7 +13495,7 @@
         "code": "no-any-expr",
         "column": 41,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 285,
+        "offset": 287,
         "target": "mypy.messages.MessageBuilder.has_no_attr"
       },
       {
@@ -13534,10 +13541,17 @@
         "target": "mypy.messages.MessageBuilder.unsupported_operand_types"
       },
       {
+        "code": "ignore-without-code",
+        "column": -1,
+        "message": "\"type: ignore\" comment without error code (consider \"type: ignore[attr-defined]\" instead)",
+        "offset": 29,
+        "target": null
+      },
+      {
         "code": "no-any-expr",
         "column": 36,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 237,
+        "offset": 223,
         "target": "mypy.messages.MessageBuilder.incompatible_argument_note"
       },
       {
@@ -13648,21 +13662,21 @@
       {
         "code": "no-any-expr",
         "column": 65,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 308,
         "target": "mypy.messages.MessageBuilder.reveal_locals"
       },
       {
         "code": "no-any-expr",
         "column": 65,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> str\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> str\")",
         "offset": 0,
         "target": "mypy.messages.MessageBuilder.reveal_locals"
       },
       {
         "code": "no-any-expr",
         "column": 75,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.messages.MessageBuilder.reveal_locals"
       },
@@ -13830,7 +13844,7 @@
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> (float, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (float, Any (special form))\")",
         "offset": 20,
         "target": "mypy.messages.best_matches"
       }
@@ -14258,154 +14272,154 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 119,
         "target": "mypy.nodes.MypyFile.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 6,
         "target": "mypy.nodes.MypyFile.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.nodes.MypyFile.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 5,
         "target": "mypy.nodes.MypyFile.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 223,
         "target": "mypy.nodes.OverloadedFuncDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypy.nodes.OverloadedFuncDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.nodes.OverloadedFuncDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 9,
         "target": "mypy.nodes.OverloadedFuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.nodes.OverloadedFuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 54,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.nodes.OverloadedFuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 160,
         "target": "mypy.nodes.FuncDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 4,
         "target": "mypy.nodes.FuncDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.nodes.FuncDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 8,
         "target": "mypy.nodes.FuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.nodes.FuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 12,
         "target": "mypy.nodes.FuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.nodes.FuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.nodes.FuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.nodes.FuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 62,
         "target": "mypy.nodes.Decorator.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 8,
         "target": "mypy.nodes.Decorator.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 123,
         "target": "mypy.nodes.Var.deserialize"
       },
@@ -14419,98 +14433,98 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 21,
         "target": "mypy.nodes.ClassDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 3,
         "target": "mypy.nodes.ClassDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.nodes.ClassDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 5,
         "target": "mypy.nodes.ClassDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 3,
         "target": "mypy.nodes.ClassDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 59,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.nodes.ClassDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 1233,
         "target": "mypy.nodes.TypeVarExpr.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 3,
         "target": "mypy.nodes.TypeVarExpr.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.nodes.TypeVarExpr.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 7,
         "target": "mypy.nodes.TypeVarExpr.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 3,
         "target": "mypy.nodes.TypeVarExpr.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.nodes.TypeVarExpr.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 12,
         "target": "mypy.nodes.ParamSpecExpr.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 10,
         "target": "mypy.nodes.ParamSpecExpr.deserialize"
       },
@@ -14524,14 +14538,14 @@
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 125,
         "target": "mypy.nodes.TypeInfo.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 52,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.nodes.TypeInfo.deserialize"
       },
@@ -14559,7 +14573,7 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 145,
         "target": "mypy.nodes.TypeAlias.deserialize"
       },
@@ -14573,7 +14587,7 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 14,
         "target": "mypy.nodes.SymbolTableNode.deserialize"
       },
@@ -14587,7 +14601,7 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 24,
         "target": "mypy.nodes.SymbolTable.deserialize"
       },
@@ -14715,14 +14729,14 @@
       {
         "code": "no-any-unimported",
         "column": 8,
-        "message": "Type of variable becomes \"set[Any]\" due to an unfollowed import",
-        "offset": 212,
+        "message": "Type of variable becomes \"set[Any (from unimported type)]\" due to an unfollowed import",
+        "offset": 213,
         "target": "mypy.options.Options.__init__"
       },
       {
         "code": "no-any-unimported",
         "column": 8,
-        "message": "Type of variable becomes \"set[Any]\" due to an unfollowed import",
+        "message": "Type of variable becomes \"set[Any (from unimported type)]\" due to an unfollowed import",
         "offset": 4,
         "target": "mypy.options.Options.__init__"
       },
@@ -14750,7 +14764,7 @@
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypy.options.Options.snapshot"
       },
@@ -14905,70 +14919,70 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 55,
         "target": "mypy.plugins.attrs.Attribute.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 152,
         "target": "mypy.plugins.attrs.attr_class_maker_callback"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypy.plugins.attrs.attr_class_maker_callback"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.plugins.attrs.attr_class_maker_callback"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 70,
         "target": "mypy.plugins.attrs._analyze_class"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 3,
         "target": "mypy.plugins.attrs._analyze_class"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.plugins.attrs._analyze_class"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.plugins.attrs._analyze_class"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.plugins.attrs._analyze_class"
       },
       {
         "code": "no-any-expr",
         "column": 58,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.plugins.attrs._analyze_class"
       },
@@ -15014,63 +15028,63 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 80,
         "target": "mypy.plugins.dataclasses.DataclassAttribute.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 155,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.transform"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.transform"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.transform"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 165,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.collect_attributes"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.collect_attributes"
       },
       {
         "code": "no-any-expr",
         "column": 64,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.collect_attributes"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 15,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.collect_attributes"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.collect_attributes"
       },
@@ -15121,238 +15135,238 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 53,
         "target": "mypy.plugins.default.typed_dict_get_callback"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.plugins.default.typed_dict_get_callback"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 4,
         "target": "mypy.plugins.default.typed_dict_get_callback"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.plugins.default.typed_dict_get_callback"
       },
       {
         "code": "no-any-expr",
         "column": 60,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.plugins.default.typed_dict_get_callback"
       },
       {
         "code": "no-any-expr",
         "column": 60,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.plugins.default.typed_dict_get_callback"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 59,
         "target": "mypy.plugins.default.typed_dict_pop_callback"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.plugins.default.typed_dict_pop_callback"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 5,
         "target": "mypy.plugins.default.typed_dict_pop_callback"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.plugins.default.typed_dict_pop_callback"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.plugins.default.typed_dict_pop_callback"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.plugins.default.typed_dict_pop_callback"
       },
       {
         "code": "no-any-expr",
         "column": 70,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.plugins.default.typed_dict_pop_callback"
       },
       {
         "code": "no-any-expr",
         "column": 44,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 2,
         "target": "mypy.plugins.default.typed_dict_pop_callback"
       },
       {
         "code": "no-any-expr",
         "column": 44,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.plugins.default.typed_dict_pop_callback"
       },
       {
         "code": "no-any-expr",
         "column": 62,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 4,
         "target": "mypy.plugins.default.typed_dict_pop_callback"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 38,
         "target": "mypy.plugins.default.typed_dict_setdefault_callback"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.plugins.default.typed_dict_setdefault_callback"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 7,
         "target": "mypy.plugins.default.typed_dict_setdefault_callback"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.plugins.default.typed_dict_setdefault_callback"
       },
       {
         "code": "no-any-expr",
         "column": 44,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.plugins.default.typed_dict_setdefault_callback"
       },
       {
         "code": "no-any-expr",
         "column": 44,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.plugins.default.typed_dict_setdefault_callback"
       },
       {
         "code": "no-any-expr",
         "column": 62,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 3,
         "target": "mypy.plugins.default.typed_dict_setdefault_callback"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 23,
         "target": "mypy.plugins.default.typed_dict_delitem_callback"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.plugins.default.typed_dict_delitem_callback"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 4,
         "target": "mypy.plugins.default.typed_dict_delitem_callback"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.plugins.default.typed_dict_delitem_callback"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.plugins.default.typed_dict_delitem_callback"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.plugins.default.typed_dict_delitem_callback"
       },
       {
         "code": "no-any-expr",
         "column": 70,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.plugins.default.typed_dict_delitem_callback"
       },
       {
         "code": "no-any-expr",
         "column": 17,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.plugins.default.typed_dict_delitem_callback"
       },
       {
         "code": "no-any-expr",
         "column": 17,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.plugins.default.typed_dict_delitem_callback"
       },
       {
         "code": "no-any-expr",
         "column": 62,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.plugins.default.typed_dict_delitem_callback"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 48,
         "target": "mypy.plugins.default.int_neg_callback"
       },
@@ -15398,7 +15412,7 @@
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> (bool, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (bool, Any (special form))\")",
         "offset": 41,
         "target": "mypy.plugins.functools.functools_total_ordering_maker_callback"
       },
@@ -15516,28 +15530,28 @@
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 239,
         "target": "mypy.report.AnyExpressionsReporter._report_any_exprs"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.report.AnyExpressionsReporter._report_any_exprs"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 15,
         "target": "mypy.report.AnyExpressionsReporter._report_types_of_anys"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.report.AnyExpressionsReporter._report_types_of_anys"
       },
@@ -15558,28 +15572,28 @@
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 32,
         "target": "mypy.report.MemoryXmlReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.__init__"
       },
@@ -15593,196 +15607,196 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 30,
         "target": "mypy.report.MemoryXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 14,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.MemoryXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 14,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 6,
         "target": "mypy.report.MemoryXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 7,
         "target": "mypy.report.MemoryXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 2,
         "target": "mypy.report.MemoryXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.MemoryXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 21,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 2,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 14,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 14,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 3,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 6,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 2,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
@@ -15803,63 +15817,63 @@
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.CoberturaPackage.as_xml"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaPackage.as_xml"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 3,
         "target": "mypy.report.CoberturaPackage.as_xml"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaPackage.as_xml"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.CoberturaPackage.as_xml"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaPackage.as_xml"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.CoberturaPackage.as_xml"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaPackage.as_xml"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaPackage.as_xml"
       },
@@ -15880,7 +15894,7 @@
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.CoberturaPackage.as_xml"
       },
@@ -15901,14 +15915,14 @@
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.CoberturaPackage.as_xml"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.CoberturaPackage.as_xml"
       },
@@ -15922,14 +15936,14 @@
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 2,
         "target": "mypy.report.CoberturaPackage.add_packages"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaPackage.add_packages"
       },
@@ -15964,7 +15978,7 @@
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.CoberturaPackage.add_packages"
       },
@@ -15978,147 +15992,147 @@
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 9,
         "target": "mypy.report.CoberturaXmlReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 3,
         "target": "mypy.report.CoberturaXmlReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 18,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 4,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 18,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 6,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
@@ -16132,112 +16146,112 @@
       {
         "code": "no-any-expr",
         "column": 50,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 3,
         "target": "mypy.report.CoberturaXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 2,
         "target": "mypy.report.CoberturaXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 18,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.CoberturaXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 18,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.CoberturaXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 42,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.CoberturaXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.CoberturaXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.CoberturaXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 2,
         "target": "mypy.report.CoberturaXmlReporter.on_finish"
       },
@@ -16286,49 +16300,49 @@
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 19,
         "target": "mypy.report.XsltHtmlReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.XsltHtmlReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.XsltHtmlReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.XsltHtmlReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.report.XsltHtmlReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.XsltHtmlReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.XsltHtmlReporter.__init__"
       },
@@ -16349,14 +16363,14 @@
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 7,
         "target": "mypy.report.XsltHtmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.XsltHtmlReporter.on_file"
       },
@@ -16377,14 +16391,14 @@
       {
         "code": "no-any-expr",
         "column": 62,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.XsltHtmlReporter.on_file"
       },
       {
         "code": "no-any-expr",
         "column": 62,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.XsltHtmlReporter.on_file"
       },
@@ -16405,14 +16419,14 @@
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 3,
         "target": "mypy.report.XsltHtmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.XsltHtmlReporter.on_finish"
       },
@@ -16433,42 +16447,42 @@
       {
         "code": "no-any-expr",
         "column": 62,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.XsltHtmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 62,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.XsltHtmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 19,
         "target": "mypy.report.XsltTxtReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.XsltTxtReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.XsltTxtReporter.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.XsltTxtReporter.__init__"
       },
@@ -16489,14 +16503,14 @@
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 2,
         "target": "mypy.report.XsltTxtReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.report.XsltTxtReporter.on_finish"
       },
@@ -16517,14 +16531,14 @@
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 63,
         "target": "mypy.report.LinePrecisionReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.report.LinePrecisionReporter.on_finish"
       }
@@ -16964,14 +16978,14 @@
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 77,
         "target": "mypy.semanal.apply_semantic_analyzer_patches"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.semanal.apply_semantic_analyzer_patches"
       },
@@ -17087,35 +17101,35 @@
       {
         "code": "no-any-expr",
         "column": 57,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> (Any, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (Any (special form), Any (special form))\")",
         "offset": 230,
         "target": "mypy.semanal_main.process_functions"
       },
       {
         "code": "no-any-expr",
         "column": 67,
-        "message": "Expression type contains \"Any\" (has type \"(Any, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), Any (special form))\")",
         "offset": 0,
         "target": "mypy.semanal_main.process_functions"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.semanal_main.process_functions"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.semanal_main.process_functions"
       },
       {
         "code": "no-any-expr",
         "column": 79,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.semanal_main.process_functions"
       }
@@ -17124,7 +17138,7 @@
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 410,
         "target": "mypy.semanal_namedtuple.NamedTupleAnalyzer.build_namedtuple_typeinfo"
       }
@@ -17204,14 +17218,14 @@
       {
         "code": "no-any-expr",
         "column": 57,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 71,
         "target": "mypy.server.deps.dump_all_dependencies"
       },
       {
         "code": "no-any-expr",
         "column": 67,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.server.deps.dump_all_dependencies"
       }
@@ -17250,21 +17264,21 @@
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression type contains \"Any\" (has type \"set[type[ReferenceType[Any]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"set[type[ReferenceType[Any (special form)]]]\")",
         "offset": 32,
         "target": "mypy.server.objgraph"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"type[ReferenceType[Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[ReferenceType[Any (special form)]]\")",
         "offset": 1,
         "target": "mypy.server.objgraph"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"type[ReferenceType[Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[ReferenceType[Any (special form)]]\")",
         "offset": 0,
         "target": "mypy.server.objgraph"
       },
@@ -17355,28 +17369,28 @@
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(int, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(int, Any (special form))\")",
         "offset": 7,
         "target": "mypy.server.objgraph.get_edge_candidates"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(int, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(int, Any (special form))\")",
         "offset": 0,
         "target": "mypy.server.objgraph.get_edge_candidates"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.server.objgraph.get_edge_candidates"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression type contains \"Any\" (has type \"enumerate[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"enumerate[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.server.objgraph.get_edge_candidates"
       },
@@ -17425,7 +17439,7 @@
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"set[type[ReferenceType[Any]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"set[type[ReferenceType[Any (special form)]]]\")",
         "offset": 2,
         "target": "mypy.server.objgraph.get_edges"
       }
@@ -17434,35 +17448,35 @@
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 233,
         "target": "mypy.server.update.FineGrainedBuildManager.update"
       },
       {
         "code": "no-any-expr",
         "column": 60,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 176,
         "target": "mypy.server.update.FineGrainedBuildManager.update_module"
       },
       {
         "code": "no-any-expr",
         "column": 50,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 416,
         "target": "mypy.server.update.propagate_changes_using_dependencies"
       },
       {
         "code": "no-any-expr",
         "column": 60,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.server.update.propagate_changes_using_dependencies"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 9,
         "target": "mypy.server.update.propagate_changes_using_dependencies"
       }
@@ -18287,42 +18301,42 @@
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 19,
         "target": "mypy.strconv.StrConv.str_repr"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.strconv.StrConv.str_repr"
       },
       {
         "code": "no-any-expr",
         "column": 58,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.strconv.StrConv.str_repr"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> str\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> str\")",
         "offset": 2,
         "target": "mypy.strconv.StrConv.str_repr"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.strconv.StrConv.str_repr"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.strconv.StrConv.str_repr"
       },
@@ -18702,14 +18716,14 @@
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> int\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> int\")",
         "offset": 157,
         "target": "mypy.stubdoc.DocStringParser.get_signatures"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> int\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> int\")",
         "offset": 0,
         "target": "mypy.stubdoc.DocStringParser.get_signatures"
       },
@@ -19090,7 +19104,7 @@
         "code": "redundant-expr",
         "column": 17,
         "message": "Left operand of \"and\" is always true",
-        "offset": 606,
+        "offset": 612,
         "target": "mypy.stubgen.StubGenerator.visit_overloaded_func_def"
       },
       {
@@ -19118,14 +19132,14 @@
         "code": "ignore-without-code",
         "column": -1,
         "message": "\"type: ignore\" comment without error code (consider \"type: ignore[misc]\" instead)",
-        "offset": 235,
+        "offset": 237,
         "target": null
       },
       {
         "code": "no-any-expr",
         "column": 48,
         "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
-        "offset": 746,
+        "offset": 756,
         "target": "mypy.stubgen.parse_options"
       },
       {
@@ -19351,6 +19365,13 @@
         "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.stubgen.parse_options"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 26,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.stubgen.parse_options"
       }
     ],
     "mypy/stubgenc.py": [
@@ -19406,7 +19427,7 @@
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 0,
         "target": "mypy.stubgenc.generate_stub_for_c_module"
       },
@@ -19427,7 +19448,7 @@
       {
         "code": "no-any-expr",
         "column": 58,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.stubgenc.generate_stub_for_c_module"
       },
@@ -19777,7 +19798,7 @@
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> (int, str)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (int, str)\")",
         "offset": 0,
         "target": "mypy.stubgenc.generate_c_type_stub"
       },
@@ -19798,7 +19819,7 @@
       {
         "code": "no-any-expr",
         "column": 72,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.stubgenc.generate_c_type_stub"
       },
@@ -20703,56 +20724,56 @@
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any (special form)]]\")",
         "offset": 18,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any (special form)]]\")",
         "offset": 0,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any (special form)]]\")",
         "offset": 2,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any (special form)]]\")",
         "offset": 0,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any (special form)]]\")",
         "offset": 2,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any (special form)]]\")",
         "offset": 0,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any (special form)]]\")",
         "offset": 2,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any (special form)]]\")",
         "offset": 0,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
@@ -21004,7 +21025,7 @@
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> (bool, str)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (bool, str)\")",
         "offset": 3,
         "target": "mypy.stubtest.Signature.__str__"
       },
@@ -22620,84 +22641,84 @@
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 3,
         "target": "mypy.suggestions.ArgUseFinder.visit_call_expr"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> AnyType\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> AnyType\")",
         "offset": 2,
         "target": "mypy.suggestions.ArgUseFinder.visit_call_expr"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(int, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(int, Any (from unimported type))\")",
         "offset": 2,
         "target": "mypy.suggestions.ArgUseFinder.visit_call_expr"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(int, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(int, Any (from unimported type))\")",
         "offset": 0,
         "target": "mypy.suggestions.ArgUseFinder.visit_call_expr"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.suggestions.ArgUseFinder.visit_call_expr"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression type contains \"Any\" (has type \"enumerate[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"enumerate[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypy.suggestions.ArgUseFinder.visit_call_expr"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.suggestions.ArgUseFinder.visit_call_expr"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.suggestions.ArgUseFinder.visit_call_expr"
       },
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.suggestions.ArgUseFinder.visit_call_expr"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypy.suggestions.ArgUseFinder.visit_call_expr"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.suggestions.ArgUseFinder.visit_call_expr"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.suggestions.ArgUseFinder.visit_call_expr"
       },
@@ -22760,7 +22781,7 @@
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> (int, int)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (int, int)\")",
         "offset": 37,
         "target": "mypy.suggestions.SuggestionEngine.find_best"
       },
@@ -22872,23 +22893,30 @@
         "target": "mypy.test.data.parse_test_case"
       },
       {
-        "code": "no-any-expr",
-        "column": 16,
-        "message": "Expression has type \"Any\"",
+        "code": "no-untyped-usage",
+        "column": 8,
+        "message": "Usage of untyped name \"suite\" in typed context",
         "offset": 159,
         "target": "mypy.test.data.DataDrivenTestCase.runtest"
       },
       {
         "code": "no-any-expr",
+        "column": 16,
+        "message": "Expression has type \"Untyped\"",
+        "offset": 0,
+        "target": "mypy.test.data.DataDrivenTestCase.runtest"
+      },
+      {
+        "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 1,
         "target": "mypy.test.data.DataDrivenTestCase.runtest"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 2,
         "target": "mypy.test.data.DataDrivenTestCase.runtest"
       },
@@ -23224,7 +23252,7 @@
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 6,
         "target": "mypy.test.data.pytest_pycollect_makeitem"
       },
@@ -23406,7 +23434,7 @@
       {
         "code": "no-any-expr",
         "column": 14,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 1,
         "target": "mypy.test.data.split_test_cases"
       },
@@ -23574,42 +23602,42 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 0,
         "target": "mypy.test.data.DataFileCollector.from_parent"
       },
       {
         "code": "no-any-expr",
         "column": 18,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 5,
         "target": "mypy.test.data.DataFileCollector.collect"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 1,
         "target": "mypy.test.data.DataFileCollector.collect"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 0,
         "target": "mypy.test.data.DataFileCollector.collect"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 0,
         "target": "mypy.test.data.DataFileCollector.collect"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 0,
         "target": "mypy.test.data.DataFileCollector.collect"
       }
@@ -23645,9 +23673,16 @@
       },
       {
         "code": "no-any-expr",
+        "column": 12,
+        "message": "Expression type contains \"Any\" (has type \"set[Any (from unimported type)]\")",
+        "offset": 22,
+        "target": "mypy.test.helpers.parse_options"
+      },
+      {
+        "code": "no-any-expr",
         "column": 7,
-        "message": "Expression has type \"Any\"",
-        "offset": 26,
+        "message": "Expression has type \"Untyped\"",
+        "offset": 7,
         "target": "mypy.test.helpers.parse_options"
       },
       {
@@ -23704,7 +23739,7 @@
       {
         "code": "no-any-unimported",
         "column": 15,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testapi"
       }
@@ -23727,7 +23762,7 @@
       {
         "code": "no-any-unimported",
         "column": 15,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testargs"
       }
@@ -23737,20 +23772,20 @@
         "code": "no-any-expr",
         "column": 33,
         "message": "Expression type contains \"Any\" (has type \"str | Any\")",
-        "offset": 135,
+        "offset": 136,
         "target": "mypy.test.testcheck.TypeCheckSuite.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression type contains \"Any\" (has type \"Literal[False] | Any\")",
+        "message": "Expression type contains \"Any\" (has type \"Literal[False] | Untyped\")",
         "offset": 105,
         "target": "mypy.test.testcheck.TypeCheckSuite.run_case_once"
       },
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 0,
         "target": "mypy.test.testcheck.TypeCheckSuite.run_case_once"
       },
@@ -24283,7 +24318,7 @@
       {
         "code": "no-any-unimported",
         "column": 17,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testgraph"
       }
@@ -24306,7 +24341,7 @@
       {
         "code": "no-any-unimported",
         "column": 31,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testinfer"
       },
@@ -24320,7 +24355,7 @@
       {
         "code": "no-any-unimported",
         "column": 31,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testinfer"
       },
@@ -24334,49 +24369,49 @@
       {
         "code": "no-any-unimported",
         "column": 37,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testinfer"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any, ...]]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any (special form), ...]]\")",
         "offset": 22,
         "target": "mypy.test.testinfer.OperandComparisonGroupingSuite.test_basic_cases"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[dict[int, tuple[Any, ...]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[dict[int, tuple[Any (special form), ...]]]\")",
         "offset": 0,
         "target": "mypy.test.testinfer.OperandComparisonGroupingSuite.test_basic_cases"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any, ...]]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any (special form), ...]]\")",
         "offset": 2,
         "target": "mypy.test.testinfer.OperandComparisonGroupingSuite.test_basic_cases"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any, ...]]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any (special form), ...]]\")",
         "offset": 4,
         "target": "mypy.test.testinfer.OperandComparisonGroupingSuite.test_basic_cases"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any, ...]]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any (special form), ...]]\")",
         "offset": 4,
         "target": "mypy.test.testinfer.OperandComparisonGroupingSuite.test_basic_cases"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any, ...]]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any (special form), ...]]\")",
         "offset": 4,
         "target": "mypy.test.testinfer.OperandComparisonGroupingSuite.test_basic_cases"
       }
@@ -24392,35 +24427,35 @@
       {
         "code": "no-any-expr",
         "column": 52,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 17,
         "target": "mypy.test.testmerge.ASTMergeSuite.dump_typeinfos_recursive"
       },
       {
         "code": "no-any-expr",
         "column": 62,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.test.testmerge.ASTMergeSuite.dump_typeinfos_recursive"
       },
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> (Any, str, str)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (Any (special form), str, str)\")",
         "offset": 30,
         "target": "mypy.test.testmerge.ASTMergeSuite.dump_types"
       },
       {
         "code": "no-any-expr",
         "column": 59,
-        "message": "Expression type contains \"Any\" (has type \"(Any, str, str)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), str, str)\")",
         "offset": 0,
         "target": "mypy.test.testmerge.ASTMergeSuite.dump_types"
       },
       {
         "code": "no-any-expr",
         "column": 60,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.test.testmerge.ASTMergeSuite.dump_types"
       }
@@ -24443,7 +24478,7 @@
       {
         "code": "no-any-unimported",
         "column": 24,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testmodulefinder"
       },
@@ -24457,7 +24492,7 @@
       {
         "code": "no-any-unimported",
         "column": 36,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testmodulefinder"
       }
@@ -24526,7 +24561,7 @@
       {
         "code": "no-any-unimported",
         "column": 27,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testreports"
       },
@@ -24547,28 +24582,28 @@
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.test.testreports.CoberturaReportSuite.test_as_xml"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.test.testreports.CoberturaReportSuite.test_as_xml"
       },
       {
         "code": "no-any-expr",
         "column": 21,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 17,
         "target": "mypy.test.testreports.CoberturaReportSuite.test_as_xml"
       },
       {
         "code": "no-any-expr",
         "column": 21,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypy.test.testreports.CoberturaReportSuite.test_as_xml"
       },
@@ -24607,7 +24642,7 @@
       {
         "code": "no-any-unimported",
         "column": 17,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testsolve"
       }
@@ -24673,7 +24708,7 @@
         "code": "no-any-expr",
         "column": 24,
         "message": "Expression type contains \"Any\" (has type \"str | Any\")",
-        "offset": 132,
+        "offset": 136,
         "target": "mypy.test.teststubgen.StubgenPythonSuite.parse_flags"
       },
       {
@@ -25215,7 +25250,7 @@
       {
         "code": "no-any-unimported",
         "column": 21,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testsubtypes"
       }
@@ -25238,21 +25273,21 @@
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> (Any, str, str)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (Any (special form), str, str)\")",
         "offset": 10,
         "target": "mypy.test.testtypegen.TypeExportSuite.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 44,
-        "message": "Expression type contains \"Any\" (has type \"(Any, str, str)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), str, str)\")",
         "offset": 0,
         "target": "mypy.test.testtypegen.TypeExportSuite.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 45,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.test.testtypegen.TypeExportSuite.run_case"
       }
@@ -25275,7 +25310,7 @@
       {
         "code": "no-any-unimported",
         "column": 17,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testtypes"
       },
@@ -25289,7 +25324,7 @@
       {
         "code": "no-any-unimported",
         "column": 19,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testtypes"
       },
@@ -25303,7 +25338,7 @@
       {
         "code": "no-any-unimported",
         "column": 16,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testtypes"
       },
@@ -25324,7 +25359,7 @@
       {
         "code": "no-any-unimported",
         "column": 16,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testtypes"
       },
@@ -25338,7 +25373,7 @@
       {
         "code": "no-any-unimported",
         "column": 20,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testtypes"
       },
@@ -25352,7 +25387,7 @@
       {
         "code": "no-any-unimported",
         "column": 32,
-        "message": "Base type Suite becomes \"Any\" due to an unfollowed import",
+        "message": "Base type Suite becomes \"Any (from unimported type)\" due to an unfollowed import",
         "offset": 0,
         "target": "mypy.test.testtypes"
       }
@@ -25441,7 +25476,7 @@
         "code": "no-any-expr",
         "column": 31,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 820,
+        "offset": 822,
         "target": "mypy.typeanal.TypeAnalyser.analyze_callable_type"
       },
       {
@@ -25661,77 +25696,77 @@
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 182,
         "target": "mypy.types.TypeAliasType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.types.TypeAliasType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 6,
         "target": "mypy.types.TypeAliasType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 174,
         "target": "mypy.types.TypeVarType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 4,
         "target": "mypy.types.TypeVarType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.types.TypeVarType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 8,
         "target": "mypy.types.TypeVarType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 5,
         "target": "mypy.types.TypeVarType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.TypeVarType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 77,
         "target": "mypy.types.ParamSpecType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 11,
         "target": "mypy.types.ParamSpecType.deserialize"
       },
@@ -25745,42 +25780,42 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 27,
         "target": "mypy.types.UnboundType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 2,
         "target": "mypy.types.UnboundType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.types.UnboundType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 7,
         "target": "mypy.types.UnboundType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypy.types.UnboundType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 45,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.UnboundType.deserialize"
       },
@@ -25801,14 +25836,14 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 23,
         "target": "mypy.types.UnpackType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 7,
         "target": "mypy.types.UnpackType.deserialize"
       },
@@ -25829,70 +25864,70 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 13,
         "target": "mypy.types.AnyType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 6,
         "target": "mypy.types.AnyType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
-        "offset": 50,
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "offset": 97,
         "target": "mypy.types.UninhabitedType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 5,
         "target": "mypy.types.UninhabitedType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 28,
         "target": "mypy.types.NoneType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 4,
         "target": "mypy.types.NoneType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 40,
         "target": "mypy.types.DeletedType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 5,
         "target": "mypy.types.DeletedType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 119,
         "target": "mypy.types.Instance.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 11,
         "target": "mypy.types.Instance.deserialize"
       },
@@ -26151,77 +26186,77 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 14,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 6,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 3,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, dict[Any, Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, dict[Any (special form), Any (special form)])\")",
         "offset": 2,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"dict[Any, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[Any (special form), Any (special form)]\")",
         "offset": 0,
         "target": "mypy.types.CallableType.serialize"
       },
@@ -26242,105 +26277,105 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 6,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 3,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 21,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 5,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 62,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 3,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 65,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 63,
         "target": "mypy.types.Overloaded.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypy.types.Overloaded.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.types.Overloaded.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 5,
         "target": "mypy.types.Overloaded.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.types.Overloaded.deserialize"
       },
@@ -26354,189 +26389,189 @@
       {
         "code": "no-any-expr",
         "column": 52,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.Overloaded.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 65,
         "target": "mypy.types.TupleType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypy.types.TupleType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.types.TupleType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 7,
         "target": "mypy.types.TupleType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.types.TupleType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.TupleType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 72,
         "target": "mypy.types.TypedDictType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypy.types.TypedDictType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.types.TypedDictType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.types.TypedDictType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypy.types.TypedDictType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.types.TypedDictType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 6,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression type contains \"Any\" (has type \"list[(Any, Type)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(Any (special form), Type)]\")",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 42,
-        "message": "Expression type contains \"Any\" (has type \"(Any, Type)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), Type)\")",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 42,
-        "message": "Expression type contains \"Any\" (has type \"(Any, Type)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), Type)\")",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 63,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 63,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
@@ -26550,14 +26585,14 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 89,
         "target": "mypy.types.LiteralType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 8,
         "target": "mypy.types.LiteralType.deserialize"
       },
@@ -26571,42 +26606,42 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 72,
         "target": "mypy.types.UnionType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypy.types.UnionType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypy.types.UnionType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 5,
         "target": "mypy.types.UnionType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypy.types.UnionType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypy.types.UnionType.deserialize"
       },
@@ -26620,14 +26655,14 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 71,
         "target": "mypy.types.TypeType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 4,
         "target": "mypy.types.TypeType.deserialize"
       },
@@ -26992,77 +27027,77 @@
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 35,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 58,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 58,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> int\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> int\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 58,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form)) -> Any (special form)\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 58,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 58,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> int\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> int\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 58,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form)) -> Any (special form)\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
@@ -27076,28 +27111,28 @@
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
@@ -27111,28 +27146,28 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"type[dict[Any, Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[dict[Any (special form), Any (special form)]]\")",
         "offset": 84,
         "target": "mypyc.analysis.dataflow"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"type[dict[Any, Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[dict[Any (special form), Any (special form)]]\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"type[dict[Any, Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[dict[Any (special form), Any (special form)]]\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"type[dict[Any, Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[dict[Any (special form), Any (special form)]]\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow"
       }
@@ -27162,644 +27197,644 @@
       {
         "code": "no-any-unimported",
         "column": 0,
-        "message": "Return type becomes \"(list[Any], list[Any], Options)\" due to an unfollowed import",
+        "message": "Return type becomes \"(list[Any (from unimported type)], list[Any (from unimported type)], Options)\" due to an unfollowed import",
         "offset": 24,
         "target": "mypyc.build.get_mypy_config"
       },
       {
         "code": "no-any-unimported",
         "column": 0,
-        "message": "Argument 1 to \"generate_c\" becomes \"list[Any]\" due to an unfollowed import",
+        "message": "Argument 1 to \"generate_c\" becomes \"list[Any (from unimported type)]\" due to an unfollowed import",
         "offset": 83,
         "target": "mypyc.build.generate_c"
       },
       {
         "code": "no-any-unimported",
         "column": 0,
-        "message": "Argument 3 to \"generate_c\" becomes \"list[(list[Any], Optional[str])]\" due to an unfollowed import",
+        "message": "Argument 3 to \"generate_c\" becomes \"list[(list[Any (from unimported type)], Optional[str])]\" due to an unfollowed import",
         "offset": 0,
         "target": "mypyc.build.generate_c"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 21,
         "target": "mypyc.build.generate_c"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.build.generate_c"
       },
       {
         "code": "no-any-expr",
         "column": 77,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 14,
         "target": "mypyc.build.generate_c"
       },
       {
         "code": "no-any-expr",
         "column": 77,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.build.generate_c"
       },
       {
         "code": "no-any-unimported",
         "column": 0,
-        "message": "Argument 1 to \"build_using_shared_lib\" becomes \"list[Any]\" due to an unfollowed import",
+        "message": "Argument 1 to \"build_using_shared_lib\" becomes \"list[Any (from unimported type)]\" due to an unfollowed import",
         "offset": 25,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 26,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 18,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 4,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression type contains \"Any\" (has type \"(Any, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (from unimported type), Any (from unimported type))\")",
         "offset": 1,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 2,
         "target": "mypyc.build.build_using_shared_lib"
       },
       {
         "code": "no-any-unimported",
         "column": 0,
-        "message": "Argument 1 to \"build_single_module\" becomes \"list[Any]\" due to an unfollowed import",
+        "message": "Argument 1 to \"build_single_module\" becomes \"list[Any (from unimported type)]\" due to an unfollowed import",
         "offset": 8,
         "target": "mypyc.build.build_single_module"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 9,
         "target": "mypyc.build.build_single_module"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_single_module"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.build_single_module"
       },
       {
         "code": "no-any-unimported",
         "column": 0,
-        "message": "Return type becomes \"list[(list[Any], Optional[str])]\" due to an unfollowed import",
+        "message": "Return type becomes \"list[(list[Any (from unimported type)], Optional[str])]\" due to an unfollowed import",
         "offset": 35,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-unimported",
         "column": 0,
-        "message": "Argument 1 to \"construct_groups\" becomes \"list[Any]\" due to an unfollowed import",
+        "message": "Argument 1 to \"construct_groups\" becomes \"list[Any (from unimported type)]\" due to an unfollowed import",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-unimported",
         "column": 8,
-        "message": "Type of variable becomes \"list[(list[Any], Optional[str])]\" due to an unfollowed import",
+        "message": "Type of variable becomes \"list[(list[Any (from unimported type)], Optional[str])]\" due to an unfollowed import",
         "offset": 16,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], None)\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], None)\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 5,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 44,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 1,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"set[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"set[Any (from unimported type)]\")",
         "offset": 1,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 52,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 52,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 63,
-        "message": "Expression type contains \"Any\" (has type \"set[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"set[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 1,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 1,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], None)\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], None)\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 58,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 18,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], None)\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], None)\")",
         "offset": 2,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"(int, (list[Any], Optional[str]))\")",
+        "message": "Expression type contains \"Any\" (has type \"(int, (list[Any (from unimported type)], Optional[str]))\")",
         "offset": 3,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"(int, (list[Any], Optional[str]))\")",
+        "message": "Expression type contains \"Any\" (has type \"(int, (list[Any (from unimported type)], Optional[str]))\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression type contains \"Any\" (has type \"enumerate[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"enumerate[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 2,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 59,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 1,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 21,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 21,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.construct_groups"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 2,
         "target": "mypyc.build.construct_groups"
       },
@@ -27813,7 +27848,7 @@
       {
         "code": "no-any-unimported",
         "column": 0,
-        "message": "Return type becomes \"(list[(list[Any], Optional[str])], list[(list[str], list[str])])\" due to an unfollowed import",
+        "message": "Return type becomes \"(list[(list[Any (from unimported type)], Optional[str])], list[(list[str], list[str])])\" due to an unfollowed import",
         "offset": 5,
         "target": "mypyc.build.mypyc_build"
       },
@@ -27827,112 +27862,112 @@
       {
         "code": "no-any-expr",
         "column": 42,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], list[Any], Options)\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], list[Any (from unimported type)], Options)\")",
         "offset": 11,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 42,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], list[Any], Options)\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], list[Any (from unimported type)], Options)\")",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 42,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 42,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 7,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 14,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 14,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 40,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 40,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 4,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
@@ -27946,42 +27981,42 @@
       {
         "code": "no-any-expr",
         "column": 44,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 1,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 44,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 66,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 66,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 21,
         "target": "mypyc.build.mypyc_build"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression type contains \"Any\" (has type \"(list[(list[Any], Optional[str])], list[(list[str], list[str])])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[(list[Any (from unimported type)], Optional[str])], list[(list[str], list[str])])\")",
         "offset": 0,
         "target": "mypyc.build.mypyc_build"
       },
@@ -27995,21 +28030,21 @@
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression type contains \"Any\" (has type \"(list[(list[Any], Optional[str])], list[(list[str], list[str])])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[(list[Any (from unimported type)], Optional[str])], list[(list[str], list[str])])\")",
         "offset": 65,
         "target": "mypyc.build.mypycify"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression type contains \"Any\" (has type \"(list[(list[Any], Optional[str])], list[(list[str], list[str])])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[(list[Any (from unimported type)], Optional[str])], list[(list[str], list[str])])\")",
         "offset": 0,
         "target": "mypyc.build.mypycify"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.build.mypycify"
       },
@@ -28149,77 +28184,77 @@
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"((list[Any], Optional[str]), (list[str], list[str]))\")",
+        "message": "Expression type contains \"Any\" (has type \"((list[Any (from unimported type)], Optional[str]), (list[str], list[str]))\")",
         "offset": 40,
         "target": "mypyc.build.mypycify"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"((list[Any], Optional[str]), (list[str], list[str]))\")",
+        "message": "Expression type contains \"Any\" (has type \"((list[Any (from unimported type)], Optional[str]), (list[str], list[str]))\")",
         "offset": 0,
         "target": "mypyc.build.mypycify"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 0,
         "target": "mypyc.build.mypycify"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 0,
         "target": "mypyc.build.mypycify"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.mypycify"
       },
       {
         "code": "no-any-expr",
         "column": 57,
-        "message": "Expression type contains \"Any\" (has type \"zip[((list[Any], Optional[str]), (list[str], list[str]))]\")",
+        "message": "Expression type contains \"Any\" (has type \"zip[((list[Any (from unimported type)], Optional[str]), (list[str], list[str]))]\")",
         "offset": 0,
         "target": "mypyc.build.mypycify"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.build.mypycify"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.build.mypycify"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 3,
         "target": "mypyc.build.mypycify"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.build.mypycify"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 3,
         "target": "mypyc.build.mypycify"
       }
@@ -28228,14 +28263,14 @@
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> str\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> str\")",
         "offset": 146,
         "target": "mypyc.codegen.emitclass.generate_slots"
       },
       {
         "code": "no-any-expr",
         "column": 80,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitclass.generate_slots"
       }
@@ -28267,175 +28302,175 @@
       {
         "code": "no-any-expr",
         "column": 9,
-        "message": "Expression type contains \"Any\" (has type \"type[list[Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[list[Any (special form)]]\")",
         "offset": 60,
         "target": "mypyc.codegen.emitmodule"
       },
       {
         "code": "no-any-expr",
         "column": 9,
-        "message": "Expression type contains \"Any\" (has type \"type[list[Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[list[Any (special form)]]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule"
       },
       {
         "code": "no-any-expr",
         "column": 9,
-        "message": "Expression type contains \"Any\" (has type \"type[list[Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[list[Any (special form)]]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule"
       },
       {
         "code": "no-any-expr",
         "column": 9,
-        "message": "Expression type contains \"Any\" (has type \"type[list[Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[list[Any (special form)]]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule"
       },
       {
         "code": "no-any-unimported",
         "column": 4,
-        "message": "Argument 4 to \"__init__\" becomes \"list[(list[Any], Optional[str])]\" due to an unfollowed import",
+        "message": "Argument 4 to \"__init__\" becomes \"list[(list[Any (from unimported type)], Optional[str])]\" due to an unfollowed import",
         "offset": 25,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 4,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 1,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression type contains \"Any\" (has type \"Generator[Any, None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[Any (from unimported type), None, None]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression type contains \"Any\" (has type \"Generator[Any, None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[Any (from unimported type), None, None]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 57,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 57,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression type contains \"Any\" (has type \"(Optional[str], list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(Optional[str], list[Any (from unimported type)])\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
       {
         "code": "no-any-expr",
         "column": 44,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.MypycPlugin.__init__"
       },
@@ -28519,329 +28554,329 @@
       {
         "code": "no-any-unimported",
         "column": 0,
-        "message": "Argument 1 to \"parse_and_typecheck\" becomes \"list[Any]\" due to an unfollowed import",
+        "message": "Argument 1 to \"parse_and_typecheck\" becomes \"list[Any (from unimported type)]\" due to an unfollowed import",
         "offset": 10,
         "target": "mypyc.codegen.emitmodule.parse_and_typecheck"
       },
       {
         "code": "no-any-unimported",
         "column": 0,
-        "message": "Argument 4 to \"parse_and_typecheck\" becomes \"list[(list[Any], Optional[str])]\" due to an unfollowed import",
+        "message": "Argument 4 to \"parse_and_typecheck\" becomes \"list[(list[Any (from unimported type)], Optional[str])]\" due to an unfollowed import",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.parse_and_typecheck"
       },
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 9,
         "target": "mypyc.codegen.emitmodule.parse_and_typecheck"
       },
       {
         "code": "no-any-expr",
         "column": 73,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 4,
         "target": "mypyc.codegen.emitmodule.parse_and_typecheck"
       },
       {
         "code": "no-any-unimported",
         "column": 0,
-        "message": "Argument 1 to \"compile_ir_to_c\" becomes \"list[(list[Any], Optional[str])]\" due to an unfollowed import",
+        "message": "Argument 1 to \"compile_ir_to_c\" becomes \"list[(list[Any (from unimported type)], Optional[str])]\" due to an unfollowed import",
         "offset": 87,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 12,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression type contains \"Any\" (has type \"dict[Any, str]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[Any (from unimported type), str]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 1,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 59,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 2,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 83,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 5,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression type contains \"Any\" (has type \"list[(Any, ModuleIR)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(Any (from unimported type), ModuleIR)]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression type contains \"Any\" (has type \"(Any, ModuleIR)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (from unimported type), ModuleIR)\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 79,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 1,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"list[(Any, ModuleIR)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(Any (from unimported type), ModuleIR)]\")",
         "offset": 1,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"list[(Any, ModuleIR)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(Any (from unimported type), ModuleIR)]\")",
         "offset": 4,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression type contains \"Any\" (has type \"dict[Any, str]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[Any (from unimported type), str]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_ir_to_c"
       },
@@ -28876,119 +28911,119 @@
       {
         "code": "no-any-unimported",
         "column": 0,
-        "message": "Argument 4 to \"compile_modules_to_c\" becomes \"list[(list[Any], Optional[str])]\" due to an unfollowed import",
+        "message": "Argument 4 to \"compile_modules_to_c\" becomes \"list[(list[Any (from unimported type)], Optional[str])]\" due to an unfollowed import",
         "offset": 5,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 25,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"dict[Any, Optional[str]]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[Any (from unimported type), Optional[str]]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 17,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 17,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 64,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 85,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression type contains \"Any\" (has type \"dict[Any, Optional[str]]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[Any (from unimported type), Optional[str]]\")",
         "offset": 1,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 7,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression type contains \"Any\" (has type \"dict[Any, Optional[str]]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[Any (from unimported type), Optional[str]]\")",
         "offset": 3,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 2,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression type contains \"Any\" (has type \"(list[Any], Optional[str])\")",
+        "message": "Expression type contains \"Any\" (has type \"(list[Any (from unimported type)], Optional[str])\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (from unimported type)]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule.compile_modules_to_c"
       }
@@ -29050,1169 +29085,1169 @@
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> (int, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (int, Any (special form))\")",
         "offset": 279,
         "target": "mypyc.ir.class_ir.ClassIR.concrete_subclasses"
       },
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression type contains \"Any\" (has type \"(int, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(int, Any (special form))\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.concrete_subclasses"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.concrete_subclasses"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.concrete_subclasses"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression type contains \"Any\" (has type \"Any | list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"Any (special form) | list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.concrete_subclasses"
       },
       {
         "code": "no-any-expr",
         "column": 65,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.concrete_subclasses"
       },
       {
         "code": "no-any-expr",
         "column": 70,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.concrete_subclasses"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 3,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 15,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 3,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 3,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 7,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 4,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 6,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, Optional[list[Any]])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, Optional[list[Any (special form)]])\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression type contains \"Any\" (has type \"Optional[list[Any]]\")",
+        "message": "Expression type contains \"Any\" (has type \"Optional[list[Any (special form)]]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 7,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 76,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 13,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression type contains \"Any\" (has type \"Generator[(Any, RType), None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[(Any (special form), RType), None, None]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(Any, RType)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), RType)\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(Any, RType)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), RType)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression type contains \"Any\" (has type \"Generator[(Any, FuncDecl), None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[(Any (special form), FuncDecl), None, None]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"(Any, FuncDecl)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), FuncDecl)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"(Any, FuncDecl)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), FuncDecl)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 87,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 87,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 87,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 87,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression type contains \"Any\" (has type \"Generator[(Any, FuncIR), None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[(Any (special form), FuncIR), None, None]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression type contains \"Any\" (has type \"(Any, FuncIR)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), FuncIR)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression type contains \"Any\" (has type \"(Any, FuncIR)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), FuncIR)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression type contains \"Any\" (has type \"Generator[((ClassIR, Any), FuncIR), None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[((ClassIR, Any (special form)), FuncIR), None, None]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"((ClassIR, Any), FuncIR)\")",
+        "message": "Expression type contains \"Any\" (has type \"((ClassIR, Any (special form)), FuncIR)\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"((ClassIR, Any), FuncIR)\")",
+        "message": "Expression type contains \"Any\" (has type \"((ClassIR, Any (special form)), FuncIR)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression type contains \"Any\" (has type \"(ClassIR, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(ClassIR, Any (special form))\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression type contains \"Any\" (has type \"(ClassIR, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(ClassIR, Any (special form))\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression type contains \"Any\" (has type \"Generator[(Any, RType), None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[(Any (special form), RType), None, None]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(Any, RType)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), RType)\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(Any, RType)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), RType)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression type contains \"Any\" (has type \"Generator[(Any, (FuncIR, Optional[FuncIR])), None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[(Any (special form), (FuncIR, Optional[FuncIR])), None, None]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(Any, (FuncIR, Optional[FuncIR]))\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), (FuncIR, Optional[FuncIR]))\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(Any, (FuncIR, Optional[FuncIR]))\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), (FuncIR, Optional[FuncIR]))\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 64,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 64,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 64,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 64,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 5,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 5,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 17,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 20,
         "target": "mypyc.ir.class_ir.serialize_vtable_entry"
       },
       {
         "code": "no-any-expr",
         "column": 7,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 14,
         "target": "mypyc.ir.class_ir.deserialize_vtable_entry"
       }
@@ -30221,105 +30256,105 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 38,
         "target": "mypyc.ir.func_ir.RuntimeArg.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 26,
         "target": "mypyc.ir.func_ir.FuncSignature.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 0,
         "target": "mypyc.ir.func_ir.FuncSignature.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.func_ir.FuncSignature.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 5,
         "target": "mypyc.ir.func_ir.FuncSignature.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.func_ir.FuncSignature.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 75,
         "target": "mypyc.ir.func_ir.FuncDecl.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 15,
         "target": "mypyc.ir.func_ir.FuncDecl.get_id_from_json"
       },
       {
         "code": "no-any-expr",
         "column": 67,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.func_ir.FuncDecl.get_id_from_json"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypyc.ir.func_ir.FuncDecl.get_id_from_json"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.func_ir.FuncDecl.get_id_from_json"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.func_ir.FuncDecl.get_id_from_json"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypyc.ir.func_ir.FuncDecl.get_id_from_json"
       },
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.func_ir.FuncDecl.get_id_from_json"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 82,
         "target": "mypyc.ir.func_ir.FuncIR.serialize"
       }
@@ -30328,175 +30363,175 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 29,
         "target": "mypyc.ir.module_ir.ModuleIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 3,
         "target": "mypyc.ir.module_ir.ModuleIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypyc.ir.module_ir.ModuleIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
         "offset": 1,
         "target": "mypyc.ir.module_ir.ModuleIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 8,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression type contains \"Any\" (has type \"(Any, RType)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), RType)\")",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 14,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 21,
         "target": "mypyc.ir.module_ir.deserialize_modules"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypyc.ir.module_ir.deserialize_modules"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.deserialize_modules"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.deserialize_modules"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.deserialize_modules"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 7,
         "target": "mypyc.ir.module_ir.deserialize_modules"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 1,
         "target": "mypyc.ir.module_ir.deserialize_modules"
       }
@@ -30621,56 +30656,56 @@
       {
         "code": "no-any-expr",
         "column": 9,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 90,
         "target": "mypyc.ir.rtypes.deserialize_type"
       },
       {
         "code": "no-any-expr",
         "column": 9,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 2,
         "target": "mypyc.ir.rtypes.deserialize_type"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 419,
         "target": "mypyc.ir.rtypes.RTuple.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 4,
         "target": "mypyc.ir.rtypes.RTuple.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.rtypes.RTuple.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
         "offset": 217,
         "target": "mypyc.ir.rtypes.RUnion.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 4,
         "target": "mypyc.ir.rtypes.RUnion.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.ir.rtypes.RUnion.deserialize"
       }
@@ -30727,7 +30762,7 @@
       {
         "code": "no-any-expr",
         "column": 45,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 140,
         "target": "mypyc.irbuild.expression.transform_member_expr"
       }
@@ -30752,14 +30787,14 @@
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
         "offset": 157,
         "target": "mypyc.irbuild.function.gen_func_item"
       },
       {
         "code": "no-any-expr",
         "column": 40,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.irbuild.function.gen_func_item"
       }
@@ -30775,343 +30810,343 @@
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 640,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 50,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> AnyType\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> AnyType\")",
         "offset": 4,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(Any, RuntimeArg)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (from unimported type), RuntimeArg)\")",
         "offset": 5,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(Any, RuntimeArg)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (from unimported type), RuntimeArg)\")",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression type contains \"Any\" (has type \"zip[(Any, RuntimeArg)]\")",
+        "message": "Expression type contains \"Any\" (has type \"zip[(Any (from unimported type), RuntimeArg)]\")",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 40,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 2,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 40,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 75,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 75,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 75,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 75,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 75,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 75,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 88,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 88,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(Any, RuntimeArg)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (from unimported type), RuntimeArg)\")",
         "offset": 12,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(Any, RuntimeArg)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (from unimported type), RuntimeArg)\")",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression type contains \"Any\" (has type \"zip[(Any, RuntimeArg)]\")",
+        "message": "Expression type contains \"Any\" (has type \"zip[(Any (from unimported type), RuntimeArg)]\")",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 21,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 7,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 3,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 2,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (from unimported type)\"",
         "offset": 0,
         "target": "mypyc.irbuild.ll_builder.LowLevelIRBuilder.native_args_to_positional"
       }
@@ -31247,35 +31282,35 @@
       {
         "code": "no-any-expr",
         "column": 42,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> (Any, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (Any (special form), Any (special form))\")",
         "offset": 70,
         "target": "mypyc.test.test_analysis.TestAnalysis.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 52,
-        "message": "Expression type contains \"Any\" (has type \"(Any, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), Any (special form))\")",
         "offset": 0,
         "target": "mypyc.test.test_analysis.TestAnalysis.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.test.test_analysis.TestAnalysis.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.test.test_analysis.TestAnalysis.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 65,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.test.test_analysis.TestAnalysis.run_case"
       }
@@ -31358,7 +31393,7 @@
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> str\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> str\")",
         "offset": 9,
         "target": "mypyc.test.test_emitclass.TestEmitClass.test_slot_key"
       }
@@ -31367,14 +31402,14 @@
       {
         "code": "no-any-expr",
         "column": 57,
-        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
         "offset": 53,
         "target": "mypyc.test.test_exceptions.TestExceptionTransform.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 63,
-        "message": "Expression type contains \"Any\" (has type \"Generator[Any, None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[Any (special form), None, None]\")",
         "offset": 0,
         "target": "mypyc.test.test_exceptions.TestExceptionTransform.run_case"
       }
@@ -31476,21 +31511,21 @@
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 62,
         "target": "mypyc.test.test_run.TestRun.run_case_step"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 0,
         "target": "mypyc.test.test_run.TestRun.run_case_step"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"Any | bool\")",
+        "message": "Expression type contains \"Any\" (has type \"Untyped | bool\")",
         "offset": 0,
         "target": "mypyc.test.test_run.TestRun.run_case_step"
       },
@@ -31525,7 +31560,7 @@
       {
         "code": "no-any-expr",
         "column": 17,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 3,
         "target": "mypyc.test.test_run.TestRun.run_case_step"
       },
@@ -31539,21 +31574,21 @@
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 8,
         "target": "mypyc.test.test_run.TestRun.run_case_step"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 7,
         "target": "mypyc.test.test_run.TestRun.run_case_step"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression type contains \"Any\" (has type \"list[(list[Any], Optional[str])]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
         "offset": 0,
         "target": "mypyc.test.test_run.TestRun.run_case_step"
       },
@@ -31567,28 +31602,28 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 7,
         "target": "mypyc.test.test_run.TestRun.run_case_step"
       },
       {
         "code": "no-any-expr",
         "column": 40,
-        "message": "Expression type contains \"Any\" (has type \"Any | bool\")",
+        "message": "Expression type contains \"Any\" (has type \"Untyped | bool\")",
         "offset": 17,
         "target": "mypyc.test.test_run.TestRun.run_case_step"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 20,
         "target": "mypyc.test.test_run.TestRun.run_case_step"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression type contains \"Any\" (has type \"Any | bool\")",
+        "message": "Expression type contains \"Any\" (has type \"Untyped | bool\")",
         "offset": 7,
         "target": "mypyc.test.test_run.TestRun.run_case_step"
       },
@@ -31616,35 +31651,35 @@
       {
         "code": "no-any-expr",
         "column": 21,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> str\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> str\")",
         "offset": 61,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
@@ -31679,35 +31714,35 @@
       {
         "code": "no-any-expr",
         "column": 21,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> str\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> str\")",
         "offset": 3,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
@@ -32094,14 +32129,14 @@
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"((Any, Any), Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"((Any (special form), Any (special form)), Any)\")",
         "offset": 1,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"((Any, Any), Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"((Any (special form), Any (special form)), Any)\")",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
@@ -32129,7 +32164,7 @@
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression type contains \"Any\" (has type \"zip[((Any, Any), Any)]\")",
+        "message": "Expression type contains \"Any\" (has type \"zip[((Any (special form), Any (special form)), Any)]\")",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
@@ -32283,35 +32318,35 @@
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(int, (Any, Any))\")",
+        "message": "Expression type contains \"Any\" (has type \"(int, (Any (special form), Any))\")",
         "offset": 1,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(int, (Any, Any))\")",
+        "message": "Expression type contains \"Any\" (has type \"(int, (Any (special form), Any))\")",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(Any, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), Any)\")",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(Any, Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any (special form), Any)\")",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Any (special form)\"",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
@@ -32325,14 +32360,14 @@
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression type contains \"Any\" (has type \"enumerate[(Any, Any)]\")",
+        "message": "Expression type contains \"Any\" (has type \"enumerate[(Any (special form), Any)]\")",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression type contains \"Any\" (has type \"zip[(Any, Any)]\")",
+        "message": "Expression type contains \"Any\" (has type \"zip[(Any (special form), Any)]\")",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
@@ -32495,14 +32530,14 @@
       {
         "code": "no-any-expr",
         "column": 7,
-        "message": "Expression type contains \"Any\" (has type \"Literal[False] | Any\")",
+        "message": "Expression type contains \"Any\" (has type \"Literal[False] | Untyped\")",
         "offset": 59,
         "target": "mypyc.test.testutil.assert_test_output"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any\"",
+        "message": "Expression has type \"Untyped\"",
         "offset": 0,
         "target": "mypyc.test.testutil.assert_test_output"
       },
@@ -32553,14 +32588,14 @@
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> int\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> int\")",
         "offset": 197,
         "target": "mypyc.transform.refcount.after_branch_decrefs"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression type contains \"Any\" (has type \"(Any) -> int\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> int\")",
         "offset": 15,
         "target": "mypyc.transform.refcount.after_branch_increfs"
       }

--- a/.mypy/baseline.json
+++ b/.mypy/baseline.json
@@ -13,28 +13,28 @@
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any (special form), Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any, Any]]\")",
         "offset": 24,
         "target": "mypy.bogus_type"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any (special form), Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any, Any]]\")",
         "offset": 0,
         "target": "mypy.bogus_type"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any (special form), Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any, Any]]\")",
         "offset": 0,
         "target": "mypy.bogus_type"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any (special form), Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[FlexibleAlias[Any, Any]]\")",
         "offset": 0,
         "target": "mypy.bogus_type"
       }
@@ -819,15 +819,22 @@
       },
       {
         "code": "no-any-expr",
+        "column": 34,
+        "message": "Expression has type \"Any\"",
+        "offset": 7,
+        "target": "mypy.build.load_baseline"
+      },
+      {
+        "code": "no-any-expr",
         "column": 7,
-        "message": "Expression has type \"Any (special form)\"",
-        "offset": 13,
+        "message": "Expression has type \"Any\"",
+        "offset": 6,
         "target": "mypy.build.load_baseline"
       },
       {
         "code": "no-any-expr",
         "column": 9,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 3,
         "target": "mypy.build.load_baseline"
       },
@@ -2255,14 +2262,14 @@
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 288,
         "target": "mypy.build.log_configuration"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.build.log_configuration"
       },
@@ -2437,42 +2444,42 @@
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.build.sorted_components"
       },
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.build.sorted_components"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.build.sorted_components"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.build.sorted_components"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.build.sorted_components"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.build.sorted_components"
       }
@@ -2965,7 +2972,7 @@
         "code": "truthy-bool",
         "column": 23,
         "message": "\"signature\" has type \"Type\" which does not implement __bool__ or __len__ so it could always be true in boolean context",
-        "offset": 263,
+        "offset": 251,
         "target": "mypy.checker.TypeChecker.check_assignment"
       },
       {
@@ -3147,7 +3154,7 @@
         "code": "no-any-expr",
         "column": 48,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 133,
+        "offset": 141,
         "target": "mypy.checker.TypeChecker.check_member_assignment"
       },
       {
@@ -3165,17 +3172,10 @@
         "target": "mypy.checker.TypeChecker.check_member_assignment"
       },
       {
-        "code": "ignore-without-code",
-        "column": -1,
-        "message": "\"type: ignore\" comment without error code (consider \"type: ignore[attr-defined]\" instead)",
-        "offset": 565,
-        "target": null
-      },
-      {
         "code": "no-any-expr",
         "column": 33,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 1319,
+        "offset": 1884,
         "target": "mypy.checker.TypeChecker.check_subtype"
       },
       {
@@ -3251,21 +3251,21 @@
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
         "offset": 344,
         "target": "mypy.checker.group_comparison_operands"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.checker.group_comparison_operands"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.checker.group_comparison_operands"
       },
@@ -4911,21 +4911,21 @@
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"(str, (Any (special form)) -> Any (special form))\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, (Any) -> Any)\")",
         "offset": 67,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form)) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
@@ -4939,203 +4939,203 @@
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 3,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 40,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 40,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 60,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 9,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 45,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 50,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 50,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.config_parser"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 4,
         "target": "mypy.config_parser"
       },
@@ -7000,6 +7000,13 @@
       },
       {
         "code": "no-any-expr",
+        "column": 18,
+        "message": "Expression has type \"Any\"",
+        "offset": 0,
+        "target": "mypy.dmypy.client.do_daemon"
+      },
+      {
+        "code": "no-any-expr",
         "column": 20,
         "message": "Expression has type \"Any\"",
         "offset": 1,
@@ -7714,28 +7721,28 @@
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (Any (special form), Any (special form))\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (Any, Any)\")",
         "offset": 31,
         "target": "mypy.errors.Errors.sort_messages"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), Any (special form))\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, Any)\")",
         "offset": 0,
         "target": "mypy.errors.Errors.sort_messages"
       },
       {
         "code": "no-any-expr",
         "column": 52,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.errors.Errors.sort_messages"
       },
       {
         "code": "no-any-expr",
         "column": 60,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.errors.Errors.sort_messages"
       }
@@ -8971,7 +8978,7 @@
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_NamedExpr"
       },
@@ -8985,7 +8992,7 @@
       {
         "code": "no-any-expr",
         "column": 60,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_NamedExpr"
       },
@@ -9230,7 +9237,7 @@
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 3,
         "target": "mypy.fastparse.ASTConverter.visit_Call"
       },
@@ -9244,7 +9251,7 @@
       {
         "code": "no-any-expr",
         "column": 14,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
@@ -9258,154 +9265,154 @@
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 69,
-        "message": "Expression type contains \"Any\" (has type \"type[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[Any]\")",
         "offset": 3,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 69,
-        "message": "Expression type contains \"Any\" (has type \"type[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[Any]\")",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 69,
-        "message": "Expression type contains \"Any\" (has type \"type[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[Any]\")",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 69,
-        "message": "Expression type contains \"Any\" (has type \"type[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[Any]\")",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 74,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Constant"
       },
@@ -9643,14 +9650,14 @@
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
@@ -9664,28 +9671,28 @@
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 57,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
@@ -9699,56 +9706,56 @@
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 57,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
       {
         "code": "no-any-expr",
         "column": 76,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_Match"
       },
@@ -9762,21 +9769,21 @@
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchValue"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 4,
         "target": "mypy.fastparse.ASTConverter.visit_MatchSingleton"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 4,
         "target": "mypy.fastparse.ASTConverter.visit_MatchSequence"
       },
@@ -9797,14 +9804,14 @@
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchSequence"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchSequence"
       },
@@ -9839,21 +9846,21 @@
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 4,
         "target": "mypy.fastparse.ASTConverter.visit_MatchStar"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 3,
         "target": "mypy.fastparse.ASTConverter.visit_MatchStar"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 5,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
@@ -9874,21 +9881,21 @@
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
       {
         "code": "no-any-expr",
         "column": 17,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
@@ -9909,28 +9916,28 @@
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 3,
         "target": "mypy.fastparse.ASTConverter.visit_MatchMapping"
       },
@@ -9958,7 +9965,7 @@
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
@@ -9972,7 +9979,7 @@
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
@@ -9993,28 +10000,28 @@
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
@@ -10035,14 +10042,14 @@
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
@@ -10056,7 +10063,7 @@
       {
         "code": "no-any-expr",
         "column": 52,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchClass"
       },
@@ -10070,14 +10077,14 @@
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 5,
         "target": "mypy.fastparse.ASTConverter.visit_MatchAs"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 3,
         "target": "mypy.fastparse.ASTConverter.visit_MatchAs"
       },
@@ -10091,14 +10098,14 @@
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchAs"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 5,
         "target": "mypy.fastparse.ASTConverter.visit_MatchOr"
       },
@@ -10112,14 +10119,14 @@
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchOr"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.ASTConverter.visit_MatchOr"
       },
@@ -10231,140 +10238,140 @@
       {
         "code": "no-any-expr",
         "column": 14,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 4,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 3,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"Any (special form) | bool\")",
+        "message": "Expression type contains \"Any\" (has type \"Any | bool\")",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"Any (special form) | bool\")",
+        "message": "Expression type contains \"Any\" (has type \"Any | bool\")",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 77,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 3,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 73,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 3,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 3,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
       {
         "code": "no-any-expr",
         "column": 83,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypy.fastparse.TypeConverter.visit_Constant"
       },
@@ -10497,6 +10504,13 @@
       {
         "code": "no-any-expr",
         "column": 16,
+        "message": "Expression has type \"Any\"",
+        "offset": 0,
+        "target": "mypy.fastparse.TypeConverter.visit_Subscript"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 38,
         "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.fastparse.TypeConverter.visit_Subscript"
@@ -11827,6 +11841,13 @@
       },
       {
         "code": "no-any-expr",
+        "column": 19,
+        "message": "Expression has type \"Any\"",
+        "offset": 0,
+        "target": "mypy.fscache.copy_os_error"
+      },
+      {
+        "code": "no-any-expr",
         "column": 7,
         "message": "Expression has type \"Any\"",
         "offset": 1,
@@ -11837,6 +11858,13 @@
         "column": 24,
         "message": "Expression has type \"Any\"",
         "offset": 1,
+        "target": "mypy.fscache.copy_os_error"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 24,
+        "message": "Expression has type \"Any\"",
+        "offset": 0,
         "target": "mypy.fscache.copy_os_error"
       }
     ],
@@ -11939,7 +11967,7 @@
       {
         "code": "no-any-return",
         "column": 8,
-        "message": "Returning Any from function declared to return \"tuple[Any (special form), ...]\"",
+        "message": "Returning Any from function declared to return \"tuple[Any, ...]\"",
         "offset": 1,
         "target": "mypy.literals._Hasher.visit_comparison_expr"
       },
@@ -11988,7 +12016,7 @@
       {
         "code": "no-any-return",
         "column": 12,
-        "message": "Returning Any from function declared to return \"Optional[tuple[Any (special form), ...]]\"",
+        "message": "Returning Any from function declared to return \"Optional[tuple[Any, ...]]\"",
         "offset": 1,
         "target": "mypy.literals._Hasher.seq_expr"
       },
@@ -12037,7 +12065,7 @@
       {
         "code": "no-any-return",
         "column": 12,
-        "message": "Returning Any from function declared to return \"Optional[tuple[Any (special form), ...]]\"",
+        "message": "Returning Any from function declared to return \"Optional[tuple[Any, ...]]\"",
         "offset": 3,
         "target": "mypy.literals._Hasher.visit_dict_expr"
       },
@@ -12171,23 +12199,44 @@
       },
       {
         "code": "no-any-expr",
+        "column": 19,
+        "message": "Expression has type \"Any\"",
+        "offset": 7,
+        "target": "mypy.main.CapturableArgumentParser.print_usage"
+      },
+      {
+        "code": "no-any-expr",
         "column": 49,
         "message": "Expression type contains \"Any\" (has type \"IO[str] | Any\")",
-        "offset": 8,
+        "offset": 1,
         "target": "mypy.main.CapturableArgumentParser.print_usage"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 19,
+        "message": "Expression has type \"Any\"",
+        "offset": 4,
+        "target": "mypy.main.CapturableArgumentParser.print_help"
       },
       {
         "code": "no-any-expr",
         "column": 48,
         "message": "Expression type contains \"Any\" (has type \"IO[str] | Any\")",
-        "offset": 5,
+        "offset": 1,
         "target": "mypy.main.CapturableArgumentParser.print_help"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 23,
+        "message": "Expression has type \"Any\"",
+        "offset": 5,
+        "target": "mypy.main.CapturableArgumentParser._print_message"
       },
       {
         "code": "no-any-expr",
         "column": 12,
         "message": "Expression type contains \"Any\" (has type \"IO[str] | Any\")",
-        "offset": 6,
+        "offset": 1,
         "target": "mypy.main.CapturableArgumentParser._print_message"
       },
       {
@@ -13422,21 +13471,21 @@
       {
         "code": "no-any-expr",
         "column": 45,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
         "offset": 18,
         "target": "mypy.memprofile.print_memory_profile"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.memprofile.print_memory_profile"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.memprofile.print_memory_profile"
       },
@@ -13662,7 +13711,7 @@
       {
         "code": "no-any-expr",
         "column": 65,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
         "offset": 308,
         "target": "mypy.messages.MessageBuilder.reveal_locals"
       },
@@ -13676,7 +13725,7 @@
       {
         "code": "no-any-expr",
         "column": 75,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.messages.MessageBuilder.reveal_locals"
       },
@@ -13844,7 +13893,7 @@
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (float, Any (special form))\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (float, Any)\")",
         "offset": 20,
         "target": "mypy.messages.best_matches"
       }
@@ -14272,154 +14321,154 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 119,
         "target": "mypy.nodes.MypyFile.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 6,
         "target": "mypy.nodes.MypyFile.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.nodes.MypyFile.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 5,
         "target": "mypy.nodes.MypyFile.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 223,
         "target": "mypy.nodes.OverloadedFuncDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypy.nodes.OverloadedFuncDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.nodes.OverloadedFuncDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 9,
         "target": "mypy.nodes.OverloadedFuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.nodes.OverloadedFuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 54,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.nodes.OverloadedFuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 160,
         "target": "mypy.nodes.FuncDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 4,
         "target": "mypy.nodes.FuncDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.nodes.FuncDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 8,
         "target": "mypy.nodes.FuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.nodes.FuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 12,
         "target": "mypy.nodes.FuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.nodes.FuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.nodes.FuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.nodes.FuncDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 62,
         "target": "mypy.nodes.Decorator.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 8,
         "target": "mypy.nodes.Decorator.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 123,
         "target": "mypy.nodes.Var.deserialize"
       },
@@ -14433,98 +14482,98 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 21,
         "target": "mypy.nodes.ClassDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 3,
         "target": "mypy.nodes.ClassDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.nodes.ClassDef.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 5,
         "target": "mypy.nodes.ClassDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 3,
         "target": "mypy.nodes.ClassDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 59,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.nodes.ClassDef.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 1233,
         "target": "mypy.nodes.TypeVarExpr.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 3,
         "target": "mypy.nodes.TypeVarExpr.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.nodes.TypeVarExpr.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 7,
         "target": "mypy.nodes.TypeVarExpr.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 3,
         "target": "mypy.nodes.TypeVarExpr.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.nodes.TypeVarExpr.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 12,
         "target": "mypy.nodes.ParamSpecExpr.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 10,
         "target": "mypy.nodes.ParamSpecExpr.deserialize"
       },
@@ -14538,14 +14587,14 @@
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 125,
         "target": "mypy.nodes.TypeInfo.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 52,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.nodes.TypeInfo.deserialize"
       },
@@ -14573,7 +14622,7 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 145,
         "target": "mypy.nodes.TypeAlias.deserialize"
       },
@@ -14587,7 +14636,7 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 14,
         "target": "mypy.nodes.SymbolTableNode.deserialize"
       },
@@ -14601,7 +14650,7 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 24,
         "target": "mypy.nodes.SymbolTable.deserialize"
       },
@@ -14764,7 +14813,7 @@
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypy.options.Options.snapshot"
       },
@@ -14919,70 +14968,70 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 55,
         "target": "mypy.plugins.attrs.Attribute.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 152,
         "target": "mypy.plugins.attrs.attr_class_maker_callback"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypy.plugins.attrs.attr_class_maker_callback"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.plugins.attrs.attr_class_maker_callback"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 70,
         "target": "mypy.plugins.attrs._analyze_class"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 3,
         "target": "mypy.plugins.attrs._analyze_class"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.plugins.attrs._analyze_class"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.plugins.attrs._analyze_class"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.plugins.attrs._analyze_class"
       },
       {
         "code": "no-any-expr",
         "column": 58,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.plugins.attrs._analyze_class"
       },
@@ -15028,63 +15077,63 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 80,
         "target": "mypy.plugins.dataclasses.DataclassAttribute.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 155,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.transform"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.transform"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.transform"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 165,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.collect_attributes"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.collect_attributes"
       },
       {
         "code": "no-any-expr",
         "column": 64,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.collect_attributes"
       },
       {
         "code": "no-any-expr",
         "column": 31,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
         "offset": 15,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.collect_attributes"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.plugins.dataclasses.DataclassTransformer.collect_attributes"
       },
@@ -15412,7 +15461,7 @@
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (bool, Any (special form))\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (bool, Any)\")",
         "offset": 41,
         "target": "mypy.plugins.functools.functools_total_ordering_maker_callback"
       },
@@ -15530,28 +15579,28 @@
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
         "offset": 239,
         "target": "mypy.report.AnyExpressionsReporter._report_any_exprs"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.report.AnyExpressionsReporter._report_any_exprs"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
         "offset": 15,
         "target": "mypy.report.AnyExpressionsReporter._report_types_of_anys"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.report.AnyExpressionsReporter._report_types_of_anys"
       },
@@ -15697,15 +15746,22 @@
       },
       {
         "code": "no-any-expr",
+        "column": 24,
+        "message": "Expression has type \"Any (from unimported type)\"",
+        "offset": 2,
+        "target": "mypy.report.MemoryXmlReporter.on_file"
+      },
+      {
+        "code": "no-any-expr",
         "column": 46,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
-        "offset": 21,
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
+        "offset": 19,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
@@ -15801,10 +15857,17 @@
         "target": "mypy.report.MemoryXmlReporter.on_finish"
       },
       {
+        "code": "no-any-expr",
+        "column": 24,
+        "message": "Expression has type \"Any (from unimported type)\"",
+        "offset": 2,
+        "target": "mypy.report.MemoryXmlReporter.on_finish"
+      },
+      {
         "code": "no-any-explicit",
         "column": 8,
         "message": "Explicit \"Any\" is not allowed",
-        "offset": 20,
+        "offset": 18,
         "target": "mypy.report.CoberturaPackage.__init__"
       },
       {
@@ -16531,14 +16594,14 @@
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
         "offset": 63,
         "target": "mypy.report.LinePrecisionReporter.on_finish"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.report.LinePrecisionReporter.on_finish"
       }
@@ -16955,6 +17018,13 @@
         "target": "mypy.semanal.SemanticAnalyzer._get_node_for_class_scoped_import"
       },
       {
+        "code": "no-any-expr",
+        "column": 22,
+        "message": "Expression has type \"Any\"",
+        "offset": 0,
+        "target": "mypy.semanal.SemanticAnalyzer._get_node_for_class_scoped_import"
+      },
+      {
         "code": "redundant-expr",
         "column": 16,
         "message": "Left operand of \"and\" is always true",
@@ -16978,14 +17048,14 @@
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
         "offset": 77,
         "target": "mypy.semanal.apply_semantic_analyzer_patches"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.semanal.apply_semantic_analyzer_patches"
       },
@@ -17101,35 +17171,35 @@
       {
         "code": "no-any-expr",
         "column": 57,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (Any (special form), Any (special form))\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (Any, Any)\")",
         "offset": 230,
         "target": "mypy.semanal_main.process_functions"
       },
       {
         "code": "no-any-expr",
         "column": 67,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), Any (special form))\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, Any)\")",
         "offset": 0,
         "target": "mypy.semanal_main.process_functions"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.semanal_main.process_functions"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.semanal_main.process_functions"
       },
       {
         "code": "no-any-expr",
         "column": 79,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.semanal_main.process_functions"
       }
@@ -17138,7 +17208,7 @@
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 410,
         "target": "mypy.semanal_namedtuple.NamedTupleAnalyzer.build_namedtuple_typeinfo"
       }
@@ -17218,14 +17288,14 @@
       {
         "code": "no-any-expr",
         "column": 57,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
         "offset": 71,
         "target": "mypy.server.deps.dump_all_dependencies"
       },
       {
         "code": "no-any-expr",
         "column": 67,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.server.deps.dump_all_dependencies"
       }
@@ -17264,21 +17334,21 @@
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression type contains \"Any\" (has type \"set[type[ReferenceType[Any (special form)]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"set[type[ReferenceType[Any]]]\")",
         "offset": 32,
         "target": "mypy.server.objgraph"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"type[ReferenceType[Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[ReferenceType[Any]]\")",
         "offset": 1,
         "target": "mypy.server.objgraph"
       },
       {
         "code": "no-any-expr",
         "column": 4,
-        "message": "Expression type contains \"Any\" (has type \"type[ReferenceType[Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[ReferenceType[Any]]\")",
         "offset": 0,
         "target": "mypy.server.objgraph"
       },
@@ -17369,28 +17439,28 @@
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(int, Any (special form))\")",
+        "message": "Expression type contains \"Any\" (has type \"(int, Any)\")",
         "offset": 7,
         "target": "mypy.server.objgraph.get_edge_candidates"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(int, Any (special form))\")",
+        "message": "Expression type contains \"Any\" (has type \"(int, Any)\")",
         "offset": 0,
         "target": "mypy.server.objgraph.get_edge_candidates"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.server.objgraph.get_edge_candidates"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression type contains \"Any\" (has type \"enumerate[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"enumerate[Any]\")",
         "offset": 0,
         "target": "mypy.server.objgraph.get_edge_candidates"
       },
@@ -17439,7 +17509,7 @@
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"set[type[ReferenceType[Any (special form)]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"set[type[ReferenceType[Any]]]\")",
         "offset": 2,
         "target": "mypy.server.objgraph.get_edges"
       }
@@ -17448,35 +17518,35 @@
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 233,
         "target": "mypy.server.update.FineGrainedBuildManager.update"
       },
       {
         "code": "no-any-expr",
         "column": 60,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 176,
         "target": "mypy.server.update.FineGrainedBuildManager.update_module"
       },
       {
         "code": "no-any-expr",
         "column": 50,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
         "offset": 416,
         "target": "mypy.server.update.propagate_changes_using_dependencies"
       },
       {
         "code": "no-any-expr",
         "column": 60,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.server.update.propagate_changes_using_dependencies"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 9,
         "target": "mypy.server.update.propagate_changes_using_dependencies"
       }
@@ -18301,21 +18371,21 @@
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
         "offset": 19,
         "target": "mypy.strconv.StrConv.str_repr"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.strconv.StrConv.str_repr"
       },
       {
         "code": "no-any-expr",
         "column": 58,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.strconv.StrConv.str_repr"
       },
@@ -18329,14 +18399,14 @@
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.strconv.StrConv.str_repr"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.strconv.StrConv.str_repr"
       },
@@ -19427,7 +19497,7 @@
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
         "offset": 0,
         "target": "mypy.stubgenc.generate_stub_for_c_module"
       },
@@ -19448,7 +19518,7 @@
       {
         "code": "no-any-expr",
         "column": 58,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.stubgenc.generate_stub_for_c_module"
       },
@@ -19819,7 +19889,7 @@
       {
         "code": "no-any-expr",
         "column": 72,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.stubgenc.generate_c_type_stub"
       },
@@ -20724,56 +20794,56 @@
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any]]\")",
         "offset": 18,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any]]\")",
         "offset": 0,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any]]\")",
         "offset": 2,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[classmethod[Any]]\")",
         "offset": 0,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any]]\")",
         "offset": 2,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any]]\")",
         "offset": 0,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any]]\")",
         "offset": 2,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[staticmethod[Any]]\")",
         "offset": 0,
         "target": "mypy.stubtest._verify_static_class_methods"
       },
@@ -22347,9 +22417,23 @@
       },
       {
         "code": "no-any-expr",
+        "column": 34,
+        "message": "Expression has type \"Any\"",
+        "offset": 4,
+        "target": "mypy.stubtest.test_stubs"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 26,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.stubtest.test_stubs"
+      },
+      {
+        "code": "no-any-expr",
         "column": 30,
         "message": "Expression has type \"Any\"",
-        "offset": 14,
+        "offset": 9,
         "target": "mypy.stubtest.test_stubs"
       },
       {
@@ -23593,10 +23677,24 @@
         "target": "mypy.test.data.split_test_cases"
       },
       {
+        "code": "no-untyped-usage",
+        "column": 27,
+        "message": "Usage of untyped name \"obj\" in typed context",
+        "offset": 8,
+        "target": "mypy.test.data.DataSuiteCollector.collect"
+      },
+      {
+        "code": "no-untyped-usage",
+        "column": 27,
+        "message": "Usage of untyped name \"obj\" in typed context",
+        "offset": 0,
+        "target": "mypy.test.data.DataSuiteCollector.collect"
+      },
+      {
         "code": "no-any-return",
         "column": 8,
         "message": "Returning Any from function declared to return \"DataFileCollector\"",
-        "offset": 31,
+        "offset": 23,
         "target": "mypy.test.data.DataFileCollector.from_parent"
       },
       {
@@ -24376,42 +24474,42 @@
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any (special form), ...]]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any, ...]]\")",
         "offset": 22,
         "target": "mypy.test.testinfer.OperandComparisonGroupingSuite.test_basic_cases"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[dict[int, tuple[Any (special form), ...]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[dict[int, tuple[Any, ...]]]\")",
         "offset": 0,
         "target": "mypy.test.testinfer.OperandComparisonGroupingSuite.test_basic_cases"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any (special form), ...]]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any, ...]]\")",
         "offset": 2,
         "target": "mypy.test.testinfer.OperandComparisonGroupingSuite.test_basic_cases"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any (special form), ...]]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any, ...]]\")",
         "offset": 4,
         "target": "mypy.test.testinfer.OperandComparisonGroupingSuite.test_basic_cases"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any (special form), ...]]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any, ...]]\")",
         "offset": 4,
         "target": "mypy.test.testinfer.OperandComparisonGroupingSuite.test_basic_cases"
       },
       {
         "code": "no-any-expr",
         "column": 55,
-        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any (special form), ...]]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[int, tuple[Any, ...]]\")",
         "offset": 4,
         "target": "mypy.test.testinfer.OperandComparisonGroupingSuite.test_basic_cases"
       }
@@ -24427,35 +24525,35 @@
       {
         "code": "no-any-expr",
         "column": 52,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
         "offset": 17,
         "target": "mypy.test.testmerge.ASTMergeSuite.dump_typeinfos_recursive"
       },
       {
         "code": "no-any-expr",
         "column": 62,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.test.testmerge.ASTMergeSuite.dump_typeinfos_recursive"
       },
       {
         "code": "no-any-expr",
         "column": 49,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (Any (special form), str, str)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (Any, str, str)\")",
         "offset": 30,
         "target": "mypy.test.testmerge.ASTMergeSuite.dump_types"
       },
       {
         "code": "no-any-expr",
         "column": 59,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), str, str)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, str, str)\")",
         "offset": 0,
         "target": "mypy.test.testmerge.ASTMergeSuite.dump_types"
       },
       {
         "code": "no-any-expr",
         "column": 60,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.test.testmerge.ASTMergeSuite.dump_types"
       }
@@ -25273,21 +25371,21 @@
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (Any (special form), str, str)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (Any, str, str)\")",
         "offset": 10,
         "target": "mypy.test.testtypegen.TypeExportSuite.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 44,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), str, str)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, str, str)\")",
         "offset": 0,
         "target": "mypy.test.testtypegen.TypeExportSuite.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 45,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.test.testtypegen.TypeExportSuite.run_case"
       }
@@ -25696,126 +25794,133 @@
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 182,
         "target": "mypy.types.TypeAliasType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.types.TypeAliasType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 6,
         "target": "mypy.types.TypeAliasType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 174,
         "target": "mypy.types.TypeVarType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 4,
         "target": "mypy.types.TypeVarType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.types.TypeVarType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 8,
         "target": "mypy.types.TypeVarType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 5,
         "target": "mypy.types.TypeVarType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.TypeVarType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 77,
         "target": "mypy.types.ParamSpecType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 11,
         "target": "mypy.types.ParamSpecType.deserialize"
       },
       {
         "code": "no-any-expr",
+        "column": 62,
+        "message": "Expression has type \"Any\"",
+        "offset": 53,
+        "target": "mypy.types.UnboundType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
         "column": 19,
         "message": "Expression has type \"Any\"",
-        "offset": 55,
+        "offset": 2,
         "target": "mypy.types.UnboundType.copy_modified"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 27,
         "target": "mypy.types.UnboundType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 2,
         "target": "mypy.types.UnboundType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.types.UnboundType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 7,
         "target": "mypy.types.UnboundType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypy.types.UnboundType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 45,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.UnboundType.deserialize"
       },
@@ -25836,22 +25941,36 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 23,
         "target": "mypy.types.UnpackType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 7,
         "target": "mypy.types.UnpackType.deserialize"
       },
       {
         "code": "no-any-expr",
+        "column": 48,
+        "message": "Expression has type \"Any\"",
+        "offset": 46,
+        "target": "mypy.types.AnyType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 65,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.AnyType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
         "column": 26,
         "message": "Expression has type \"Any\"",
-        "offset": 49,
+        "offset": 2,
         "target": "mypy.types.AnyType.copy_modified"
       },
       {
@@ -25864,78 +25983,92 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 13,
         "target": "mypy.types.AnyType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 6,
         "target": "mypy.types.AnyType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
-        "offset": 97,
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "offset": 98,
         "target": "mypy.types.UninhabitedType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 5,
         "target": "mypy.types.UninhabitedType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 28,
         "target": "mypy.types.NoneType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 4,
         "target": "mypy.types.NoneType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 40,
         "target": "mypy.types.DeletedType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 5,
         "target": "mypy.types.DeletedType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 119,
         "target": "mypy.types.Instance.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 11,
         "target": "mypy.types.Instance.deserialize"
       },
       {
         "code": "no-any-expr",
+        "column": 48,
+        "message": "Expression has type \"Any\"",
+        "offset": 13,
+        "target": "mypy.types.Instance.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 73,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.Instance.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
         "column": 32,
         "message": "Expression has type \"Any\"",
-        "offset": 17,
+        "offset": 3,
         "target": "mypy.types.Instance.copy_modified"
       },
       {
@@ -25996,9 +26129,128 @@
       },
       {
         "code": "no-any-expr",
+        "column": 57,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 56,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 62,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 46,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 50,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 51,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 54,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 68,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 41,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 43,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 54,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 46,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 58,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
         "column": 52,
         "message": "Expression has type \"Any\"",
-        "offset": 20,
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 64,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 58,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 58,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "target": "mypy.types.CallableType.copy_modified"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 52,
+        "message": "Expression has type \"Any\"",
+        "offset": 3,
         "target": "mypy.types.CallableType.copy_modified"
       },
       {
@@ -26186,77 +26438,77 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 14,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 6,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 3,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, dict[Any (special form), Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, dict[Any, Any])\")",
         "offset": 2,
         "target": "mypy.types.CallableType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"dict[Any (special form), Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[Any, Any]\")",
         "offset": 0,
         "target": "mypy.types.CallableType.serialize"
       },
@@ -26277,105 +26529,105 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 6,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 3,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 21,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 5,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 62,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 3,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 65,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.CallableType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 63,
         "target": "mypy.types.Overloaded.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypy.types.Overloaded.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.types.Overloaded.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 5,
         "target": "mypy.types.Overloaded.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.types.Overloaded.deserialize"
       },
@@ -26389,189 +26641,189 @@
       {
         "code": "no-any-expr",
         "column": 52,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.Overloaded.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 65,
         "target": "mypy.types.TupleType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypy.types.TupleType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.types.TupleType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 7,
         "target": "mypy.types.TupleType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.types.TupleType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.TupleType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 72,
         "target": "mypy.types.TypedDictType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypy.types.TypedDictType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.types.TypedDictType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.types.TypedDictType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypy.types.TypedDictType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.types.TypedDictType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 6,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression type contains \"Any\" (has type \"list[(Any (special form), Type)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[(Any, Type)]\")",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 41,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 42,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), Type)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, Type)\")",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 42,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), Type)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, Type)\")",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 63,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 63,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.TypedDictType.deserialize"
       },
@@ -26585,14 +26837,14 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 89,
         "target": "mypy.types.LiteralType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 8,
         "target": "mypy.types.LiteralType.deserialize"
       },
@@ -26606,42 +26858,42 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 72,
         "target": "mypy.types.UnionType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypy.types.UnionType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypy.types.UnionType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 5,
         "target": "mypy.types.UnionType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypy.types.UnionType.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypy.types.UnionType.deserialize"
       },
@@ -26655,14 +26907,14 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 71,
         "target": "mypy.types.TypeType.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 4,
         "target": "mypy.types.TypeType.deserialize"
       },
@@ -27027,42 +27279,21 @@
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 35,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 58,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
-        "offset": 0,
-        "target": "mypyc.analysis.dataflow.CFG.__str__"
-      },
-      {
-        "code": "no-any-expr",
-        "column": 58,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> int\")",
-        "offset": 0,
-        "target": "mypyc.analysis.dataflow.CFG.__str__"
-      },
-      {
-        "code": "no-any-expr",
-        "column": 58,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form)) -> Any (special form)\")",
-        "offset": 0,
-        "target": "mypyc.analysis.dataflow.CFG.__str__"
-      },
-      {
-        "code": "no-any-expr",
-        "column": 58,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
@@ -27076,28 +27307,49 @@
       {
         "code": "no-any-expr",
         "column": 58,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form)) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
+        "offset": 0,
+        "target": "mypyc.analysis.dataflow.CFG.__str__"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 58,
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
+        "offset": 0,
+        "target": "mypyc.analysis.dataflow.CFG.__str__"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 58,
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> int\")",
+        "offset": 0,
+        "target": "mypyc.analysis.dataflow.CFG.__str__"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 58,
+        "message": "Expression type contains \"Any\" (has type \"(Any) -> Any\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
@@ -27111,28 +27363,28 @@
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
       {
         "code": "no-any-expr",
         "column": 68,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.analysis.dataflow.CFG.__str__"
       },
@@ -27146,28 +27398,28 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"type[dict[Any (special form), Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[dict[Any, Any]]\")",
         "offset": 84,
         "target": "mypyc.analysis.dataflow"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"type[dict[Any (special form), Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[dict[Any, Any]]\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"type[dict[Any (special form), Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[dict[Any, Any]]\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"type[dict[Any (special form), Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[dict[Any, Any]]\")",
         "offset": 0,
         "target": "mypyc.analysis.dataflow"
       }
@@ -28008,9 +28260,16 @@
       },
       {
         "code": "no-any-expr",
+        "column": 23,
+        "message": "Expression has type \"Any\"",
+        "offset": 5,
+        "target": "mypyc.build.mypyc_build"
+      },
+      {
+        "code": "no-any-expr",
         "column": 11,
         "message": "Expression type contains \"Any\" (has type \"list[(list[Any (from unimported type)], Optional[str])]\")",
-        "offset": 21,
+        "offset": 16,
         "target": "mypyc.build.mypyc_build"
       },
       {
@@ -28270,7 +28529,7 @@
       {
         "code": "no-any-expr",
         "column": 80,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.codegen.emitclass.generate_slots"
       }
@@ -28302,28 +28561,28 @@
       {
         "code": "no-any-expr",
         "column": 9,
-        "message": "Expression type contains \"Any\" (has type \"type[list[Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[list[Any]]\")",
         "offset": 60,
         "target": "mypyc.codegen.emitmodule"
       },
       {
         "code": "no-any-expr",
         "column": 9,
-        "message": "Expression type contains \"Any\" (has type \"type[list[Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[list[Any]]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule"
       },
       {
         "code": "no-any-expr",
         "column": 9,
-        "message": "Expression type contains \"Any\" (has type \"type[list[Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[list[Any]]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule"
       },
       {
         "code": "no-any-expr",
         "column": 9,
-        "message": "Expression type contains \"Any\" (has type \"type[list[Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"type[list[Any]]\")",
         "offset": 0,
         "target": "mypyc.codegen.emitmodule"
       },
@@ -29085,1169 +29344,1169 @@
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (int, Any (special form))\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (int, Any)\")",
         "offset": 279,
         "target": "mypyc.ir.class_ir.ClassIR.concrete_subclasses"
       },
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression type contains \"Any\" (has type \"(int, Any (special form))\")",
+        "message": "Expression type contains \"Any\" (has type \"(int, Any)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.concrete_subclasses"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.concrete_subclasses"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.concrete_subclasses"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression type contains \"Any\" (has type \"Any (special form) | list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"Any | list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.concrete_subclasses"
       },
       {
         "code": "no-any-expr",
         "column": 65,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.concrete_subclasses"
       },
       {
         "code": "no-any-expr",
         "column": 70,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.concrete_subclasses"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 3,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 15,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 3,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 3,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 7,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 4,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 29,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 6,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, Optional[list[Any (special form)]])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, Optional[list[Any]])\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression type contains \"Any\" (has type \"Optional[list[Any (special form)]]\")",
+        "message": "Expression type contains \"Any\" (has type \"Optional[list[Any]]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 7,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 76,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 13,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression type contains \"Any\" (has type \"Generator[(Any (special form), RType), None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[(Any, RType), None, None]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), RType)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, RType)\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), RType)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, RType)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression type contains \"Any\" (has type \"Generator[(Any (special form), FuncDecl), None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[(Any, FuncDecl), None, None]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), FuncDecl)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, FuncDecl)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), FuncDecl)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, FuncDecl)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 87,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 87,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 87,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 87,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression type contains \"Any\" (has type \"Generator[(Any (special form), FuncIR), None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[(Any, FuncIR), None, None]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), FuncIR)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, FuncIR)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), FuncIR)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, FuncIR)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 51,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression type contains \"Any\" (has type \"Generator[((ClassIR, Any (special form)), FuncIR), None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[((ClassIR, Any), FuncIR), None, None]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"((ClassIR, Any (special form)), FuncIR)\")",
+        "message": "Expression type contains \"Any\" (has type \"((ClassIR, Any), FuncIR)\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"((ClassIR, Any (special form)), FuncIR)\")",
+        "message": "Expression type contains \"Any\" (has type \"((ClassIR, Any), FuncIR)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression type contains \"Any\" (has type \"(ClassIR, Any (special form))\")",
+        "message": "Expression type contains \"Any\" (has type \"(ClassIR, Any)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression type contains \"Any\" (has type \"(ClassIR, Any (special form))\")",
+        "message": "Expression type contains \"Any\" (has type \"(ClassIR, Any)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 26,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression type contains \"Any\" (has type \"Generator[(Any (special form), RType), None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[(Any, RType), None, None]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 39,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), RType)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, RType)\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), RType)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, RType)\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression type contains \"Any\" (has type \"Generator[(Any (special form), (FuncIR, Optional[FuncIR])), None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[(Any, (FuncIR, Optional[FuncIR])), None, None]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), (FuncIR, Optional[FuncIR]))\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, (FuncIR, Optional[FuncIR]))\")",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), (FuncIR, Optional[FuncIR]))\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, (FuncIR, Optional[FuncIR]))\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 28,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 64,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 64,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 64,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 64,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 5,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 48,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 20,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 5,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 17,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 35,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 43,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 56,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.class_ir.ClassIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 20,
         "target": "mypyc.ir.class_ir.serialize_vtable_entry"
       },
       {
         "code": "no-any-expr",
         "column": 7,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 14,
         "target": "mypyc.ir.class_ir.deserialize_vtable_entry"
       }
@@ -30256,105 +30515,105 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 38,
         "target": "mypyc.ir.func_ir.RuntimeArg.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 26,
         "target": "mypyc.ir.func_ir.FuncSignature.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 0,
         "target": "mypyc.ir.func_ir.FuncSignature.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 24,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.func_ir.FuncSignature.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 5,
         "target": "mypyc.ir.func_ir.FuncSignature.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 36,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.func_ir.FuncSignature.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 75,
         "target": "mypyc.ir.func_ir.FuncDecl.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 47,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 15,
         "target": "mypyc.ir.func_ir.FuncDecl.get_id_from_json"
       },
       {
         "code": "no-any-expr",
         "column": 67,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.func_ir.FuncDecl.get_id_from_json"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypyc.ir.func_ir.FuncDecl.get_id_from_json"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.func_ir.FuncDecl.get_id_from_json"
       },
       {
         "code": "no-any-expr",
         "column": 19,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.func_ir.FuncDecl.get_id_from_json"
       },
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypyc.ir.func_ir.FuncDecl.get_id_from_json"
       },
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.func_ir.FuncDecl.get_id_from_json"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 82,
         "target": "mypyc.ir.func_ir.FuncIR.serialize"
       }
@@ -30363,175 +30622,175 @@
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 29,
         "target": "mypyc.ir.module_ir.ModuleIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 3,
         "target": "mypyc.ir.module_ir.ModuleIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypyc.ir.module_ir.ModuleIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 23,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression type contains \"Any\" (has type \"(str, list[Any (special form)])\")",
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
         "offset": 1,
         "target": "mypyc.ir.module_ir.ModuleIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 8,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 33,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 12,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 13,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), RType)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, RType)\")",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 14,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.ModuleIR.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 21,
         "target": "mypyc.ir.module_ir.deserialize_modules"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypyc.ir.module_ir.deserialize_modules"
       },
       {
         "code": "no-any-expr",
         "column": 25,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.deserialize_modules"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.deserialize_modules"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.module_ir.deserialize_modules"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 7,
         "target": "mypyc.ir.module_ir.deserialize_modules"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 1,
         "target": "mypyc.ir.module_ir.deserialize_modules"
       }
@@ -30656,56 +30915,56 @@
       {
         "code": "no-any-expr",
         "column": 9,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 90,
         "target": "mypyc.ir.rtypes.deserialize_type"
       },
       {
         "code": "no-any-expr",
         "column": 9,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 2,
         "target": "mypyc.ir.rtypes.deserialize_type"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 419,
         "target": "mypyc.ir.rtypes.RTuple.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 4,
         "target": "mypyc.ir.rtypes.RTuple.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.rtypes.RTuple.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 15,
-        "message": "Expression type contains \"Any\" (has type \"dict[str, Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 217,
         "target": "mypyc.ir.rtypes.RUnion.serialize"
       },
       {
         "code": "no-any-expr",
         "column": 16,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 4,
         "target": "mypyc.ir.rtypes.RUnion.deserialize"
       },
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.ir.rtypes.RUnion.deserialize"
       }
@@ -30762,7 +31021,7 @@
       {
         "code": "no-any-expr",
         "column": 45,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 140,
         "target": "mypyc.irbuild.expression.transform_member_expr"
       }
@@ -30787,14 +31046,14 @@
       {
         "code": "no-any-expr",
         "column": 30,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any (special form)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
         "offset": 157,
         "target": "mypyc.irbuild.function.gen_func_item"
       },
       {
         "code": "no-any-expr",
         "column": 40,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.irbuild.function.gen_func_item"
       }
@@ -31282,35 +31541,35 @@
       {
         "code": "no-any-expr",
         "column": 42,
-        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (Any (special form), Any (special form))\")",
+        "message": "Expression type contains \"Any\" (has type \"(Untyped) -> (Any, Any)\")",
         "offset": 70,
         "target": "mypyc.test.test_analysis.TestAnalysis.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 52,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), Any (special form))\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, Any)\")",
         "offset": 0,
         "target": "mypyc.test.test_analysis.TestAnalysis.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.test.test_analysis.TestAnalysis.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.test.test_analysis.TestAnalysis.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 65,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.test.test_analysis.TestAnalysis.run_case"
       }
@@ -31402,14 +31661,14 @@
       {
         "code": "no-any-expr",
         "column": 57,
-        "message": "Expression type contains \"Any\" (has type \"list[Any (special form)]\")",
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
         "offset": 53,
         "target": "mypyc.test.test_exceptions.TestExceptionTransform.run_case"
       },
       {
         "code": "no-any-expr",
         "column": 63,
-        "message": "Expression type contains \"Any\" (has type \"Generator[Any (special form), None, None]\")",
+        "message": "Expression type contains \"Any\" (has type \"Generator[Any, None, None]\")",
         "offset": 0,
         "target": "mypyc.test.test_exceptions.TestExceptionTransform.run_case"
       }
@@ -31658,28 +31917,28 @@
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
       {
         "code": "no-any-expr",
         "column": 53,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
@@ -31721,28 +31980,28 @@
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
       {
         "code": "no-any-expr",
         "column": 61,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.test.test_run.fix_native_line_number"
       },
@@ -32129,14 +32388,14 @@
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"((Any (special form), Any (special form)), Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"((Any, Any), Any)\")",
         "offset": 1,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"((Any (special form), Any (special form)), Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"((Any, Any), Any)\")",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
@@ -32164,7 +32423,7 @@
       {
         "code": "no-any-expr",
         "column": 34,
-        "message": "Expression type contains \"Any\" (has type \"zip[((Any (special form), Any (special form)), Any)]\")",
+        "message": "Expression type contains \"Any\" (has type \"zip[((Any, Any), Any)]\")",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
@@ -32318,35 +32577,35 @@
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(int, (Any (special form), Any))\")",
+        "message": "Expression type contains \"Any\" (has type \"(int, (Any, Any))\")",
         "offset": 1,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(int, (Any (special form), Any))\")",
+        "message": "Expression type contains \"Any\" (has type \"(int, (Any, Any))\")",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, Any)\")",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression type contains \"Any\" (has type \"(Any (special form), Any)\")",
+        "message": "Expression type contains \"Any\" (has type \"(Any, Any)\")",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
       {
         "code": "no-any-expr",
         "column": 8,
-        "message": "Expression has type \"Any (special form)\"",
+        "message": "Expression has type \"Any\"",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
@@ -32360,14 +32619,14 @@
       {
         "code": "no-any-expr",
         "column": 27,
-        "message": "Expression type contains \"Any\" (has type \"enumerate[(Any (special form), Any)]\")",
+        "message": "Expression type contains \"Any\" (has type \"enumerate[(Any, Any)]\")",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },
       {
         "code": "no-any-expr",
         "column": 37,
-        "message": "Expression type contains \"Any\" (has type \"zip[(Any (special form), Any)]\")",
+        "message": "Expression type contains \"Any\" (has type \"zip[(Any, Any)]\")",
         "offset": 0,
         "target": "mypyc.test.test_serialization.assert_blobs_same"
       },

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -12,6 +12,7 @@ from typing import (
 from typing_extensions import Final, TypeAlias as _TypeAlias
 
 from mypy.backports import nullcontext
+from mypy.checkexpr import has_untyped_type
 from mypy.errors import Errors, report_internal_error
 from mypy.nodes import (
     SymbolTable, Statement, MypyFile, Var, Expression, Lvalue, Node,
@@ -38,7 +39,7 @@ from mypy.types import (
     is_named_instance, union_items, TypeQuery, LiteralType,
     is_optional, remove_optional, TypeTranslator, StarType, get_proper_type, ProperType,
     get_proper_types, is_literal_type, TypeAliasType, TypeGuardedType, ParamSpecType,
-    is_unannotated_any,
+    is_unannotated_any, UntypedType,
 )
 from mypy.sametypes import is_same_type
 from mypy.messages import (
@@ -819,7 +820,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 super_types.update({
                     arg: UnionType.make_union(arg_type) for arg, arg_type in item_arg_types.items()
                 })
-                any_ = AnyType(TypeOfAny.unannotated)
+                any_ = UntypedType()
                 if defn.unanalyzed_type:
                     assert isinstance(defn.unanalyzed_type, CallableType)
                     assert isinstance(defn.type, CallableType)
@@ -988,7 +989,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                         else:
                             arg_types.append(super_type.arg_types[super_i])
                     elif not defn.type:
-                        arg_types.append(AnyType(TypeOfAny.unannotated))
+                        arg_types.append(UntypedType())
                 if defn.type:
                     assert isinstance(defn.type, CallableType)
                     if isinstance(get_proper_type(defn.type.ret_type), AnyType):
@@ -2351,6 +2352,33 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                     return True
         return False
 
+    def check_assignment_for_untyped(self, lvalues: List[Lvalue]):
+        for l in lvalues:
+            if isinstance(l, TupleExpr):
+                self.check_assignment_for_untyped(l.items)
+            elif isinstance(l, NameExpr) and l.node:
+                if not isinstance(l.node, Var):
+                    continue
+                t = get_proper_type(l.node.type)
+                if not t:
+                    # No type? it's either deferred or can't be inferred (handled elsewhere)
+                    continue
+                if is_unannotated_any(t) or isinstance(t, UntypedType):
+                    self.msg.untyped_name_usage(l.name, l)
+            elif isinstance(l, MemberExpr):
+                # FuncDef and TypeInfo are reported in other places
+                if not l.node or not isinstance(l.node, Var):
+                    continue
+                t = get_proper_type(l.node.type)
+                if not t:
+                    # No type? it's either deferred or can't be inferred (handled elsewhere)
+                    continue
+                if is_unannotated_any(t) or isinstance(t, UntypedType):
+                    self.msg.untyped_name_usage(l.name, l)
+            elif isinstance(l, IndexExpr):
+                if not l.method_type or has_untyped_type(l.method_type):
+                    self.msg.untyped_indexed_assignment(l)
+
     def visit_assignment_stmt(self, s: AssignmentStmt) -> None:
         """Type check an assignment statement.
 
@@ -2362,7 +2390,6 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if not (s.is_alias_def and self.is_stub):
             with self.enter_final_context(s.is_final_def):
                 self.check_assignment(s.lvalues[-1], s.rvalue, s.type is None, s.new_syntax)
-
         if s.is_alias_def:
             self.check_type_alias_rvalue(s)
 
@@ -2392,6 +2419,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if (s.is_final_def and s.type and not has_no_typevars(s.type)
                 and self.scope.active_class() is not None):
             self.fail(message_registry.DEPENDENT_FINAL_IN_CLASS_BODY, s)
+        if (
+            not self.current_node_deferred
+            and self.options.disallow_untyped_calls and not isinstance(s.rvalue, TempNode)
+        ):
+            self.check_assignment_for_untyped(s.lvalues)
 
     def check_type_alias_rvalue(self, s: AssignmentStmt) -> None:
         if not (self.is_stub and isinstance(s.rvalue, OpExpr) and s.rvalue.op == '|'):
@@ -4104,7 +4136,10 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             c.column = s.column
             self.expr_checker.accept(c, allow_none_return=True)
         else:
-            s.expr.accept(self.expr_checker)
+            if not self.current_node_deferred:
+                t = get_proper_type(s.expr.accept(self.expr_checker))
+                if isinstance(t, UntypedType):
+                    self.msg.untyped_name_usage(s.expr.name, s.expr)  # type: ignore
             for elt in flatten(s.expr):
                 if isinstance(elt, NameExpr):
                     self.binder.assign_type(elt, DeletedType(source=elt.name),
@@ -5632,11 +5667,11 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if not isinstance(typ, PartialType):
             return typ
         if typ.type is None:
-            return UnionType.make_union([AnyType(TypeOfAny.unannotated), NoneType()])
+            return UnionType.make_union([UntypedType(), NoneType()])
         else:
             return Instance(
                 typ.type,
-                [AnyType(TypeOfAny.unannotated)] * len(typ.type.type_vars))
+                [UntypedType()] * len(typ.type.type_vars))
 
     def is_defined_in_base_class(self, var: Var) -> bool:
         if var.info:

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -4134,8 +4134,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         else:
             if not self.current_node_deferred:
                 t = get_proper_type(s.expr.accept(self.expr_checker))
-                if isinstance(t, UntypedType):
-                    self.msg.untyped_name_usage(s.expr.name, s.expr)  # type: ignore
+                if isinstance(t, UntypedType) and isinstance(s.expr, (NameExpr, MemberExpr)):
+                    self.msg.untyped_name_usage(s.expr.name, s.expr)
             for elt in flatten(s.expr):
                 if isinstance(elt, NameExpr):
                     self.binder.assign_type(elt, DeletedType(source=elt.name),

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -3474,7 +3474,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 self.check_subtype(rvalue_type, lvalue_type, context, msg,
                                    '{} has type'.format(rvalue_name),
                                    '{} has type'.format(lvalue_name), code=code)
-                if isinstance(rvalue, (NameExpr, MemberExpr)):
+                if not self.current_node_deferred and isinstance(rvalue, (NameExpr, MemberExpr)):
                     if (
                         self.options.disallow_untyped_calls
                         and isinstance(rvalue_type, UntypedType)

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -2356,20 +2356,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         for l in lvalues:
             if isinstance(l, TupleExpr):
                 self.check_assignment_for_untyped(l.items)
-            elif isinstance(l, NameExpr) and l.node:
-                if not isinstance(l.node, Var):
-                    continue
-                t = get_proper_type(l.node.type)
-                if not t:
-                    # No type? it's either deferred or can't be inferred (handled elsewhere)
-                    continue
-                if is_unannotated_any(t) or isinstance(t, UntypedType):
-                    self.msg.untyped_name_usage(l.name, l)
-            elif isinstance(l, MemberExpr):
-                # FuncDef and TypeInfo are reported in other places
-                if not l.node or not isinstance(l.node, Var):
-                    continue
-                t = get_proper_type(l.node.type)
+            elif isinstance(l, (NameExpr, MemberExpr)):
+                t = get_proper_type(self.type_map.get(l))
                 if not t:
                     # No type? it's either deferred or can't be inferred (handled elsewhere)
                     continue
@@ -3486,6 +3474,14 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
                 self.check_subtype(rvalue_type, lvalue_type, context, msg,
                                    '{} has type'.format(rvalue_name),
                                    '{} has type'.format(lvalue_name), code=code)
+                if isinstance(rvalue, (NameExpr, MemberExpr)):
+                    if (
+                        self.options.disallow_untyped_calls
+                        and isinstance(rvalue_type, UntypedType)
+                    ):
+                        self.msg.untyped_name_usage(rvalue.name, rvalue)
+                    elif self.options.disallow_any_expr and isinstance(rvalue_type, AnyType):
+                        self.msg.disallowed_any_type(rvalue_type, rvalue)
             return rvalue_type
 
     def check_member_assignment(self, instance_type: Type, attribute_type: Type,

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -20,7 +20,7 @@ from mypy.types import (
     PartialType, DeletedType, UninhabitedType, TypeType, TypeOfAny, LiteralType, LiteralValue,
     is_named_instance, FunctionLike, ParamSpecType, ParamSpecFlavor,
     StarType, is_optional, remove_optional, is_generic_instance, get_proper_type, ProperType,
-    get_proper_types, flatten_nested_unions, LITERAL_TYPE_NAMES,
+    get_proper_types, flatten_nested_unions, LITERAL_TYPE_NAMES, UntypedType,
 )
 from mypy.nodes import (
     NameExpr, RefExpr, Var, FuncDef, OverloadedFuncDef, TypeInfo, CallExpr,
@@ -345,7 +345,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
                 isinstance(callee_type, CallableType)):
             if callee_type.implicit:
                 self.msg.untyped_function_call(callee_type, e)
-            elif not callee_type.fully_typed:
+            elif has_untyped_type(callee_type):
                 # check for partially typed defs
                 if isinstance(callee_type.definition, FuncDef):
                     if callee_type.definition.info:
@@ -1307,7 +1307,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         else:
             # In dynamically typed functions use implicit 'Any' types for
             # type variables.
-            inferred_args = [AnyType(TypeOfAny.unannotated)] * len(callee_type.variables)
+            inferred_args = [UntypedType()] * len(callee_type.variables)
         return self.apply_inferred_arguments(callee_type, inferred_args,
                                              context)
 
@@ -2072,7 +2072,9 @@ class ExpressionChecker(ExpressionVisitor[Type]):
     def check_any_type_call(self, args: List[Expression], callee: Type) -> Tuple[Type, Type]:
         self.infer_arg_types_in_empty_context(args)
         callee = get_proper_type(callee)
-        if isinstance(callee, AnyType):
+        if isinstance(callee, UntypedType):
+            return UntypedType(), UntypedType()
+        elif isinstance(callee, AnyType):
             return (AnyType(TypeOfAny.from_another_any, source_any=callee),
                     AnyType(TypeOfAny.from_another_any, source_any=callee))
         else:
@@ -3721,7 +3723,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
         """
 
         if not self.chk.in_checked_function():
-            return AnyType(TypeOfAny.unannotated)
+            return UntypedType()
         elif len(e.call.args) == 0:
             if self.chk.options.python_version[0] == 2:
                 self.chk.fail(message_registry.TOO_FEW_ARGS_FOR_SUPER, e)
@@ -4008,6 +4010,7 @@ class ExpressionChecker(ExpressionVisitor[Type]):
             self.msg.disallowed_any_type(typ, node)
 
         if not self.chk.in_checked_function() or self.chk.current_node_deferred:
+            # this is more of a placeholder I think
             return AnyType(TypeOfAny.unannotated)
         else:
             return typ
@@ -4281,6 +4284,11 @@ def has_any_type(
     return t.accept(HasAnyType(ignore_in_type_obj, ignore_any_from_error=ignore_any_from_error))
 
 
+def has_untyped_type(t: Type, ignore_in_type_obj: bool = False) -> bool:
+    """Whether t contains an untyped type"""
+    return t.accept(HasUntypedType())
+
+
 class HasAnyType(types.TypeQuery[bool]):
     def __init__(self, ignore_in_type_obj: bool, ignore_any_from_error: bool = False) -> None:
         super().__init__(any)
@@ -4300,6 +4308,15 @@ class HasAnyType(types.TypeQuery[bool]):
         if self.ignore_in_type_obj and t.is_type_obj():
             return False
         return super().visit_callable_type(t)
+
+
+class HasUntypedType(types.TypeQuery[bool]):
+    def __init__(self) -> None:
+        super().__init__(any)
+
+    def visit_any(self, t: AnyType) -> bool:
+        return isinstance(t, UntypedType) or t.type_of_any in (
+            TypeOfAny.unannotated, TypeOfAny.from_omitted_generics)
 
 
 def has_coroutine_decorator(t: Type) -> bool:

--- a/mypy/checkexpr.py
+++ b/mypy/checkexpr.py
@@ -4285,7 +4285,7 @@ def has_any_type(
 
 
 def has_untyped_type(t: Type, ignore_in_type_obj: bool = False) -> bool:
-    """Whether t contains an untyped type"""
+    """Whether ``t`` contains an untyped type"""
     return t.accept(HasUntypedType())
 
 

--- a/mypy/checkmember.py
+++ b/mypy/checkmember.py
@@ -7,7 +7,7 @@ from mypy.types import (
     Type, Instance, AnyType, TupleType, TypedDictType, CallableType, FunctionLike,
     TypeVarLikeType, Overloaded, TypeVarType, UnionType, PartialType, TypeOfAny, LiteralType,
     DeletedType, NoneType, TypeType, has_type_vars, get_proper_type, ProperType, ParamSpecType,
-    ENUM_REMOVED_PROPS
+    ENUM_REMOVED_PROPS, UntypedType
 )
 from mypy.nodes import (
     TypeInfo, FuncBase, Var, FuncDef, SymbolNode, SymbolTable, Context,
@@ -145,6 +145,9 @@ def _analyze_member_access(name: str,
     typ = get_proper_type(typ)
     if isinstance(typ, Instance):
         return analyze_instance_member_access(name, typ, mx, override_info)
+    elif isinstance(typ, UntypedType):
+        # The base object isn't typed.
+        return UntypedType()
     elif isinstance(typ, AnyType):
         # The base object has dynamic type.
         return AnyType(TypeOfAny.from_another_any, source_any=typ)

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -110,6 +110,11 @@ NO_UNTYPED_CALL: Final = ErrorCode(
     "Disallow calling functions without type annotations from annotated functions",
     "General",
 )
+NO_UNTYPED_USAGE: Final = ErrorCode(
+    "no-untyped-usage",
+    "Disallow using members without type annotations",
+    "General",
+)
 REDUNDANT_CAST: Final = ErrorCode(
     "redundant-cast", "Check that cast changes type of expression", "General"
 )

--- a/mypy/exprtotype.py
+++ b/mypy/exprtotype.py
@@ -9,8 +9,8 @@ from mypy.nodes import (
 )
 from mypy.fastparse import parse_type_string
 from mypy.types import (
-    Type, UnboundType, TypeList, EllipsisType, AnyType, CallableArgument, TypeOfAny,
-    RawExpressionType, ProperType, UnionType, ANNOTATED_TYPE_NAMES,
+    Type, UnboundType, TypeList, EllipsisType,  CallableArgument,
+    RawExpressionType, ProperType, UnionType, ANNOTATED_TYPE_NAMES, UntypedType,
 )
 from mypy.options import Options
 
@@ -106,7 +106,7 @@ def expr_to_unanalyzed_type(expr: Expression,
 
         # Go through the constructor args to get its name and type.
         name = None
-        default_type = AnyType(TypeOfAny.unannotated)
+        default_type = UntypedType()
         typ: Type = default_type
         for i, arg in enumerate(expr.args):
             if expr.arg_names[i] is not None:

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -38,7 +38,7 @@ from mypy.patterns import (
 )
 from mypy.types import (
     Type, CallableType, AnyType, UnboundType, TupleType, TypeList, EllipsisType, CallableArgument,
-    TypeOfAny, Instance, RawExpressionType, ProperType, UnionType,
+    TypeOfAny, Instance, RawExpressionType, ProperType, UnionType, UntypedType,
 )
 from mypy import defaults
 from mypy import message_registry, errorcodes as codes
@@ -780,7 +780,7 @@ class ASTConverter:
                         self.fail(message_registry.DUPLICATE_TYPE_SIGNATURES, lineno, n.col_offset)
                     arg_types = [a.type_annotation
                                  if a.type_annotation is not None
-                                 else AnyType(TypeOfAny.unannotated)
+                                 else UntypedType()
                                  for a in args]
                 else:
                     # PEP 484 disallows both type annotations and type comments
@@ -790,7 +790,7 @@ class ASTConverter:
                                                      line=lineno,
                                                      override_column=n.col_offset)
                                        .translate_expr_list(func_type_ast.argtypes))
-                    arg_types = [a if a is not None else AnyType(TypeOfAny.unannotated)
+                    arg_types = [a if a is not None else UntypedType()
                                 for a in translated_args]
                 return_type = TypeConverter(self.errors,
                                             line=lineno).visit(func_type_ast.returns)
@@ -829,11 +829,11 @@ class ASTConverter:
                           blocker=False)
             else:
                 func_type = CallableType([a if a is not None else
-                                          AnyType(TypeOfAny.unannotated) for a in arg_types],
+                                          UntypedType() for a in arg_types],
                                          arg_kinds,
                                          arg_names,
                                          return_type if return_type is not None else
-                                         AnyType(TypeOfAny.unannotated),
+                                         UntypedType(),
                                          _dummy_fallback)
 
         func_def = FuncDef(

--- a/mypy/fastparse2.py
+++ b/mypy/fastparse2.py
@@ -42,7 +42,7 @@ from mypy.nodes import (
 )
 from mypy.types import (
     Type, CallableType, AnyType, UnboundType, EllipsisType, TypeOfAny, Instance,
-    ProperType
+    ProperType, UntypedType
 )
 from mypy import message_registry, errorcodes as codes
 from mypy.errors import Errors
@@ -393,13 +393,13 @@ class ASTConverter:
                         isinstance(func_type_ast.argtypes[0], ast3.Ellipsis)):
                     arg_types = [a.type_annotation
                                  if a.type_annotation is not None
-                                 else AnyType(TypeOfAny.unannotated)
+                                 else UntypedType()
                                  for a in args]
                 else:
                     # PEP 484 disallows both type annotations and type comments
                     if any(a.type_annotation is not None for a in args):
                         self.fail(message_registry.DUPLICATE_TYPE_SIGNATURES, lineno, n.col_offset)
-                    arg_types = [a if a is not None else AnyType(TypeOfAny.unannotated) for
+                    arg_types = [a if a is not None else UntypedType() for
                                  a in converter.translate_expr_list(func_type_ast.argtypes)]
                 return_type = converter.visit(func_type_ast.returns)
 
@@ -432,7 +432,7 @@ class ASTConverter:
                 self.fail('Type signature has too few arguments', lineno, n.col_offset,
                           blocker=False)
             else:
-                any_type = AnyType(TypeOfAny.unannotated)
+                any_type = UntypedType()
                 func_type = CallableType([a if a is not None else any_type for a in arg_types],
                                         arg_kinds,
                                         arg_names,

--- a/mypy/maptype.py
+++ b/mypy/maptype.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 
 from mypy.expandtype import expand_type
 from mypy.nodes import TypeInfo
-from mypy.types import Type, TypeVarId, Instance, AnyType, TypeOfAny, ProperType
+from mypy.types import Type, TypeVarId, Instance, AnyType, TypeOfAny, ProperType, UntypedType
 
 
 def map_instance_to_supertype(instance: Instance,
@@ -89,7 +89,7 @@ def map_instance_to_direct_supertypes(instance: Instance,
     else:
         # Relationship with the supertype not specified explicitly. Use dynamic
         # type arguments implicitly.
-        any_type = AnyType(TypeOfAny.unannotated)
+        any_type = UntypedType()
         return [Instance(supertype, [any_type] * len(supertype.type_vars))]
 
 

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -31,7 +31,8 @@ from mypy.nodes import (
     TypeInfo, Context, MypyFile, FuncDef, reverse_builtin_aliases,
     ArgKind, ARG_POS, ARG_OPT, ARG_NAMED, ARG_NAMED_OPT, ARG_STAR, ARG_STAR2,
     ReturnStmt, NameExpr, Var, CONTRAVARIANT, COVARIANT, SymbolNode,
-    CallExpr, IndexExpr, StrExpr, SymbolTable, TempNode, SYMBOL_FUNCBASE_TYPES
+    CallExpr, IndexExpr, StrExpr, SymbolTable, TempNode, SYMBOL_FUNCBASE_TYPES, MemberExpr,
+    Expression
 )
 from mypy.operators import op_methods, op_methods_to_symbols
 from mypy.subtypes import (
@@ -58,6 +59,7 @@ TYPES_FOR_UNIMPORTED_HINTS: Final = {
     'typing.TypeVar',
     'typing.Union',
     'typing.cast',
+    'basedtyping.Untyped',
 }
 
 
@@ -416,12 +418,27 @@ class MessageBuilder:
                   code=codes.NO_UNTYPED_CALL)
         return AnyType(TypeOfAny.from_error)
 
-    def partially_typed_function_call(self, callee: CallableType, context: Context) -> Type:
-        name = callable_name(callee) or '(unknown)'
+    def partially_typed_function_call(self, callee: CallableType, context: CallExpr):
+        name = callable_name(callee) or f'"{context.callee.name}"' or '(unknown)'  # type: ignore
         self.fail(f'Call to incomplete function {name} in typed context', context,
                   code=codes.NO_UNTYPED_CALL)
         self.note(f'Type is "{callee}"', context)
-        return AnyType(TypeOfAny.from_error)
+
+    def untyped_indexed_assignment(self, context: IndexExpr):
+        # don't care about CallExpr because they are handled by partially_typed_function_call
+        if isinstance(context.base, (NameExpr, MemberExpr)):
+            message = f'Untyped indexed-assignment to "{context.base.name}" in typed context'
+            self.fail(message, context, code=codes.NO_UNTYPED_USAGE)
+
+    def untyped_name_usage(self, name: Union[str, Expression], context: Context):
+        if isinstance(name, NameExpr):
+            name = name.name
+        elif not isinstance(name, str):
+            self.fail('Usage of untyped name in typed context', context,
+                      code=codes.NO_UNTYPED_USAGE)
+            return
+        self.fail(f'Usage of untyped name "{name}" in typed context', context,
+              code=codes.NO_UNTYPED_USAGE)
 
     def incompatible_argument(self,
                               n: int,
@@ -1320,7 +1337,7 @@ class MessageBuilder:
     def disallowed_any_type(self, typ: Type, context: Context) -> None:
         typ = get_proper_type(typ)
         if isinstance(typ, AnyType):
-            message = 'Expression has type "Any"'
+            message = f'Expression has type "{typ.describe()}"'
         else:
             message = 'Expression type contains "Any" (has type {})'.format(format_type(typ))
         self.fail(message, context, code=codes.NO_ANY_EXPR)
@@ -1783,7 +1800,7 @@ def format_type_inner(typ: Type,
     elif isinstance(typ, NoneType):
         return 'None'
     elif isinstance(typ, AnyType):
-        return 'Any'
+        return typ.describe()
     elif isinstance(typ, DeletedType):
         return '<deleted>'
     elif isinstance(typ, UninhabitedType):

--- a/mypy/options.py
+++ b/mypy/options.py
@@ -117,6 +117,7 @@ class Options:
         # File names, directory names or subpaths to avoid checking
         self.exclude: List[str] = []
 
+        # Based options
         self.legacy = False
         self.write_baseline = False
         self.baseline_file = defaults.BASELINE_FILE

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -99,7 +99,7 @@ from mypy.types import (
     TypeTranslator, TypeOfAny, TypeType, NoneType, PlaceholderType, TPDICT_NAMES, ProperType,
     get_proper_type, get_proper_types, TypeAliasType, TypeVarLikeType,
     PROTOCOL_NAMES, TYPE_ALIAS_NAMES, FINAL_TYPE_NAMES, FINAL_DECORATOR_NAMES, REVEAL_TYPE_NAMES,
-    is_named_instance, is_unannotated_any,
+    is_named_instance, is_unannotated_any, UntypedType,
 )
 from mypy.typeops import function_type, get_type_vars, infer_impl_from_parts
 from mypy.type_visitor import TypeQuery
@@ -657,7 +657,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                         defn.type = defn.type.copy_modified(ret_type=NoneType())
                 elif self.options.infer_function_types:
                     defn.type = CallableType(
-                        [AnyType(TypeOfAny.unannotated) for _ in defn.arg_kinds],
+                        [UntypedType() for _ in defn.arg_kinds],
                         defn.arg_kinds,
                         defn.arg_names,
                         NoneType(),
@@ -671,7 +671,7 @@ class SemanticAnalyzer(NodeVisitor[None],
                 elif self.options.disallow_untyped_defs:
                     self_type = fill_typevars_with_any(defn.info)
                     defn.type = CallableType(
-                        [AnyType(TypeOfAny.unannotated) for _ in defn.arg_kinds],
+                        [UntypedType() for _ in defn.arg_kinds],
                         defn.arg_kinds,
                         defn.arg_names,
                         self_type,
@@ -4668,7 +4668,7 @@ class SemanticAnalyzer(NodeVisitor[None],
         if args is not None:
             # TODO: assert len(args) == len(node.defn.type_vars)
             return Instance(node, args)
-        return Instance(node, [AnyType(TypeOfAny.unannotated)] * len(node.defn.type_vars))
+        return Instance(node, [UntypedType()] * len(node.defn.type_vars))
 
     def builtin_type(self, fully_qualified_name: str) -> Instance:
         """Legacy function -- use named_type() instead."""
@@ -5621,16 +5621,16 @@ def infer_fdef_types_from_defaults(defn: Union[FuncDef, Decorator], self: Semant
                 if arg.variable.is_inferred and arg.initializer:
                     arg.initializer.accept(self)
                     typ = self.analyze_simple_literal_type(arg.initializer, False)
-                arg_types.append(typ or AnyType(TypeOfAny.unannotated))
+                arg_types.append(typ or UntypedType())
         ret_type = None
         if self.options.default_return and self.options.disallow_untyped_defs:
             ret_type = NoneType()
         if any(not isinstance(get_proper_type(t), AnyType) for t in arg_types) or ret_type:
             defn.type = CallableType(arg_types
-                                     or [AnyType(TypeOfAny.unannotated) for _ in defn.arg_kinds],
+                                     or [UntypedType() for _ in defn.arg_kinds],
                                      defn.arg_kinds,
                                      defn.arg_names,
-                                     ret_type or AnyType(TypeOfAny.unannotated),
+                                     ret_type or UntypedType(),
                                      self.named_type('builtins.function'),
                                      line=defn.line,
                                      column=defn.column)

--- a/mypy/semanal_infer.py
+++ b/mypy/semanal_infer.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from mypy.nodes import Expression, Decorator, CallExpr, FuncDef, RefExpr, Var, ARG_POS
 from mypy.types import (
-    Type, CallableType, AnyType, TypeOfAny, TypeVarType, ProperType, get_proper_type
+    Type, CallableType, AnyType, TypeOfAny, TypeVarType, ProperType, get_proper_type, UntypedType
 )
 from mypy.typeops import function_type
 from mypy.typevars import has_no_typevars
@@ -84,7 +84,7 @@ def calculate_return_type(expr: Expression) -> Optional[ProperType]:
             typ = expr.node.type
             if typ is None:
                 # No signature -> default to Any.
-                return AnyType(TypeOfAny.unannotated)
+                return UntypedType()
             # Explicit Any return?
             if isinstance(typ, CallableType):
                 return get_proper_type(typ.ret_type)

--- a/mypy/semanal_namedtuple.py
+++ b/mypy/semanal_namedtuple.py
@@ -9,7 +9,7 @@ from typing_extensions import Final
 
 from mypy.types import (
     Type, TupleType, AnyType, TypeOfAny, CallableType, TypeType, TypeVarType,
-    UnboundType, LiteralType,
+    UnboundType, LiteralType, UntypedType,
 )
 from mypy.semanal_shared import (
     SemanticAnalyzerInterface, set_callable_name, calculate_tuple_fallback, PRIORITY_FALLBACKS
@@ -124,7 +124,7 @@ class NamedTupleAnalyzer:
                 name = stmt.lvalues[0].name
                 items.append(name)
                 if stmt.type is None:
-                    types.append(AnyType(TypeOfAny.unannotated))
+                    types.append(UntypedType())
                 else:
                     analyzed = self.api.anal_type(stmt.type)
                     if analyzed is None:
@@ -330,7 +330,7 @@ class NamedTupleAnalyzer:
                 if not ok:
                     return [], [], [], typename, False
         if not types:
-            types = [AnyType(TypeOfAny.unannotated) for _ in items]
+            types = [UntypedType() for _ in items]
         underscore = [item for item in items if item.startswith('_')]
         if underscore:
             self.fail('"{}()" field names cannot start with an underscore: '.format(type_name)

--- a/mypy/semanal_typeddict.py
+++ b/mypy/semanal_typeddict.py
@@ -5,7 +5,7 @@ from typing import Optional, List, Set, Tuple
 from typing_extensions import Final
 
 from mypy.types import (
-    Type, AnyType, TypeOfAny, TypedDictType, TPDICT_NAMES, RequiredType,
+    Type, TypedDictType, TPDICT_NAMES, RequiredType, UntypedType,
 )
 from mypy.nodes import (
     CallExpr, TypedDictExpr, Expression, NameExpr, Context, StrExpr, BytesExpr, UnicodeExpr,
@@ -161,7 +161,7 @@ class TypedDictAnalyzer:
                 # Append name and type in this case...
                 fields.append(name)
                 if stmt.type is None:
-                    types.append(AnyType(TypeOfAny.unannotated))
+                    types.append(UntypedType())
                 else:
                     analyzed = self.api.anal_type(stmt.type, allow_required=True)
                     if analyzed is None:

--- a/mypy/stubgen.py
+++ b/mypy/stubgen.py
@@ -171,7 +171,8 @@ class Options:
                  files: List[str],
                  verbose: bool,
                  quiet: bool,
-                 export_less: bool) -> None:
+                 export_less: bool,
+                 legacy: bool) -> None:
         # See parse_options for descriptions of the flags.
         self.pyversion = pyversion
         self.no_import = no_import
@@ -189,6 +190,7 @@ class Options:
         self.verbose = verbose
         self.quiet = quiet
         self.export_less = export_less
+        self.legacy = legacy
 
 
 class StubSource:
@@ -530,7 +532,8 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
                  _all_: Optional[List[str]], pyversion: Tuple[int, int],
                  include_private: bool = False,
                  analyzed: bool = False,
-                 export_less: bool = False) -> None:
+                 export_less: bool = False,
+                 legacy: bool = False) -> None:
         # Best known value of __all__.
         self._all_ = _all_
         self._output: List[str] = []
@@ -550,6 +553,8 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
         self.analyzed = analyzed
         # Disable implicit exports of package-internal imports?
         self.export_less = export_less
+        # Don't use based features?
+        self.legacy = legacy
         # Add imports that could be implicitly generated
         self.import_tracker.add_import_from("typing", [("NamedTuple", None)])
         # Names in __all__ are required
@@ -567,6 +572,7 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
         self.referenced_names = find_referenced_names(o)
         known_imports = {
             "_typeshed": ["Incomplete"],
+            "basedtyping": ["Untyped"],
             "typing": ["Any", "TypeVar"],
             "collections.abc": ["Generator"],
         }
@@ -690,21 +696,23 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
             return_name = 'None'
             for expr, in_assignment in all_yield_expressions(o):
                 if expr.expr is not None and not self.is_none_expr(expr.expr):
-                    self.add_typing_import('Incomplete')
-                    yield_name = 'Incomplete'
+                    yield_name = self.untyped
                 if in_assignment:
-                    self.add_typing_import('Incomplete')
-                    send_name = 'Incomplete'
+                    send_name = self.untyped
             if has_return_statement(o):
-                self.add_typing_import('Incomplete')
-                return_name = 'Incomplete'
+                return_name = self.untyped
             generator_name = self.typing_name('Generator')
             retname = f'{generator_name}[{yield_name}, {send_name}, {return_name}]'
         elif not has_return_statement(o) and not is_abstract:
-            retname = 'None'
+            retname = ''
         retfield = ''
-        if retname is not None:
-            retfield = ' -> ' + retname
+        if not self.legacy:
+            if retname is None:
+                retfield = f' -> {self.untyped}'
+            elif retname:
+                retfield = f' -> {retname}'
+        elif retname is not None:
+            retfield = ' -> ' + (retname or 'None')
 
         self.add(', '.join(args))
         self.add("){}: ...\n".format(retfield))
@@ -955,18 +963,16 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
             list_items = cast(List[StrExpr], rvalue.args[1].items)
             items = [item.value for item in list_items]
         else:
-            self.add('%s%s: Incomplete' % (self._indent, lvalue.name))
-            self.import_tracker.require_name('Incomplete')
+            self.add(f'%s%s: {self.untyped}' % (self._indent, lvalue.name))
             return
         self.import_tracker.require_name('NamedTuple')
         self.add('{}class {}(NamedTuple):'.format(self._indent, lvalue.name))
         if len(items) == 0:
             self.add(' ...\n')
         else:
-            self.import_tracker.require_name('Incomplete')
             self.add('\n')
             for item in items:
-                self.add('{}    {}: Incomplete\n'.format(self._indent, item))
+                self.add('{}    {}: {}\n'.format(self._indent, item, self.untyped))
         self._state = CLASS
 
     def is_alias_expression(self, expr: Expression, top_level: bool = True) -> bool:
@@ -1146,13 +1152,22 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
         else:
             return name
 
-    def add_typing_import(self, name: str) -> None:
+    @property
+    def untyped(self) -> str:
+        if not self.legacy:
+            result = "Untyped"
+        else:
+            result = "Incomplete"
+        return self.add_typing_import(result)
+
+    def add_typing_import(self, name: str) -> str:
         """Add a name to be imported from typing, unless it's imported already.
 
         The import will be internal to the stub.
         """
         name = self.typing_name(name)
         self.import_tracker.require_name(name)
+        return name
 
     def add_abc_import(self, name: str) -> None:
         """Add a name to be imported from collections.abc, unless it's imported already.
@@ -1221,11 +1236,9 @@ class StubGenerator(mypy.traverser.TraverserVisitor):
             return 'bool'
         if can_infer_optional and \
                 isinstance(rvalue, NameExpr) and rvalue.name == 'None':
-            self.add_typing_import('Incomplete')
-            return '{} | None'.format(self.typing_name('Incomplete'))
+            return '{} | None'.format(self.untyped)
         if can_be_any:
-            self.add_typing_import('Incomplete')
-            return self.typing_name('Incomplete')
+            return self.untyped
         else:
             return ''
 
@@ -1522,7 +1535,8 @@ def generate_stub_from_ast(mod: StubSource,
                            parse_only: bool = False,
                            pyversion: Tuple[int, int] = defaults.PYTHON3_VERSION,
                            include_private: bool = False,
-                           export_less: bool = False) -> None:
+                           export_less: bool = False,
+                           legacy: bool = False) -> None:
     """Use analysed (or just parsed) AST to generate type stub for single file.
 
     If directory for target doesn't exist it will created. Existing stub
@@ -1532,7 +1546,8 @@ def generate_stub_from_ast(mod: StubSource,
                         pyversion=pyversion,
                         include_private=include_private,
                         analyzed=not parse_only,
-                        export_less=export_less)
+                        export_less=export_less,
+                        legacy=legacy)
     assert mod.ast is not None, "This function must be used only with analyzed modules"
     mod.ast.accept(gen)
 
@@ -1588,7 +1603,8 @@ def generate_stubs(options: Options) -> None:
             generate_stub_from_ast(mod, target,
                                    options.parse_only, options.pyversion,
                                    options.include_private,
-                                   options.export_less)
+                                   options.export_less,
+                                   options.legacy)
 
     # Separately analyse C modules using different logic.
     for mod in c_modules:
@@ -1659,6 +1675,8 @@ def parse_options(args: List[str]) -> Options:
                              "Python 2 right now)")
     parser.add_argument('-o', '--output', metavar='PATH', dest='output_dir', default='out',
                         help="change the output directory [default: %(default)s]")
+    parser.add_argument("--legacy", action='store_true',
+                        help="don't used based features")
     parser.add_argument('-m', '--module', action='append', metavar='MODULE',
                         dest='modules', default=[],
                         help="generate stub for module; can repeat for more modules")
@@ -1696,7 +1714,8 @@ def parse_options(args: List[str]) -> Options:
                    files=ns.files,
                    verbose=ns.verbose,
                    quiet=ns.quiet,
-                   export_less=ns.export_less)
+                   export_less=ns.export_less,
+                   legacy=ns.legacy)
 
 
 def main() -> None:

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -1115,8 +1115,8 @@ def get_mypy_type_of_runtime_value(runtime: Any) -> Optional[mypy.types.Type]:
         # Give up on properties to avoid issues with things that are typed as attributes.
         return None
 
-    def anytype() -> mypy.types.AnyType:
-        return mypy.types.AnyType(mypy.types.TypeOfAny.unannotated)
+    def anytype() -> mypy.types.UntypedType:
+        return mypy.types.UntypedType()
 
     if isinstance(
         runtime,

--- a/mypy/subtypes.py
+++ b/mypy/subtypes.py
@@ -8,7 +8,7 @@ from mypy.types import (
     Instance, TypeVarType, CallableType, TupleType, TypedDictType, UnionType, Overloaded,
     ErasedType, PartialType, DeletedType, UninhabitedType, TypeType, is_named_instance,
     FunctionLike, TypeOfAny, LiteralType, get_proper_type, TypeAliasType, ParamSpecType,
-    UnpackType, TUPLE_LIKE_INSTANCE_NAMES,
+    UnpackType, TUPLE_LIKE_INSTANCE_NAMES, UntypedType,
 )
 import mypy.applytype
 import mypy.constraints
@@ -597,7 +597,7 @@ def is_protocol_implementation(left: Instance, right: Instance,
                 return False
             if isinstance(subtype, PartialType):
                 subtype = NoneType() if subtype.type is None else Instance(
-                    subtype.type, [AnyType(TypeOfAny.unannotated)] * len(subtype.type.type_vars)
+                    subtype.type, [UntypedType()] * len(subtype.type.type_vars)
                 )
             if not proper_subtype:
                 # Nominal check currently ignores arg names

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -562,7 +562,7 @@ def pytest_pycollect_makeitem(collector: Any, name: str,
             # Non-None result means this obj is a test case.
             # The collect method of the returned DataSuiteCollector instance will be called later,
             # with self.obj being obj.
-            return DataSuiteCollector.from_parent(  # type: ignore[no-untyped-call]
+            return DataSuiteCollector.from_parent(  # type: ignore[unused-ignore, no-untyped-call]
                 parent=collector, name=name,
             )
     return None

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -7,7 +7,7 @@ import contextlib
 
 from typing import List, Iterable, Dict, Tuple, Callable, Any, Iterator, Union
 
-from mypy import defaults
+from mypy import defaults, errorcodes
 import mypy.api as api
 
 import pytest
@@ -379,6 +379,8 @@ def parse_options(program_text: str, testcase: DataDrivenTestCase,
         flag_list: List[str] = flags.group(1).split()
         if based:
             flag_list.insert(0, '--default-return')
+        else:
+            flag_list.extend(["--disable-error-code", "no-untyped-usage"])
         flag_list.append('--no-site-packages')  # the tests shouldn't need an installed Python
         if "--local-partial-types" in flag_list:
             flag_list.remove("--local-partial-types")
@@ -396,6 +398,7 @@ def parse_options(program_text: str, testcase: DataDrivenTestCase,
             # TODO: Enable strict optional in test cases by default
             #  (requires *many* test case changes)
             options.strict_optional = False
+            options.disabled_error_codes.add(errorcodes.NO_UNTYPED_USAGE)
         options.error_summary = False
 
     # Allow custom python version to override testcase_pyversion.

--- a/mypy/test/testcheck.py
+++ b/mypy/test/testcheck.py
@@ -28,6 +28,7 @@ typecheck_files = [
     'check-based-default-return.test',
     'check-based-ignore-any-from-error.test',
     'check-based-type-render.test',
+    'check-based-untyped.test',
     'check-based-infer-function-types.test',
     'check-based-incomplete-defs.test',
     'check-union-or-syntax.test',

--- a/mypy/test/teststubgen.py
+++ b/mypy/test/teststubgen.py
@@ -555,7 +555,7 @@ class StubgenPythonSuite(DataSuite):
 
     required_out_section = True
     base_path = '.'
-    files = ['stubgen.test']
+    files = ['stubgen.test', 'stubgen-based.test']
 
     def run_case(self, testcase: DataDrivenTestCase) -> None:
         with local_sys_path_set():
@@ -577,6 +577,10 @@ class StubgenPythonSuite(DataSuite):
                 f.write(content)
 
         options = self.parse_flags(source, extra)
+        print(testcase.name)
+        print(testcase.file)
+        if "based" not in testcase.file.split(os.sep)[-1]:
+            options.legacy = True
         modules = self.parse_modules(source)
         out_dir = 'out'
         try:

--- a/mypy/typeanal.py
+++ b/mypy/typeanal.py
@@ -20,7 +20,7 @@ from mypy.types import (
     PlaceholderType, Overloaded, get_proper_type, TypeAliasType, RequiredType,
     TypeVarLikeType, ParamSpecType, ParamSpecFlavor, UnpackType,
     callable_with_ellipsis, TYPE_ALIAS_NAMES, FINAL_TYPE_NAMES,
-    LITERAL_TYPE_NAMES, ANNOTATED_TYPE_NAMES,
+    LITERAL_TYPE_NAMES, ANNOTATED_TYPE_NAMES, UntypedType,
 )
 
 from mypy.nodes import (
@@ -388,6 +388,8 @@ class TypeAnalyser(SyntheticTypeVisitor[Type], TypeAnalyzerPluginInterface):
             return UnpackType(
                 self.anal_type(t.args[0]), line=t.line, column=t.column,
             )
+        elif fullname == "basedtyping.Untyped":
+            return UntypedType(TypeOfAny.explicit)
         return None
 
     def get_omitted_any(self, typ: Type, fullname: Optional[str] = None) -> AnyType:
@@ -1138,9 +1140,9 @@ def get_omitted_any(disallow_any: bool, fail: MsgCallback, note: MsgCallback,
                     typ,
                     code=codes.TYPE_ARG)
 
-        any_type = AnyType(TypeOfAny.from_omitted_generics, line=typ.line, column=typ.column)
+        any_type = UntypedType(TypeOfAny.from_omitted_generics, line=typ.line, column=typ.column)
     else:
-        any_type = AnyType(
+        any_type = UntypedType(
             TypeOfAny.from_omitted_generics, line=orig_type.line, column=orig_type.column
         )
     return any_type
@@ -1348,7 +1350,7 @@ class HasExplicitAny(TypeQuery[bool]):
         super().__init__(any)
 
     def visit_any(self, t: AnyType) -> bool:
-        return t.type_of_any == TypeOfAny.explicit
+        return t.type_of_any == TypeOfAny.explicit and not isinstance(t, UntypedType)
 
     def visit_typeddict_type(self, t: TypedDictType) -> bool:
         # typeddict is checked during TypedDict declaration, so don't typecheck it here.

--- a/mypy/typeops.py
+++ b/mypy/typeops.py
@@ -15,7 +15,7 @@ from mypy.types import (
     TypeVarType, UninhabitedType, FormalArgument, UnionType, NoneType,
     AnyType, TypeOfAny, TypeType, ProperType, LiteralType, get_proper_type, get_proper_types,
     copy_type, TypeAliasType, TypeQuery, ParamSpecType,
-    ENUM_REMOVED_PROPS, is_unannotated_any
+    ENUM_REMOVED_PROPS, is_unannotated_any, UntypedType
 )
 from mypy.nodes import (
     FuncBase, FuncItem, FuncDef, OverloadedFuncDef, TypeInfo, ARG_STAR, ARG_STAR2, ARG_POS,
@@ -544,15 +544,15 @@ def callable_type(fdef: FuncItem, fallback: Instance,
         self_type: Type = fill_typevars(fdef.info)
         if fdef.is_class or fdef.name == '__new__':
             self_type = TypeType.make_normalized(self_type)
-        args = [self_type] + [AnyType(TypeOfAny.unannotated)] * (len(fdef.arg_names)-1)
+        args = [self_type] + [UntypedType()] * (len(fdef.arg_names)-1)
     else:
-        args = [AnyType(TypeOfAny.unannotated)] * len(fdef.arg_names)
+        args = [UntypedType()] * len(fdef.arg_names)
 
     return CallableType(
         args,
         fdef.arg_kinds,
         fdef.arg_names,
-        ret_type or AnyType(TypeOfAny.unannotated),
+        ret_type or UntypedType(),
         fallback,
         name=fdef.name,
         line=fdef.line,
@@ -887,7 +887,7 @@ def infer_impl_from_parts(impl: OverloadPart, types: List[CallableType], fallbac
     res_arg_types = [
         arg_types2[arg_name]
         if arg_name in arg_types2 and arg_kind not in (ARG_STAR, ARG_STAR2)
-        else AnyType(TypeOfAny.unannotated)
+        else UntypedType()
         for arg_name, arg_kind in zip(impl_func.arg_names, impl_func.arg_kinds)
     ]
     ret_type = UnionType.make_union(ret_types)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -871,31 +871,32 @@ class AnyType(ProperType):
         if not mypy.options._based:
             return 'Any'
 
-        def type_of_any(toa: int = self.type_of_any) -> Optional[str]:
-            if toa == TypeOfAny.unannotated:
+        def describe_type_of_any(type_of_any: int = self.type_of_any) -> Optional[str]:
+            if type_of_any == TypeOfAny.unannotated:
                 return "unannotated"
-            elif toa == TypeOfAny.explicit:
+            elif type_of_any == TypeOfAny.explicit:
                 return None
-            elif toa == TypeOfAny.from_unimported_type:
+            elif type_of_any == TypeOfAny.from_unimported_type:
                 return "from unimported type"
-            elif toa == TypeOfAny.from_omitted_generics:
+            elif type_of_any == TypeOfAny.from_omitted_generics:
                 return "from omitted generics"
-            elif toa == TypeOfAny.from_error:
+            elif type_of_any == TypeOfAny.from_error:
                 return "from error"
-            elif toa == TypeOfAny.special_form:
-                return "special form"
-            elif toa == TypeOfAny.from_another_any:
-                return type_of_any(self.source_any.type_of_any) if self.source_any else None
-            elif toa == TypeOfAny.implementation_artifact:
+            elif type_of_any == TypeOfAny.special_form:
+                return "unknown"
+            elif type_of_any == TypeOfAny.from_another_any:
+                return (describe_type_of_any(self.source_any.type_of_any)
+                        if self.source_any else None)
+            elif type_of_any == TypeOfAny.implementation_artifact:
                 return "from a limitation"
-            elif toa == TypeOfAny.suggestion_engine:
+            elif type_of_any == TypeOfAny.suggestion_engine:
                 return "from a suggestion"
             assert False, "unreachable"
-        s = self.__class__.__name__.split("Type")[0]
-        type_of = type_of_any()
+        description = self.__class__.__name__.split("Type")[0]
+        type_of = describe_type_of_any()
         if type_of:
-            return f'{s} ({type_of})'
-        return s
+            return f'{description} ({type_of})'
+        return description
 
 
 class UntypedType(AnyType):

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -883,7 +883,7 @@ class AnyType(ProperType):
             elif type_of_any == TypeOfAny.from_error:
                 return "from error"
             elif type_of_any == TypeOfAny.special_form:
-                return "unknown"
+                return None
             elif type_of_any == TypeOfAny.from_another_any:
                 return (describe_type_of_any(self.source_any.type_of_any)
                         if self.source_any else None)

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -867,6 +867,53 @@ class AnyType(ProperType):
                        AnyType.deserialize(source) if source is not None else None,
                        data['missing_import_name'])
 
+    def describe(self) -> str:
+        if not mypy.options._based:
+            return 'Any'
+
+        def type_of_any(toa: int = self.type_of_any) -> Optional[str]:
+            if toa == TypeOfAny.unannotated:
+                return "unannotated"
+            elif toa == TypeOfAny.explicit:
+                return None
+            elif toa == TypeOfAny.from_unimported_type:
+                return "from unimported type"
+            elif toa == TypeOfAny.from_omitted_generics:
+                return "from omitted generics"
+            elif toa == TypeOfAny.from_error:
+                return "from error"
+            elif toa == TypeOfAny.special_form:
+                return "special form"
+            elif toa == TypeOfAny.from_another_any:
+                return type_of_any(self.source_any.type_of_any) if self.source_any else None
+            elif toa == TypeOfAny.implementation_artifact:
+                return "from a limitation"
+            elif toa == TypeOfAny.suggestion_engine:
+                return "from a suggestion"
+            assert False, "unreachable"
+        s = self.__class__.__name__.split("Type")[0]
+        type_of = type_of_any()
+        if type_of:
+            return f'{s} ({type_of})'
+        return s
+
+
+class UntypedType(AnyType):
+    def __init__(self,
+                 type_of_any: int = TypeOfAny.unannotated,
+                 missing_import_name: Optional[str] = None,
+                 line: int = -1,
+                 column: int = -1):
+        super().__init__(type_of_any,
+                         missing_import_name=missing_import_name,
+                         line=line,
+                         column=column)
+
+    def describe(self) -> str:
+        if not mypy.options._based:
+            return super().describe()
+        return "Untyped"
+
 
 class UninhabitedType(ProperType):
     """This type has no members.
@@ -2323,7 +2370,7 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
     def visit_any(self, t: AnyType) -> str:
         if self.any_as_dots and t.type_of_any == TypeOfAny.special_form:
             return '...'
-        return 'Any'
+        return t.describe()
 
     def visit_none_type(self, t: NoneType) -> str:
         return "None"

--- a/mypy/typeshed/stdlib/basedtyping.pyi
+++ b/mypy/typeshed/stdlib/basedtyping.pyi
@@ -1,0 +1,3 @@
+from typing import _SpecialForm
+
+Untyped: _SpecialForm

--- a/mypy/typeshed/stdlib/typing.pyi
+++ b/mypy/typeshed/stdlib/typing.pyi
@@ -12,8 +12,6 @@ if sys.version_info >= (3, 7):
 if sys.version_info >= (3, 9):
     from types import GenericAlias
 
-Any = object()
-
 class TypeVar:
     __name__: str
     __bound__: Type[Any] | None
@@ -47,6 +45,7 @@ _T = TypeVar("_T")
 
 def overload(func: _F) -> _F: ...
 
+Any: _SpecialForm = ...
 Union: _SpecialForm = ...
 Optional: _SpecialForm = ...
 Tuple: _SpecialForm = ...

--- a/mypy_self_check.ini
+++ b/mypy_self_check.ini
@@ -29,7 +29,7 @@ no_warn_return_any = True
 no_warn_unreachable = True
 implicit_reexport = True
 disallow_redefinition = True
-disable_error_code = truthy-bool, redundant-expr, ignore-without-code
+disable_error_code = truthy-bool, redundant-expr, ignore-without-code, no-untyped-usage
 
 [mypy-mypy.*,mypyc.*]
 default_return = True

--- a/runtests.py
+++ b/runtests.py
@@ -46,8 +46,6 @@ cmds = {
     # Self type check
     'self': [executable, '-m', 'mypy', '--config-file', 'mypy_self_check.ini', "--baseline-file=",
              '-p', 'mypy'],
-    'self_strict': [executable, '-m', 'mypy', '--config-file', 'mypy_self_check_strict.ini', '-p',
-                    'mypy'],
     # Lint
     'lint': ['flake8', '-j0'],
     # Fast test cases only (this is the bulk of the test suite)

--- a/test-data/unit/check-based-default-return.test
+++ b/test-data/unit/check-based-default-return.test
@@ -101,7 +101,7 @@ class A:
 
 f = lambda x: x
 g = lambda: ...
-reveal_type(f)  # N: Revealed type is "def (x: Untyped) -> Any (unknown)"
+reveal_type(f)  # N: Revealed type is "def (x: Untyped) -> Any"
 reveal_type(g)  # N: Revealed type is "def () -> ellipsis"
 
 

--- a/test-data/unit/check-based-default-return.test
+++ b/test-data/unit/check-based-default-return.test
@@ -21,7 +21,7 @@ reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: int)"
 # flags: --allow-untyped-defs --allow-any-expr
 
 def f(): ...
-reveal_type(f)  # N: Revealed type is "def () -> Any"
+reveal_type(f)  # N: Revealed type is "def () -> Untyped"
 
 def g(i: int): ...
 reveal_type(g)  # N: Revealed type is "def (i: int)"
@@ -34,20 +34,20 @@ class A:
     def h(self, i: int): ...
     def i(self, i: int, j): ... # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]
 
-reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A) -> Any"
-reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: Any) -> Any"
+reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A) -> Untyped"
+reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: Untyped) -> Untyped"
 reveal_type(A.h)  # N: Revealed type is "def (self: __main__.A, i: int)"
-reveal_type(A.i)  # N: Revealed type is "def (self: __main__.A, i: int, j: Any)"
+reveal_type(A.i)  # N: Revealed type is "def (self: __main__.A, i: int, j: Untyped)"
 
 
 [case testIncompleteDefs]
 # flags: --allow-incomplete-defs --allow-untyped-defs --allow-any-expr
 
 def f(i): ...
-reveal_type(f)  # N: Revealed type is "def (i: Any) -> Any"
+reveal_type(f)  # N: Revealed type is "def (i: Untyped) -> Untyped"
 
 def g(i: int, j): ...
-reveal_type(g)  # N: Revealed type is "def (i: int, j: Any)"
+reveal_type(g)  # N: Revealed type is "def (i: int, j: Untyped)"
 
 class A:
     def f(self): ...
@@ -55,10 +55,10 @@ class A:
     def h(self, i: int): ...
     def i(self, i: int, j): ...
 
-reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A) -> Any"
-reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: Any) -> Any"
+reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A) -> Untyped"
+reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: Untyped) -> Untyped"
 reveal_type(A.h)  # N: Revealed type is "def (self: __main__.A, i: int)"
-reveal_type(A.i)  # N: Revealed type is "def (self: __main__.A, i: int, j: Any)"
+reveal_type(A.i)  # N: Revealed type is "def (self: __main__.A, i: int, j: Untyped)"
 
 
 [case testGenerator]
@@ -101,7 +101,7 @@ class A:
 
 f = lambda x: x
 g = lambda: ...
-reveal_type(f)  # N: Revealed type is "def (x: Any) -> Any"
+reveal_type(f)  # N: Revealed type is "def (x: Untyped) -> Any (special form)"
 reveal_type(g)  # N: Revealed type is "def () -> ellipsis"
 
 
@@ -168,7 +168,7 @@ class A:
     def f(self, i, j: int): ...
     def f(self, i: int = 0, j: int = 0): ...
 
-reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A), def (self: __main__.A, i: Any), def (self: __main__.A, i: Any, j: int))"
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A), def (self: __main__.A, i: Untyped), def (self: __main__.A, i: Untyped, j: int))"
 
 @overload
 def f(): ...
@@ -178,7 +178,7 @@ def f(i): ...
 def f(i, j: int): ...
 def f(i: int = 0, j: int = 0): ...
 
-reveal_type(f)  # N: Revealed type is "Overload(def (), def (i: Any), def (i: Any, j: int))"
+reveal_type(f)  # N: Revealed type is "Overload(def (), def (i: Untyped), def (i: Untyped, j: int))"
 
 
 [case testOverloadUntyped]
@@ -194,7 +194,7 @@ class A:
     def f(self, *, j: int): ...
     def f(self, i: int = 0, j: int = 0): ...
 
-reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A), def (self: __main__.A, i: Any), def (self: __main__.A, *, j: int))"
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A), def (self: __main__.A, i: Untyped), def (self: __main__.A, *, j: int))"
 
 @overload
 def f(): ...
@@ -204,7 +204,7 @@ def f(i): ...
 def f(*, j: int): ...
 def f(i: int = 0, j: int = 0): ...
 
-reveal_type(f)  # N: Revealed type is "Overload(def (), def (i: Any), def (*, j: int))"
+reveal_type(f)  # N: Revealed type is "Overload(def (), def (i: Untyped), def (*, j: int))"
 
 [case testOverloadOther]
 # flags: --allow-untyped-defs --allow-incomplete-defs --allow-any-expr
@@ -219,7 +219,7 @@ class A:
     def f(self, i, j: int): ...
     def f(self, i: int = 0, j: int = 0) -> object: ...
 
-reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A) -> int, def (self: __main__.A, i: Any), def (self: __main__.A, i: Any, j: int))"
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A) -> int, def (self: __main__.A, i: Untyped), def (self: __main__.A, i: Untyped, j: int))"
 
 class B:
     @overload
@@ -230,7 +230,7 @@ class B:
     def f(self, i, j: int) -> int: ...
     def f(self, i: int = 0, j: int = 0) -> object: ...
 
-reveal_type(B.f)  # N: Revealed type is "Overload(def (self: __main__.B) -> str, def (self: __main__.B, i: Any), def (self: __main__.B, i: Any, j: int) -> int)"
+reveal_type(B.f)  # N: Revealed type is "Overload(def (self: __main__.B) -> str, def (self: __main__.B, i: Untyped), def (self: __main__.B, i: Untyped, j: int) -> int)"
 
 
 [case testNewHasError]

--- a/test-data/unit/check-based-default-return.test
+++ b/test-data/unit/check-based-default-return.test
@@ -101,7 +101,7 @@ class A:
 
 f = lambda x: x
 g = lambda: ...
-reveal_type(f)  # N: Revealed type is "def (x: Untyped) -> Any (special form)"
+reveal_type(f)  # N: Revealed type is "def (x: Untyped) -> Any (unknown)"
 reveal_type(g)  # N: Revealed type is "def () -> ellipsis"
 
 

--- a/test-data/unit/check-based-ignore-any-from-error.test
+++ b/test-data/unit/check-based-ignore-any-from-error.test
@@ -13,13 +13,13 @@ g = f + 1  # E: Expression has type "Any"  [no-any-expr]
 # flags: --no-ignore-any-from-error
 from typing import Any
 a = AMONGUS  # E: Name "AMONGUS" is not defined  [name-defined] \
-             # E: Expression has type "Any"  [no-any-expr]
-b = a + 1  # E: Expression has type "Any"  [no-any-expr]
-c = b()  # E: Expression has type "Any"  [no-any-expr]
-d = [c]  # E: Expression type contains "Any" (has type "list[Any]")  [no-any-expr] \
-         # E: Expression has type "Any"  [no-any-expr]
-e = d[0].d  # E: Expression type contains "Any" (has type "list[Any]")  [no-any-expr] \
-            # E: Expression has type "Any"  [no-any-expr]
-e + 1  # E: Expression has type "Any"  [no-any-expr]
+             # E: Expression has type "Any (from error)"  [no-any-expr]
+b = a + 1  # E: Expression has type "Any (from error)"  [no-any-expr]
+c = b()  # E: Expression has type "Any (from error)"  [no-any-expr]
+d = [c]  # E: Expression type contains "Any" (has type "list[Any (from error)]")  [no-any-expr] \
+         # E: Expression has type "Any (from error)"  [no-any-expr]
+e = d[0].d  # E: Expression type contains "Any" (has type "list[Any (from error)]")  [no-any-expr] \
+            # E: Expression has type "Any (from error)"  [no-any-expr]
+e + 1  # E: Expression has type "Any (from error)"  [no-any-expr]
 f: Any  # E: Explicit "Any" is not allowed  [no-any-explicit]
 g = f + 1  # E: Expression has type "Any"  [no-any-expr]

--- a/test-data/unit/check-based-incomplete-defs.test
+++ b/test-data/unit/check-based-incomplete-defs.test
@@ -2,7 +2,7 @@
 # flags: --config-file tmp/mypy.ini
 from b import foo
 foo(1, 2)  # E: Call to incomplete function "foo" in typed context  [no-untyped-call] \
-           # N: Type is "def (a: int, b: Any)"
+           # N: Type is "def (a: int, b: Untyped)"
 
 [file b.py]
 def foo(a: int, b): ...

--- a/test-data/unit/check-based-infer-function-types.test
+++ b/test-data/unit/check-based-infer-function-types.test
@@ -4,10 +4,10 @@
 # flags: --allow-untyped-defs --allow-incomplete-defs --allow-any-expr
 
 def f(): ...
-reveal_type(f)  # N: Revealed type is "def () -> Any"
+reveal_type(f)  # N: Revealed type is "def () -> Untyped"
 
 def g(i=1, b=""): ...
-reveal_type(g)  # N: Revealed type is "def (i: int =, b: str =) -> Any"
+reveal_type(g)  # N: Revealed type is "def (i: int =, b: str =) -> Untyped"
 
 class A1:
     def __new__(cls): ...
@@ -16,8 +16,8 @@ class B1(A1):
     def __new__(cls): ...
     def __init__(self): ...
 
-reveal_type(A1.__new__)  # N: Revealed type is "def (cls: type[__main__.A1]) -> Any"
-reveal_type(B1.__new__)  # N: Revealed type is "def (cls: type[__main__.B1]) -> Any"
+reveal_type(A1.__new__)  # N: Revealed type is "def (cls: type[__main__.A1]) -> Untyped"
+reveal_type(B1.__new__)  # N: Revealed type is "def (cls: type[__main__.B1]) -> Untyped"
 reveal_type(A1.__init__)  # N: Revealed type is "def (self: __main__.A1)"
 reveal_type(B1.__init__)  # N: Revealed type is "def (self: __main__.B1)"
 
@@ -77,10 +77,10 @@ reveal_type(C.foo)  # N: Revealed type is "def (self: __main__.C, a: object =)"
 # flags: --no-infer-function-types --allow-untyped-defs --allow-incomplete-defs --allow-any-expr --no-default-return
 
 def f(): ...
-reveal_type(f)  # N: Revealed type is "def () -> Any"
+reveal_type(f)  # N: Revealed type is "def () -> Untyped"
 
 def g(i=1, b=""): ...
-reveal_type(g)  # N: Revealed type is "def (i: Any =, b: Any =) -> Any"
+reveal_type(g)  # N: Revealed type is "def (i: Untyped =, b: Untyped =) -> Untyped"
 
 class A1:
     def __new__(cls): ...
@@ -89,10 +89,10 @@ class B1(A1):
     def __new__(cls): ...
     def __init__(self): ...
 
-reveal_type(A1.__new__)  # N: Revealed type is "def (cls: type[__main__.A1]) -> Any"
-reveal_type(B1.__new__)  # N: Revealed type is "def (cls: type[__main__.B1]) -> Any"
-reveal_type(A1.__init__)  # N: Revealed type is "def (self: __main__.A1) -> Any"
-reveal_type(B1.__init__)  # N: Revealed type is "def (self: __main__.B1) -> Any"
+reveal_type(A1.__new__)  # N: Revealed type is "def (cls: type[__main__.A1]) -> Untyped"
+reveal_type(B1.__new__)  # N: Revealed type is "def (cls: type[__main__.B1]) -> Untyped"
+reveal_type(A1.__init__)  # N: Revealed type is "def (self: __main__.A1) -> Untyped"
+reveal_type(B1.__init__)  # N: Revealed type is "def (self: __main__.B1) -> Untyped"
 
 class A2:
     def __new__(cls, a: int): ...
@@ -101,10 +101,10 @@ class B2(A2):
     def __new__(cls, a): ...
     def __init__(self, a): ...
 
-reveal_type(A2.__new__)  # N: Revealed type is "def (cls: type[__main__.A2], a: int) -> Any"
-reveal_type(B2.__new__)  # N: Revealed type is "def (cls: type[__main__.B2], a: Any) -> Any"
+reveal_type(A2.__new__)  # N: Revealed type is "def (cls: type[__main__.A2], a: int) -> Untyped"
+reveal_type(B2.__new__)  # N: Revealed type is "def (cls: type[__main__.B2], a: Untyped) -> Untyped"
 reveal_type(A2.__init__)  # N: Revealed type is "def (self: __main__.A2, a: int)"
-reveal_type(B2.__init__)  # N: Revealed type is "def (self: __main__.B2, a: Any) -> Any"
+reveal_type(B2.__init__)  # N: Revealed type is "def (self: __main__.B2, a: Untyped) -> Untyped"
 
 
 [case testSimpleOverload]
@@ -180,7 +180,7 @@ def f(__a: str): ...
 def f(__a: int): ...
 
 def f(*args):  # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]
-    reveal_type(args)  # N: Revealed type is "tuple[Any, ...]"
+    reveal_type(args)  # N: Revealed type is "tuple[Untyped, ...]"
     if args:
         return "asdf"  # E: No return value expected  [return-value]
 [builtins fixtures/tuple.pyi]
@@ -196,7 +196,7 @@ def f(*, kwargs: str): ...
 def f(*, kwargs: int): ...
 
 def f(**kwargs):  # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]
-    reveal_type(kwargs)  # N: Revealed type is "dict[str, Any]"
+    reveal_type(kwargs)  # N: Revealed type is "dict[str, Untyped]"
     return 1 # E: No return value expected  [return-value]
 [builtins fixtures/dict.pyi]
 

--- a/test-data/unit/check-based-type-render.test
+++ b/test-data/unit/check-based-type-render.test
@@ -12,3 +12,12 @@ class A(Generic[T2]):
 
 reveal_type(A.f)  # N: Revealed type is "def [T2 (from A), T] (self: __main__.A[T2], t: T, t2: T2) -> list[int] | str"
 reveal_type(A[int]().f)  # N: Revealed type is "def [T] (t: T, t2: int) -> list[int] | str"
+
+
+[case testRenderAny]
+# flags: --allow-any-generics --allow-any-expr --allow-any-explicit
+from typing import Any, List
+a: list
+reveal_type(a)  # N: Revealed type is "list[Untyped]"
+b: List[Any]
+reveal_type(b)  # N: Revealed type is "list[Any]"

--- a/test-data/unit/check-based-untyped.test
+++ b/test-data/unit/check-based-untyped.test
@@ -1,15 +1,22 @@
-[case testUntypedAttribute]
+[case testUntypedReference]
 from basedtyping import Untyped
 a: Untyped
+c: int
+
 a = 1  # E: Usage of untyped name "a" in typed context  [no-untyped-usage]
+c = a  # E: Usage of untyped name "a" in typed context  [no-untyped-usage]
 del a  # E: Usage of untyped name "a" in typed context  [no-untyped-usage]
+
 class A:
-    a: Untyped
+    b: Untyped
 a1: A
-del a1.a  # E: Usage of untyped name "a" in typed context  [no-untyped-usage]
-del a1.a[1]  # E: Expression has type "Untyped"  [no-any-expr]
-del a1.a.b  # E: Expression has type "Untyped"  [no-any-expr] \
-            # E: Usage of untyped name "b" in typed context  [no-untyped-usage]
+del a1.b  # E: Usage of untyped name "b" in typed context  [no-untyped-usage]
+del a1.b[1]  # E: Expression has type "Untyped"  [no-any-expr]
+del a1.b.c  # E: Expression has type "Untyped"  [no-any-expr] \
+            # E: Usage of untyped name "c" in typed context  [no-untyped-usage]
+a2: A
+c = a1.b  # E: Usage of untyped name "b" in typed context  [no-untyped-usage]
+a1.b = 1  # E: Usage of untyped name "b" in typed context  [no-untyped-usage]
 
 
 [case testUntypedIndex]
@@ -55,3 +62,23 @@ def f2(a: Untyped) -> int: ...
 f1(1)
 f2(1)  # E: Call to incomplete function "f2" in typed context  [no-untyped-call] \
        # N: Type is "def (a: Untyped) -> int"
+
+
+[case testUntypedProperty]
+# flags: --allow-untyped-defs --allow-any-decorated
+from basedtyping import Untyped
+
+class A:
+    @property
+    def foo(self): ...
+    @foo.setter
+    def foo(self, value): ...
+    @property
+    def bar(self) -> Untyped: ...
+    @bar.setter
+    def bar(self, value: Untyped) -> None: ...
+
+a: A
+a.foo = 1  # E: Usage of untyped name "foo" in typed context  [no-untyped-usage]
+a.bar = 1  # E: Usage of untyped name "bar" in typed context  [no-untyped-usage]
+[builtins fixtures/property.pyi]

--- a/test-data/unit/check-based-untyped.test
+++ b/test-data/unit/check-based-untyped.test
@@ -1,0 +1,57 @@
+[case testUntypedAttribute]
+from basedtyping import Untyped
+a: Untyped
+a = 1  # E: Usage of untyped name "a" in typed context  [no-untyped-usage]
+del a  # E: Usage of untyped name "a" in typed context  [no-untyped-usage]
+class A:
+    a: Untyped
+a1: A
+del a1.a  # E: Usage of untyped name "a" in typed context  [no-untyped-usage]
+del a1.a[1]  # E: Expression has type "Untyped"  [no-any-expr]
+del a1.a.b  # E: Expression has type "Untyped"  [no-any-expr] \
+            # E: Usage of untyped name "b" in typed context  [no-untyped-usage]
+
+
+[case testUntypedIndex]
+# flags: --allow-any-generics
+from typing import List
+from basedtyping import Untyped
+
+class A(list): ...
+a = A()
+a[0] = 1  # E: Untyped indexed-assignment to "a" in typed context  [no-untyped-usage]
+class B(List[Untyped]):
+    a: A
+b = B()
+b[0] = 1  # E: Untyped indexed-assignment to "b" in typed context  [no-untyped-usage]
+b.a[0] = 1  # E: Untyped indexed-assignment to "a" in typed context  [no-untyped-usage]
+c: Untyped
+c()[1] = 1  # E: Expression has type "Untyped"  [no-any-expr]
+[builtins fixtures/list.pyi]
+
+
+[case testUntypedOmittedGeneric]
+# flags: --allow-any-generics
+from typing import List
+from basedtyping import Untyped
+
+def f1(a: List): ...
+def f2(a: List[Untyped]): ...
+a = [1]
+f1(a)  # E: Call to incomplete function "f1" in typed context  [no-untyped-call] \
+       # N: Type is "def (a: list[Untyped])"
+f2(a)  # E: Call to incomplete function "f2" in typed context  [no-untyped-call] \
+       # N: Type is "def (a: list[Untyped])"
+
+
+[case testIncompleteCall]
+# flags: --allow-any-explicit
+from typing import Any
+from basedtyping import Untyped
+
+def f1(a: Any): ...
+def f2(a: Untyped) -> int: ...
+
+f1(1)
+f2(1)  # E: Call to incomplete function "f2" in typed context  [no-untyped-call] \
+       # N: Type is "def (a: Untyped) -> int"

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1150,8 +1150,8 @@ from typing import Any
 class Foo:
     g: Any = 2
 
-z: int = Foo().g
-x = Foo().g  # type: int
+z: int = Foo().g  # E: Expression has type "Any"
+x = Foo().g  # type: int  # E: Expression has type "Any"
 m: Any = Foo().g  # E: Expression has type "Any"
 n = Foo().g  # type: Any  # E: Expression has type "Any"
 [builtins fixtures/list.pyi]

--- a/test-data/unit/fixtures/property.pyi
+++ b/test-data/unit/fixtures/property.pyi
@@ -6,7 +6,7 @@ class object:
     def __init__(self) -> None: pass
 
 class type:
-    def __init__(self, x: typing.Any) -> None: pass
+    def __init__(self, x: object) -> None: pass
 
 class function: pass
 

--- a/test-data/unit/lib-stub/basedtyping.pyi
+++ b/test-data/unit/lib-stub/basedtyping.pyi
@@ -1,0 +1,7 @@
+# Stub for basedtyping. Many of the definitions have special handling in
+# the type checker, so they can just be initialized to anything.
+#
+# DO NOT ADD TO THIS FILE UNLESS YOU HAVE A GOOD REASON! Additional definitions
+# will slow down tests.
+
+Untyped = 0

--- a/test-data/unit/stubgen-based.test
+++ b/test-data/unit/stubgen-based.test
@@ -1,0 +1,2670 @@
+-- Test cases for stubgen that generate stubs from Python code
+
+[case testEmptyFile]
+[out]
+
+[case testSingleFunction]
+def f():
+    x = 1
+[out]
+def f(): ...
+
+[case testTwoFunctions]
+def f(a, b):
+    x = 1
+def g(arg):
+    pass
+[out]
+def f(a, b): ...
+def g(arg): ...
+
+[case testDefaultArgInt]
+def f(a, b=2): ...
+def g(b=-1, c=0): ...
+[out]
+def f(a, b: int = ...): ...
+def g(b: int = ..., c: int = ...): ...
+
+[case testDefaultArgNone]
+def f(x=None): ...
+[out]
+from basedtyping import Untyped
+
+def f(x: Untyped | None = ...): ...
+
+[case testDefaultArgBool]
+def f(x=True, y=False): ...
+[out]
+def f(x: bool = ..., y: bool = ...): ...
+
+[case testDefaultArgStr]
+def f(x='foo'): ...
+[out]
+def f(x: str = ...): ...
+
+[case testDefaultArgBytes]
+def f(x=b'foo'): ...
+[out]
+def f(x: bytes = ...): ...
+
+[case testDefaultArgFloat]
+def f(x=1.2): ...
+[out]
+def f(x: float = ...): ...
+
+[case testDefaultArgOther]
+def f(x=ord): ...
+[out]
+def f(x=...): ...
+
+[case testPreserveFunctionAnnotation]
+def f(x: Foo) -> Bar: ...
+def g(x: Foo = Foo()) -> Bar: ...
+[out]
+def f(x: Foo) -> Bar: ...
+def g(x: Foo = ...) -> Bar: ...
+
+[case testPreserveFunctionAnnotationWithArgs]
+def f(x: foo['x']) -> bar: ...
+def g(x: foo[x]) -> bar: ...
+def h(x: foo['x', 'y']) -> bar: ...
+def i(x: foo[x, y]) -> bar: ...
+def j(x: foo['x', y]) -> bar: ...
+def k(x: foo[x, 'y']) -> bar: ...
+def lit_str(x: Literal['str']) -> Literal['str']: ...
+def lit_int(x: Literal[1]) -> Literal[1]: ...
+[out]
+def f(x: foo['x']) -> bar: ...
+def g(x: foo[x]) -> bar: ...
+def h(x: foo['x', 'y']) -> bar: ...
+def i(x: foo[x, y]) -> bar: ...
+def j(x: foo['x', y]) -> bar: ...
+def k(x: foo[x, 'y']) -> bar: ...
+def lit_str(x: Literal['str']) -> Literal['str']: ...
+def lit_int(x: Literal[1]) -> Literal[1]: ...
+
+[case testPreserveVarAnnotation]
+x: Foo
+[out]
+x: Foo
+
+[case testPreserveVarAnnotationWithoutQuotes]
+x: 'Foo'
+[out]
+x: Foo
+
+[case testVarArgs]
+def f(x, *y): ...
+[out]
+def f(x, *y): ...
+
+[case testKwVarArgs]
+def f(x, **y): ...
+[out]
+def f(x, **y): ...
+
+[case testVarArgsWithKwVarArgs]
+def f(a, *b, **c): ...
+def g(a, *b, c=1): ...
+def h(a, *b, c=1, **d): ...
+def i(a, *, b=1): ...
+def j(a, *, b=1, **c): ...
+[out]
+def f(a, *b, **c): ...
+def g(a, *b, c: int = ...): ...
+def h(a, *b, c: int = ..., **d): ...
+def i(a, *, b: int = ...): ...
+def j(a, *, b: int = ..., **c): ...
+
+[case testClass]
+class A:
+    def f(self, x):
+        x = 1
+def g(): ...
+[out]
+class A:
+    def f(self, x): ...
+
+def g(): ...
+
+[case testVariable]
+x = 1
+[out]
+x: int
+
+[case testAnnotatedVariable]
+x: int = 1
+[out]
+x: int
+
+[case testAnnotatedVariableGeneric]
+x: Foo[int, str] = ...
+[out]
+x: Foo[int, str]
+
+[case testAnnotatedVariableOldSyntax]
+x = 1  # type: int
+[out]
+x: int
+
+[case testAnnotatedVariableNone]
+x: None
+[out]
+x: None
+
+[case testAnnotatedVariableNoneOldSyntax]
+x = None  # type: None
+[out]
+x: None
+
+[case testMultipleVariable]
+x = y = 1
+[out]
+x: int
+y: int
+
+[case testClassVariable]
+class C:
+    x = 1
+[out]
+class C:
+    x: int
+
+[case testInitTypeAnnotationPreserved]
+class C:
+    def __init__(self, x: str):
+        pass
+[out]
+class C:
+    def __init__(self, x: str): ...
+
+[case testSelfAssignment]
+class C:
+    def __init__(self):
+        self.x = 1
+        x.y = 2
+[out]
+class C:
+    x: int
+    def __init__(self): ...
+
+[case testSelfAndClassBodyAssignment]
+x = 1
+class C:
+    x = 1
+    def __init__(self):
+        self.x = 1
+        self.x = 1
+[out]
+x: int
+
+class C:
+    x: int
+    def __init__(self): ...
+
+[case testEmptyClass]
+class A: ...
+[out]
+class A: ...
+
+[case testSkipPrivateFunction]
+def _f(): ...
+def g(): ...
+[out]
+def g(): ...
+
+[case testIncludePrivateFunction]
+# flags:  --include-private
+def _f(): ...
+def g(): ...
+[out]
+def _f(): ...
+def g(): ...
+
+[case testSkipPrivateMethod]
+class A:
+    def _f(self): ...
+[out]
+class A: ...
+
+[case testIncludePrivateMethod]
+# flags:  --include-private
+class A:
+    def _f(self): ...
+[out]
+class A:
+    def _f(self): ...
+
+[case testSkipPrivateVar]
+_x = 1
+class A:
+    _y = 1
+[out]
+class A: ...
+
+[case testIncludePrivateVar]
+# flags:  --include-private
+_x = 1
+class A:
+    _y = 1
+[out]
+_x: int
+
+class A:
+    _y: int
+
+[case testSpecialInternalVar]
+__all__ = []
+__author__ = ''
+__version__ = ''
+[out]
+
+[case testBaseClass]
+class A: ...
+class B(A): ...
+[out]
+class A: ...
+class B(A): ...
+
+[case testDecoratedFunction]
+@decorator
+def foo(x): ...
+[out]
+def foo(x): ...
+
+[case testMultipleAssignment]
+x, y = 1, 2
+[out]
+from basedtyping import Untyped
+
+x: Untyped
+y: Untyped
+
+[case testMultipleAssignmentAnnotated]
+x, y = 1, "2" # type: int, str
+[out]
+x: int
+y: str
+
+[case testMultipleAssignment2]
+[x, y] = 1, 2
+[out]
+from basedtyping import Untyped
+
+x: Untyped
+y: Untyped
+
+[case testKeywordOnlyArg]
+def f(x, *, y=1): ...
+def g(x, *, y=1, z=2): ...
+[out]
+def f(x, *, y: int = ...): ...
+def g(x, *, y: int = ..., z: int = ...): ...
+
+[case testProperty]
+class A:
+    @property
+    def f(self):
+        return 1
+    @f.setter
+    def f(self, x): ...
+
+    def h(self):
+        self.f = 1
+[out]
+from basedtyping import Untyped
+
+class A:
+    @property
+    def f(self) -> Untyped: ...
+    @f.setter
+    def f(self, x): ...
+    def h(self): ...
+
+[case testStaticMethod]
+class A:
+    @staticmethod
+    def f(x): ...
+[out]
+class A:
+    @staticmethod
+    def f(x): ...
+
+[case testClassMethod]
+class A:
+    @classmethod
+    def f(cls): ...
+[out]
+class A:
+    @classmethod
+    def f(cls): ...
+
+[case testIfMainCheck]
+def a(): ...
+if __name__ == '__main__':
+    x = 1
+    def f(): ...
+def b(): ...
+[out]
+def a(): ...
+def b(): ...
+
+[case testImportStar]
+from x import *
+from a.b import *
+def f(): ...
+[out]
+from x import *
+from a.b import *
+
+def f(): ...
+
+[case testNoSpacesBetweenEmptyClasses]
+class X:
+    def g(self): ...
+class A: ...
+class B: ...
+class C:
+    def f(self): ...
+[out]
+class X:
+    def g(self): ...
+
+class A: ...
+class B: ...
+
+class C:
+    def f(self): ...
+
+[case testExceptionBaseClasses]
+class A(Exception): ...
+class B(ValueError): ...
+[out]
+class A(Exception): ...
+class B(ValueError): ...
+
+[case testOmitSomeSpecialMethods]
+class A:
+    def __str__(self): ...
+    def __repr__(self): ...
+    def __eq__(self): ...
+    def __getstate__(self): ...
+    def __setstate__(self, state): ...
+[out]
+from basedtyping import Untyped
+
+class A:
+    def __eq__(self) -> Untyped: ...
+
+-- Tests that will perform runtime imports of modules.
+-- Don't use `_import` suffix if there are unquoted forward references.
+
+[case testOmitDefsNotInAll_import]
+__all__ = [] + ['f']
+def f(): ...
+def g(): ...
+[out]
+def f(): ...
+
+[case testOmitDefsNotInAll_semanal]
+__all__ = ['f']
+def f(): ...
+def g(): ...
+[out]
+def f(): ...
+
+[case testVarDefsNotInAll_import]
+__all__ = [] + ['f', 'g']
+def f(): ...
+x = 1
+y = 1
+def g(): ...
+[out]
+def f(): ...
+def g(): ...
+
+[case testIncludeClassNotInAll_import]
+__all__ = [] + ['f']
+def f(): ...
+class A: ...
+[out]
+def f(): ...
+
+class A: ...
+
+[case testAllAndClass_import]
+__all__ = ['A']
+class A:
+    x = 1
+    def f(self): ...
+[out]
+class A:
+    x: int
+    def f(self): ...
+
+[case testSkipMultiplePrivateDefs]
+class A: ...
+_x = 1
+_y = 1
+_z = 1
+class C: ...
+[out]
+class A: ...
+class C: ...
+
+[case testIncludeMultiplePrivateDefs]
+# flags:  --include-private
+class A: ...
+_x = 1
+_y = 1
+_z = 1
+class C: ...
+[out]
+class A: ...
+
+_x: int
+_y: int
+_z: int
+
+class C: ...
+
+[case testIncludeFromImportIfInAll_import]
+from re import match, search, sub
+__all__ = ['match', 'sub', 'x']
+x = 1
+[out]
+from re import match as match, sub as sub
+
+x: int
+
+[case testExportModule_import]
+import re
+__all__ = ['re', 'x']
+x = 1
+y = 2
+[out]
+import re as re
+
+x: int
+
+[case testExportModule2_import]
+import re
+__all__ = ['re', 'x']
+x = 1
+y = 2
+[out]
+import re as re
+
+x: int
+
+[case testExportModuleAs_import]
+import re as rex
+__all__ = ['rex', 'x']
+x = 1
+y = 2
+[out]
+import re as rex
+
+x: int
+
+[case testExportModuleInPackage_import]
+import urllib.parse as p
+__all__ = ['p']
+[out]
+import urllib.parse as p
+
+[case testExportPackageOfAModule_import]
+import urllib.parse
+__all__ = ['urllib']
+
+[out]
+import urllib as urllib
+
+[case testRelativeImportAll]
+from .x import *
+[out]
+from .x import *
+
+[case testCommentForUndefinedName_import]
+__all__ = ['f', 'x', 'C', 'g']
+def f(): ...
+x = 1
+class C:
+    def g(self): ...
+[out]
+def f(): ...
+
+x: int
+
+class C:
+    def g(self): ...
+
+# Names in __all__ with no definition:
+#   g
+
+[case testIgnoreSlots]
+class A:
+    __slots__ = ()
+[out]
+class A: ...
+
+[case testSkipPrivateProperty]
+class A:
+    @property
+    def _foo(self): ...
+[out]
+class A: ...
+
+[case testIncludePrivateProperty]
+# flags:  --include-private
+class A:
+    @property
+    def _foo(self): ...
+[out]
+class A:
+    @property
+    def _foo(self): ...
+
+[case testSkipPrivateStaticAndClassMethod]
+class A:
+    @staticmethod
+    def _foo(): ...
+    @classmethod
+    def _bar(cls): ...
+[out]
+class A: ...
+
+[case testIncludePrivateStaticAndClassMethod]
+# flags:  --include-private
+class A:
+    @staticmethod
+    def _foo(): ...
+    @classmethod
+    def _bar(cls): ...
+[out]
+class A:
+    @staticmethod
+    def _foo(): ...
+    @classmethod
+    def _bar(cls): ...
+
+[case testNamedtuple]
+import collections, x
+X = collections.namedtuple('X', ['a', 'b'])
+[out]
+from basedtyping import Untyped
+from typing import NamedTuple
+
+class X(NamedTuple):
+    a: Untyped
+    b: Untyped
+
+[case testEmptyNamedtuple]
+import collections
+X = collections.namedtuple('X', [])
+[out]
+from typing import NamedTuple
+
+class X(NamedTuple): ...
+
+[case testNamedtupleAltSyntax]
+from collections import namedtuple, xx
+X = namedtuple('X', 'a b')
+xx
+[out]
+from basedtyping import Untyped
+from typing import NamedTuple
+
+class X(NamedTuple):
+    a: Untyped
+    b: Untyped
+
+[case testNamedtupleAltSyntaxUsingComma]
+from collections import namedtuple, xx
+X = namedtuple('X', 'a,    b')
+xx
+[out]
+from basedtyping import Untyped
+from typing import NamedTuple
+
+class X(NamedTuple):
+    a: Untyped
+    b: Untyped
+
+[case testNamedtupleAltSyntaxUsingMultipleCommas]
+from collections import namedtuple, xx
+X = namedtuple('X', 'a,,   b')
+xx
+[out]
+from basedtyping import Untyped
+from typing import NamedTuple
+
+class X(NamedTuple):
+    a: Untyped
+    b: Untyped
+
+[case testNamedtupleWithUnderscore]
+from collections import namedtuple as _namedtuple
+def f(): ...
+X = _namedtuple('X', 'a b')
+def g(): ...
+[out]
+from basedtyping import Untyped
+from typing import NamedTuple
+
+def f(): ...
+
+class X(NamedTuple):
+    a: Untyped
+    b: Untyped
+
+def g(): ...
+
+[case testNamedtupleBaseClass]
+import collections, x
+_X = collections.namedtuple('_X', ['a', 'b'])
+class Y(_X): ...
+[out]
+from basedtyping import Untyped
+from typing import NamedTuple
+
+class _X(NamedTuple):
+    a: Untyped
+    b: Untyped
+
+class Y(_X): ...
+
+[case testNamedtupleAltSyntaxFieldsTuples]
+from collections import namedtuple, xx
+X = namedtuple('X', ())
+Y = namedtuple('Y', ('a',))
+Z = namedtuple('Z', ('a', 'b', 'c', 'd', 'e'))
+xx
+[out]
+from basedtyping import Untyped
+from typing import NamedTuple
+
+class X(NamedTuple): ...
+
+class Y(NamedTuple):
+    a: Untyped
+
+class Z(NamedTuple):
+    a: Untyped
+    b: Untyped
+    c: Untyped
+    d: Untyped
+    e: Untyped
+
+[case testDynamicNamedTuple]
+from collections import namedtuple
+N = namedtuple('N', ['x', 'y'] + ['z'])
+[out]
+from basedtyping import Untyped
+
+N: Untyped
+
+[case testArbitraryBaseClass]
+import x
+class D(x.C): ...
+[out]
+import x
+
+class D(x.C): ...
+
+[case testArbitraryBaseClass2]
+import x.y
+class D(x.y.C): ...
+[out]
+import x.y
+
+class D(x.y.C): ...
+
+[case testUnqualifiedArbitraryBaseClassWithNoDef]
+class A(int): ...
+[out]
+class A(int): ...
+
+[case testUnqualifiedArbitraryBaseClass]
+from x import X
+class A(X): ...
+[out]
+from x import X
+
+class A(X): ...
+
+[case testUnqualifiedArbitraryBaseClassWithImportAs]
+from x import X as _X
+class A(_X): ...
+[out]
+from x import X as _X
+
+class A(_X): ...
+
+[case testGenericClass]
+class D(Generic[T]): ...
+[out]
+class D(Generic[T]): ...
+
+[case testObjectBaseClass]
+class A(object): ...
+[out]
+class A: ...
+
+[case testEmptyLines]
+def x(): ...
+def f():
+    class A:
+        def f(self):
+            self.x = 1
+def g(): ...
+[out]
+def x(): ...
+def f(): ...
+def g(): ...
+
+[case testNestedClass]
+class A:
+    class B:
+        x = 1
+        def f(self): ...
+    def g(self): ...
+[out]
+class A:
+    class B:
+        x: int
+        def f(self): ...
+    def g(self): ...
+
+[case testExportViaRelativeImport]
+from .api import get
+[out]
+from .api import get as get
+
+[case testExportViaRelativePackageImport]
+from .packages.urllib3.contrib import parse
+[out]
+from .packages.urllib3.contrib import parse as parse
+
+[case testNoExportViaRelativeImport]
+from . import get
+get()
+[out]
+
+[case testRelativeImportAndBase]
+from .x import X
+class A(X):
+     pass
+[out]
+from .x import X
+
+class A(X): ...
+
+[case testDuplicateDef]
+def syslog(a): pass
+def syslog(a): pass
+[out]
+def syslog(a): ...
+
+[case testAsyncAwait_fast_parser]
+async def f(a):
+   x = await y
+[out]
+async def f(a): ...
+
+[case testInferOptionalOnlyFunc]
+class A:
+    x = None
+    def __init__(self, a=None):
+        self.x = []
+    def method(self, a=None):
+        self.x = []
+[out]
+from basedtyping import Untyped
+
+class A:
+    x: Untyped
+    def __init__(self, a: Untyped | None = ...): ...
+    def method(self, a: Untyped | None = ...): ...
+
+[case testAnnotationImportsFrom]
+import foo
+from collections import defaultdict
+x: defaultdict
+
+[out]
+from collections import defaultdict
+
+x: defaultdict
+
+[case testAnnotationImports]
+import foo
+import collections
+x: collections.defaultdict
+
+[out]
+import collections
+
+x: collections.defaultdict
+
+
+[case testAnnotationImports2]
+from typing import List
+import collections
+x: List[collections.defaultdict]
+
+[out]
+import collections
+from typing import List
+
+x: List[collections.defaultdict]
+
+
+[case testAnnotationFwRefs]
+x: C
+
+class C:
+    attr: C
+
+y: C
+[out]
+x: C
+
+class C:
+    attr: C
+
+y: C
+
+[case testTypeVarPreserved]
+tv = TypeVar('tv')
+
+[out]
+from typing import TypeVar
+
+tv = TypeVar('tv')
+
+[case testTypeVarArgsPreserved]
+tv = TypeVar('tv', int, str)
+
+[out]
+from typing import TypeVar
+
+tv = TypeVar('tv', int, str)
+
+[case testTypeVarNamedArgsPreserved]
+tv = TypeVar('tv', bound=bool, covariant=True)
+
+[out]
+from typing import TypeVar
+
+tv = TypeVar('tv', bound=bool, covariant=True)
+
+[case testTypeAliasPreserved]
+alias = str
+
+[out]
+alias = str
+
+[case testDeepTypeAliasPreserved]
+
+alias = Dict[str, List[str]]
+
+[out]
+alias = Dict[str, List[str]]
+
+[case testDeepGenericTypeAliasPreserved]
+from typing import TypeVar
+
+T = TypeVar('T')
+alias = Union[T, List[T]]
+
+[out]
+from typing import TypeVar
+
+T = TypeVar('T')
+alias = Union[T, List[T]]
+
+[case testEllipsisAliasPreserved]
+
+alias = Tuple[int, ...]
+
+[out]
+alias = Tuple[int, ...]
+
+[case testCallableAliasPreserved]
+
+alias1 = Callable[..., int]
+alias2 = Callable[[str, bool], None]
+
+[out]
+alias1 = Callable[..., int]
+alias2 = Callable[[str, bool], None]
+
+[case testAliasPullsImport]
+from module import Container
+
+alias = Container[Any]
+
+[out]
+from module import Container
+from typing import Any
+
+alias = Container[Any]
+
+[case testAliasOnlyToplevel]
+class Foo:
+    alias = str
+
+[out]
+from basedtyping import Untyped
+
+class Foo:
+    alias: Untyped
+
+[case testAliasExceptions]
+noalias1 = None
+noalias2 = ...
+noalias3 = True
+
+[out]
+from basedtyping import Untyped
+
+noalias1: Untyped
+noalias2: Untyped
+noalias3: bool
+
+-- More features/fixes:
+--   do not export deleted names
+
+[case testFunctionNoReturnInfersReturnNone]
+def f():
+    x = 1
+[out]
+def f(): ...
+
+[case testFunctionReturnNoReturnType]
+def f():
+    return 1
+def g():
+    return
+[out]
+from basedtyping import Untyped
+
+def f() -> Untyped: ...
+def g(): ...
+
+[case testFunctionEllipsisInfersReturnNone]
+def f(): ...
+[out]
+def f(): ...
+
+[case testFunctionYields]
+def f():
+    yield 123
+def g():
+    x = yield
+def h1():
+    yield
+    return
+def h2():
+    yield
+    return "abc"
+def all():
+    x = yield 123
+    return "abc"
+[out]
+from basedtyping import Untyped
+from collections.abc import Generator
+
+def f() -> Generator[Untyped, None, None]: ...
+def g() -> Generator[None, Untyped, None]: ...
+def h1() -> Generator[None, None, None]: ...
+def h2() -> Generator[None, None, Untyped]: ...
+def all() -> Generator[Untyped, Untyped, Untyped]: ...
+
+[case testFunctionYieldsNone]
+def f():
+    yield
+def g():
+    yield None
+
+[out]
+from collections.abc import Generator
+
+def f() -> Generator[None, None, None]: ...
+def g() -> Generator[None, None, None]: ...
+
+[case testGeneratorAlreadyDefined]
+class Generator:
+    pass
+
+def f():
+    yield 123
+[out]
+from basedtyping import Untyped
+from collections.abc import Generator as _Generator
+
+class Generator: ...
+
+def f() -> _Generator[Untyped, None, None]: ...
+
+[case testCallable]
+from typing import Callable
+
+x: Callable[[int, int], int]
+[out]
+from typing import Callable
+
+x: Callable[[int, int], int]
+
+[case testAwaitDef]
+class F:
+    async def f(self):
+        return 1
+
+async def g():
+    return 2
+[out]
+from basedtyping import Untyped
+
+class F:
+    async def f(self) -> Untyped: ...
+
+async def g() -> Untyped: ...
+
+[case testCoroutineImportAsyncio]
+import asyncio
+
+class F:
+    @asyncio.coroutine
+    def f(self):
+        return 1
+
+@asyncio.coroutine
+def g():
+    return 2
+
+@asyncio.coroutine
+def h():
+    return 3
+[out]
+import asyncio
+from basedtyping import Untyped
+
+class F:
+    @asyncio.coroutine
+    def f(self) -> Untyped: ...
+
+@asyncio.coroutine
+def g() -> Untyped: ...
+@asyncio.coroutine
+def h() -> Untyped: ...
+
+[case testCoroutineImportAsyncioCoroutines]
+import asyncio.coroutines
+
+class F:
+    @asyncio.coroutines.coroutine
+    def f(self):
+        return 1
+
+@asyncio.coroutines.coroutine
+def g():
+    return 2
+[out]
+import asyncio.coroutines
+from basedtyping import Untyped
+
+class F:
+    @asyncio.coroutines.coroutine
+    def f(self) -> Untyped: ...
+
+@asyncio.coroutines.coroutine
+def g() -> Untyped: ...
+
+[case testCoroutineImportAsyncioCoroutinesSub]
+import asyncio
+
+class F:
+    @asyncio.coroutines.coroutine
+    def f(self):
+        return 1
+
+@asyncio.coroutines.coroutine
+def g():
+    return 2
+[out]
+import asyncio
+from basedtyping import Untyped
+
+class F:
+    @asyncio.coroutines.coroutine
+    def f(self) -> Untyped: ...
+
+@asyncio.coroutines.coroutine
+def g() -> Untyped: ...
+
+[case testCoroutineImportTypes]
+import types
+
+class F:
+    @types.coroutine
+    def f(self):
+        return 1
+
+@types.coroutine
+def g():
+    return 2
+[out]
+import types
+from basedtyping import Untyped
+
+class F:
+    @types.coroutine
+    def f(self) -> Untyped: ...
+
+@types.coroutine
+def g() -> Untyped: ...
+
+[case testCoroutineFromAsyncioImportCoroutine]
+from asyncio import coroutine
+
+class F:
+    @coroutine
+    def f(self):
+        return 1
+
+@coroutine
+def g():
+    return 2
+[out]
+from asyncio import coroutine
+from basedtyping import Untyped
+
+class F:
+    @coroutine
+    def f(self) -> Untyped: ...
+
+@coroutine
+def g() -> Untyped: ...
+
+[case testCoroutineFromAsyncioCoroutinesImportCoroutine]
+from asyncio.coroutines import coroutine
+
+class F:
+    @coroutine
+    def f(self):
+        return 1
+
+@coroutine
+def g():
+    return 2
+[out]
+from asyncio.coroutines import coroutine
+from basedtyping import Untyped
+
+class F:
+    @coroutine
+    def f(self) -> Untyped: ...
+
+@coroutine
+def g() -> Untyped: ...
+
+[case testCoroutineFromTypesImportCoroutine]
+from types import coroutine
+
+class F:
+    @coroutine
+    def f(self):
+        return 1
+
+@coroutine
+def g():
+    return 2
+[out]
+from basedtyping import Untyped
+from types import coroutine
+
+class F:
+    @coroutine
+    def f(self) -> Untyped: ...
+
+@coroutine
+def g() -> Untyped: ...
+
+[case testCoroutineFromAsyncioImportCoroutineAsC]
+from asyncio import coroutine as c
+
+class F:
+    @c
+    def f(self):
+        return 1
+
+@c
+def g():
+    return 2
+[out]
+from asyncio import coroutine as c
+from basedtyping import Untyped
+
+class F:
+    @c
+    def f(self) -> Untyped: ...
+
+@c
+def g() -> Untyped: ...
+
+[case testCoroutineFromAsyncioCoroutinesImportCoroutineAsC]
+from asyncio.coroutines import coroutine as c
+
+class F:
+    @c
+    def f(self):
+        return 1
+
+@c
+def g():
+    return 2
+[out]
+from asyncio.coroutines import coroutine as c
+from basedtyping import Untyped
+
+class F:
+    @c
+    def f(self) -> Untyped: ...
+
+@c
+def g() -> Untyped: ...
+
+[case testCoroutineFromTypesImportCoroutineAsC]
+from types import coroutine as c
+
+class F:
+    @c
+    def f(self):
+        return 1
+
+@c
+def g():
+    return 2
+[out]
+from basedtyping import Untyped
+from types import coroutine as c
+
+class F:
+    @c
+    def f(self) -> Untyped: ...
+
+@c
+def g() -> Untyped: ...
+
+[case testCoroutineImportAsyncioAsA]
+import asyncio as a
+
+class F:
+    @a.coroutine
+    def f(self):
+        return 1
+
+@a.coroutine
+def g():
+    return 2
+[out]
+import asyncio as a
+from basedtyping import Untyped
+
+class F:
+    @a.coroutine
+    def f(self) -> Untyped: ...
+
+@a.coroutine
+def g() -> Untyped: ...
+
+[case testCoroutineImportAsyncioCoroutinesAsC]
+import asyncio.coroutines as c
+
+class F:
+    @c.coroutine
+    def f(self):
+        return 1
+
+@c.coroutine
+def g():
+    return 2
+[out]
+import asyncio.coroutines as c
+from basedtyping import Untyped
+
+class F:
+    @c.coroutine
+    def f(self) -> Untyped: ...
+
+@c.coroutine
+def g() -> Untyped: ...
+
+[case testCoroutineImportAsyncioCoroutinesSubAsA]
+import asyncio as a
+
+class F:
+    @a.coroutines.coroutine
+    def f(self):
+        return 1
+
+@a.coroutines.coroutine
+def g():
+    return 2
+[out]
+import asyncio as a
+from basedtyping import Untyped
+
+class F:
+    @a.coroutines.coroutine
+    def f(self) -> Untyped: ...
+
+@a.coroutines.coroutine
+def g() -> Untyped: ...
+
+[case testCoroutineImportTypesAsT]
+import types as t
+
+class F:
+    @t.coroutine
+    def f(self):
+        return 1
+
+@t.coroutine
+def g():
+    return 2
+[out]
+import types as t
+from basedtyping import Untyped
+
+class F:
+    @t.coroutine
+    def f(self) -> Untyped: ...
+
+@t.coroutine
+def g() -> Untyped: ...
+
+[case testCoroutineSpecialCase_import]
+import asyncio
+
+__all__ = ['C']
+
+@asyncio.coroutine
+def f():
+    pass
+
+class C:
+    def f(self):
+        pass
+[out]
+import asyncio
+
+class C:
+    def f(self): ...
+
+-- Tests for stub generation from semantically analyzed trees.
+-- These tests are much slower, so use the `_semanal` suffix only when needed.
+
+[case testNestedClass_semanal]
+class Outer:
+    class Inner:
+        pass
+
+A = Outer.Inner
+[out]
+class Outer:
+    class Inner: ...
+A = Outer.Inner
+
+[case testFunctionAlias_semanal]
+from asyncio import coroutine
+
+@coroutine
+def start_server():
+    ...
+
+start = start_server
+[out]
+from asyncio import coroutine
+
+@coroutine
+def start_server(): ...
+start = start_server
+
+[case testModuleAlias_semanal]
+import a
+
+b = a
+[file a.py]
+x = 1
+[out]
+import a
+
+b = a
+
+[case testBadAliasNested_semanal]
+import a
+
+x = registry[a.f]
+[file a.py]
+def f(): ...
+[out]
+from basedtyping import Untyped
+
+x: Untyped
+
+[case testCrossModuleClass_semanal]
+import a
+
+class C:
+    x: A
+    def f(self) -> A: ...
+A = a.A
+[file a.py]
+class A: ...
+[out]
+import a
+
+class C:
+    x: A
+    def f(self) -> A: ...
+A = a.A
+
+[case testCrossModuleFunction_semanal]
+import a
+g = a.f
+[file a.py]
+def f(): ...
+[out]
+import a
+
+g = a.f
+
+[case testPrivateAliasesExcluded_semanal]
+import a, _a
+
+class C: ...
+
+A = a._A
+B = _a.f
+_C = C
+[file a.py]
+class _A: ...
+[file _a.py]
+def f(): ...
+[out]
+from basedtyping import Untyped
+
+class C: ...
+
+A: Untyped
+B: Untyped
+
+[case testPrivateAliasesIncluded_semanal]
+# flags: --include-private
+import a, _a
+
+class C: ...
+
+A = a._A
+B = _a.f
+_C = C
+[file a.py]
+class _A: ...
+[file _a.py]
+def f(): ...
+[out]
+import _a
+import a
+
+class C: ...
+A = a._A
+B = _a.f
+_C = C
+
+[case testFinalWrapped_semanal]
+from typing import Final
+
+x: Final = 1
+y: Final = x
+z: Final[object]
+t: Final
+[out]
+from basedtyping import Untyped
+from typing import Final
+
+x: Final[int]
+y: Final[Untyped]
+z: Final[object]
+t: Final[Untyped]
+
+[case testFinalInvalid_semanal]
+Final = 'boom'
+
+x: Final = 1
+[out]
+Final: str
+x: Final
+
+[case testNoFunctionNested_semanal]
+import a
+from typing import Dict, Any
+
+funcs: Dict[Any, Any]
+f = funcs[a.f]
+[out]
+from basedtyping import Untyped
+from typing import Any, Dict
+
+funcs: Dict[Any, Any]
+f: Untyped
+
+[case testAbstractMethodNameExpr]
+from abc import ABCMeta, abstractmethod
+
+class A(metaclass=ABCMeta):
+    @abstractmethod
+    def meth(self):
+        pass
+[out]
+from abc import ABCMeta, abstractmethod
+from basedtyping import Untyped
+
+class A(metaclass=ABCMeta):
+    @abstractmethod
+    def meth(self) -> Untyped: ...
+
+[case testAbstractMethodMemberExpr]
+import abc
+
+class A(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def meth(self):
+        pass
+[out]
+import abc
+from basedtyping import Untyped
+
+class A(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def meth(self) -> Untyped: ...
+
+[case testAbstractMethodMemberExpr2]
+import abc as _abc
+
+class A(metaclass=abc.ABCMeta):
+    @_abc.abstractmethod
+    def meth(self):
+        pass
+[out]
+import abc as _abc
+from basedtyping import Untyped
+
+class A(metaclass=abc.ABCMeta):
+    @_abc.abstractmethod
+    def meth(self) -> Untyped: ...
+
+[case testABCMeta_semanal]
+from base import Base
+from abc import abstractmethod
+
+class C(Base):
+    @abstractmethod
+    def other(self):
+        pass
+
+[file base.py]
+from abc import abstractmethod, ABCMeta
+
+class Base(metaclass=ABCMeta):
+    @abstractmethod
+    def meth(self):
+        pass
+[out]
+import abc
+from abc import abstractmethod
+from base import Base
+from basedtyping import Untyped
+
+class C(Base, metaclass=abc.ABCMeta):
+    @abstractmethod
+    def other(self) -> Untyped: ...
+
+[case testInvalidNumberOfArgsInAnnotation]
+def f(x):
+    # type: () -> int
+    return ''
+
+[out]
+from basedtyping import Untyped
+
+def f(x) -> Untyped: ...
+
+[case testFunctionPartiallyAnnotated]
+def f(x):
+    pass
+
+def g(x, y: str):
+    pass
+
+class A:
+    def f(self, x):
+        pass
+
+[out]
+from basedtyping import Untyped
+
+def f(x): ...
+def g(x, y: str) -> Untyped: ...
+
+class A:
+    def f(self, x): ...
+
+[case testExplicitAnyArg]
+from typing import Any
+
+def f(x: Any):
+    pass
+def g(x, y: Any) -> str:
+    pass
+def h(x: Any) -> str:
+    pass
+
+[out]
+from basedtyping import Untyped
+from typing import Any
+
+def f(x: Any) -> Untyped: ...
+def g(x, y: Any) -> str: ...
+def h(x: Any) -> str: ...
+
+[case testExplicitReturnedAny]
+from typing import Any
+
+def f(x: str) -> Any:
+    pass
+def g(x, y: str) -> Any:
+    pass
+def h(x) -> Any:
+    pass
+
+[out]
+from typing import Any
+
+def f(x: str) -> Any: ...
+def g(x, y: str) -> Any: ...
+def h(x) -> Any: ...
+
+[case testPlacementOfDecorators]
+class A:
+    @property
+    def x(self):
+        self.y = 'y'
+        return 'x'
+
+class B:
+    @property
+    def x(self):
+        return 'x'
+
+    @x.setter
+    def x(self, value):
+        self.y = 'y'
+
+[out]
+from basedtyping import Untyped
+
+class A:
+    y: str
+    @property
+    def x(self) -> Untyped: ...
+
+class B:
+    @property
+    def x(self) -> Untyped: ...
+    y: str
+    @x.setter
+    def x(self, value): ...
+
+[case testMisplacedTypeComment]
+def f():
+    x = 0
+
+    # type: str
+    y = ''
+
+[out]
+def f(): ...
+
+[case testConditionalImportAll_semanal]
+__all__ = ['cookielib']
+
+if object():
+    from http import cookiejar as cookielib
+else:
+    import cookielib
+
+[out]
+import cookielib as cookielib
+
+[case testCannotCalculateMRO_semanal]
+class X: pass
+
+class int(int, X):  # Cycle
+    pass
+
+class A: pass
+class B(A): pass
+class C(B): pass
+class D(A, B): pass # No consistent method resolution order
+class E(C, D): pass # Ditto
+
+[out]
+class X: ...
+class int(int, X): ...
+class A: ...
+class B(A): ...
+class C(B): ...
+class D(A, B): ...
+class E(C, D): ...
+
+[case testUnreachableCode_semanal]
+MYPY = False
+class A: pass
+if MYPY:
+    class C(A):
+        def f(self): pass
+else:
+    def f(i):
+        return i
+
+    class C(A):
+        def g(self): pass
+[out]
+MYPY: bool
+
+class A: ...
+
+class C(A):
+    def f(self): ...
+
+[case testAbstractProperty1_semanal]
+import other
+import abc
+
+class A:
+    @abc.abstractproperty
+    def x(self): pass
+
+[out]
+import abc
+from basedtyping import Untyped
+
+class A(metaclass=abc.ABCMeta):
+    @property
+    @abc.abstractmethod
+    def x(self) -> Untyped: ...
+
+[case testAbstractProperty2_semanal]
+import other
+from abc import abstractproperty
+
+class A:
+    @abstractproperty
+    def x(self): pass
+
+[out]
+import abc
+from basedtyping import Untyped
+
+class A(metaclass=abc.ABCMeta):
+    @property
+    @abc.abstractmethod
+    def x(self) -> Untyped: ...
+
+[case testAbstractProperty3_semanal]
+import other
+from abc import abstractproperty as alias_name
+
+class A:
+    @alias_name
+    def x(self): pass
+
+[out]
+import abc
+from basedtyping import Untyped
+
+class A(metaclass=abc.ABCMeta):
+    @property
+    @abc.abstractmethod
+    def x(self) -> Untyped: ...
+
+[case testClassWithNameUntypedOrOptional]
+Y = object()
+
+def g(x=None): pass
+
+x = g()
+
+class Untyped:
+    pass
+
+def Optional():
+    return 0
+
+[out]
+from basedtyping import Untyped as _Untyped
+
+Y: _Untyped
+
+def g(x: _Untyped | None = ...): ...
+
+x: _Untyped
+
+class Untyped: ...
+
+def Optional() -> _Untyped: ...
+
+[case testExportedNameImported]
+# modules: main a b
+from a import C
+
+class D(C): pass
+
+[file a.py]
+from b import C
+
+[file b.py]
+class C: pass
+
+[out]
+# main.pyi
+from a import C
+
+class D(C): ...
+# a.pyi
+from b import C as C
+# b.pyi
+class C: ...
+
+[case testVendoredSix]
+from p1.vendored import six
+from p1.vendor.six import foobar
+from p1.packages.six.moves import http_client
+from .packages.six.moves import queue
+from p1.vendored.six.moves.http_client import foo
+from p1.vendored.six.moves.urllib.parse import bar
+
+class C(http_client.HTTPMessage): pass
+class D(six.Iterator): pass
+
+[out]
+import six
+from six import foobar as foobar
+from six.moves import http_client, queue as queue
+from six.moves.http_client import foo as foo
+from six.moves.urllib.parse import bar as bar
+
+class C(http_client.HTTPMessage): ...
+class D(six.Iterator): ...
+
+[case testVendoredPackage]
+# modules: main p.vendored.requests p.sub.requests
+from p.vendored.requests import Request
+from p.sub.requests import Request2
+
+x = Request()
+y = Request2()
+
+[file p/__init__.py]
+
+[file p/vendored/__init__.py]
+
+[file p/vendored/requests.py]
+class Request:
+    pass
+
+[file p/sub/__init__.py]
+
+[file p/sub/requests.py]
+class Request2:
+    pass
+
+[out]
+# main.pyi
+from basedtyping import Untyped
+
+x: Untyped
+y: Untyped
+<out/p/vendored/requests.pyi was not generated>
+# p/sub/requests.pyi
+class Request2: ...
+
+[case testTestFiles]
+# modules: p p.x p.tests p.tests.test_foo
+
+[file p/__init__.py]
+def f(): pass
+
+[file p/x.py]
+def g(): pass
+
+[file p/tests/__init__.py]
+
+[file p/tests/test_foo.py]
+def test_thing(): pass
+
+[out]
+# p/__init__.pyi
+def f(): ...
+# p/x.pyi
+def g(): ...
+<out/p/tests.pyi was not generated>
+<out/p/tests/test_foo.pyi was not generated>
+
+[case testTestFiles_import]
+# modules: p p.x p.tests p.tests.test_foo
+
+[file p/__init__.py]
+def f(): pass
+
+[file p/x.py]
+def g(): pass
+
+[file p/tests/__init__.py]
+
+[file p/tests/test_foo.py]
+def test_thing(): pass
+
+[out]
+# p/__init__.pyi
+def f(): ...
+# p/x.pyi
+def g(): ...
+<out/p/tests.pyi was not generated>
+<out/p/tests/test_foo.pyi was not generated>
+
+[case testVerboseFlag]
+# Just test that --verbose does not break anything in a basic test case.
+# flags: --verbose
+
+def f(x, y): pass
+[out]
+def f(x, y): ...
+
+[case testImportedModuleExits_import]
+# modules: a b c
+
+[file a.py]
+def g(): pass
+
+[file b.py]
+import sys
+def f(): pass
+sys.exit(1)
+
+[file c.py]
+x = 0
+
+[out]
+# a.pyi
+def g(): ...
+# b.pyi
+def f(): ...
+# c.pyi
+x: int
+
+[case testImportedModuleHardExits_import]
+# modules: a b c
+
+[file a.py]
+def g(): pass
+
+[file b.py]
+import os
+def f(): pass
+os._exit(1)  # Kill process
+
+[file c.py]
+x = 0
+
+[out]
+# a.pyi
+def g(): ...
+# b.pyi
+def f(): ...
+# c.pyi
+x: int
+
+[case testImportedModuleHardExits2_import]
+# modules: p/a p/b p/c
+
+[file p/__init__.py]
+
+[file p/a.py]
+def g(): pass
+
+[file p/b.py]
+import os
+def f(): pass
+os._exit(1)  # Kill process
+
+[file p/c.py]
+x = 0
+
+[out]
+# p/a.pyi
+def g(): ...
+# p/b.pyi
+def f(): ...
+# p/c.pyi
+x: int
+
+[case testImportedModuleHardExits3_import]
+# modules: p p/a
+
+[file p/__init__.py]
+import os
+def f(): pass
+os._exit(1)  # Kill process
+
+[file p/a.py]
+def g(): pass
+
+[out]
+# p/__init__.pyi
+def f(): ...
+# p/a.pyi
+def g(): ...
+
+[case testImportedModuleHardExits4_import]
+# flags: -p p
+# modules: p p/a
+
+[file p/__init__.py]
+def ff(): pass
+
+[file p/a.py]
+import os
+def gg(): pass
+os._exit(1)  # Kill process
+
+[out]
+# p/__init__.pyi
+def ff(): ...
+# p/a.pyi
+def gg(): ...
+
+[case testExportInternalImportsByDefault]
+# modules: p p/a
+
+[file p/__init__.py]
+from p.a import A, f
+from m import C
+
+a: A
+c: C
+f()
+
+[file p/a.py]
+class A: pass
+def f(): pass
+
+[file m.py]
+class C: pass
+
+[out]
+# p/__init__.pyi
+from m import C
+from p.a import A as A, f as f
+
+a: A
+c: C
+# p/a.pyi
+class A: ...
+
+def f(): ...
+
+[case testNoExportOfInternalImportsIfAll_import]
+# modules: p p/a
+
+[file p/__init__.py]
+from p.a import A
+
+__all__ = ['a']
+
+a = None  # type: A
+b = 0  # type: int
+
+[file p/a.py]
+class A: pass
+
+[out]
+# p/__init__.pyi
+from p.a import A
+
+a: A
+# p/a.pyi
+class A: ...
+
+[case testExportInternalImportsByDefaultFromUnderscorePackage]
+# modules: p
+
+[file p.py]
+from _p import A
+from _m import B
+from _pm import C
+
+a: A
+b: B
+c: C
+
+[file _p.py]
+class A: pass
+
+[file _m.py]
+class B: pass
+
+[file _pm.py]
+class C: pass
+
+[out]
+from _m import B
+from _p import A as A
+from _pm import C
+
+a: A
+b: B
+c: C
+
+[case testDisableExportOfInternalImports]
+# flags: --export-less
+# modules: p p/a
+
+[file p/__init__.py]
+from p.a import A, B
+from m import C
+
+a: A
+c: C
+
+[file p/a.py]
+class A: pass
+class B: pass
+
+[file m.py]
+class C: pass
+
+[out]
+# p/__init__.pyi
+from m import C
+from p.a import A, B as B
+
+a: A
+c: C
+# p/a.pyi
+class A: ...
+class B: ...
+
+[case testExportInternalImportsByDefaultUsingRelativeImport]
+# modules: p.a
+
+[file p/__init__.py]
+
+[file p/a.py]
+from .b import f
+f()
+
+[file p/b.py]
+def f(): pass
+
+[out]
+from .b import f as f
+
+[case testExportInternalImportsByDefaultSkipPrivate]
+# modules: p.a
+
+[file p/__init__.py]
+
+[file p/a.py]
+from .b import _f, _g as _g, _i
+from p.b import _h
+_f()
+_h()
+
+[file p/b.py]
+def _f(): pass
+def _g(): pass
+def _h(): pass
+def _i(): pass
+x = 0
+
+[out]
+
+[case testExportInternalImportsByDefaultIncludePrivate]
+# flags: --include-private
+# modules: p.a
+
+[file p/__init__.py]
+
+[file p/a.py]
+from .b import _f
+_f()
+
+[file p/b.py]
+def _f(): pass
+
+[out]
+from .b import _f as _f
+
+[case testHideDunderModuleAttributes]
+from m import (
+    __about__,
+    __author__,
+    __copyright__,
+    __email__,
+    __license__,
+    __summary__,
+    __title__,
+    __uri__,
+    __version__
+)
+
+class A:
+    __uri__ = 0
+
+[file m.py]
+__about__ = ''
+__author__ = ''
+__copyright__ = ''
+__email__ = ''
+__license__ = ''
+__summary__ = ''
+__title__ = ''
+__uri__ = ''
+__version__ = ''
+
+[out]
+class A: ...
+
+[case testHideDunderModuleAttributesWithAll_import]
+from m import (
+    __about__,
+    __author__,
+    __copyright__,
+    __email__,
+    __license__,
+    __summary__,
+    __title__,
+    __uri__,
+    __version__
+)
+
+__all__ = ['__about__', '__author__', '__version__']
+
+[file m.py]
+__about__ = ''
+__author__ = ''
+__copyright__ = ''
+__email__ = ''
+__license__ = ''
+__summary__ = ''
+__title__ = ''
+__uri__ = ''
+__version__ = ''
+
+[out]
+
+[case testAttrsClass_semanal]
+import attr
+
+@attr.s
+class C:
+    x = attr.ib()
+
+[out]
+from basedtyping import Untyped
+
+class C:
+    x: Untyped
+    def __init__(self, x): ...
+    def __lt__(self, other) -> Untyped: ...
+    def __le__(self, other) -> Untyped: ...
+    def __gt__(self, other) -> Untyped: ...
+    def __ge__(self, other) -> Untyped: ...
+
+[case testNamedTupleInClass]
+from collections import namedtuple
+
+class C:
+    N = namedtuple('N', ['x', 'y'])
+[out]
+from basedtyping import Untyped
+from typing import NamedTuple
+
+class C:
+    class N(NamedTuple):
+        x: Untyped
+        y: Untyped
+
+[case testImports_directImportsWithAlias]
+import p.a as a
+import p.b as b
+
+x: a.X
+y: b.Y
+
+[out]
+import p.a as a
+import p.b as b
+
+x: a.X
+y: b.Y
+
+[case testImports_directImportsMixed]
+import p.a
+import p.a as a
+import p.b as b
+
+x: a.X
+y: b.Y
+z: p.a.X
+
+[out]
+import p.a as a
+import p.b as b
+import p.a
+
+x: a.X
+y: b.Y
+z: p.a.X
+
+[case testImport_overwrites_directWithAlias_from]
+import p.a as a
+from p import a
+
+x: a.X
+
+[out]
+from p import a as a
+
+x: a.X
+
+[case testImport_overwrites_directWithAlias_fromWithAlias]
+import p.a as a
+from p import b as a
+
+x: a.X
+
+[out]
+from p import b as a
+
+x: a.X
+
+[case testImports_overwrites_direct_from]
+import a
+from p import a
+
+x: a.X
+
+[out]
+from p import a as a
+
+x: a.X
+
+[case testImports_overwrites_direct_fromWithAlias]
+import a
+from p import b as a
+
+x: a.X
+
+[out]
+from p import b as a
+
+x: a.X
+
+[case testImports_overwrites_from_directWithAlias]
+from p import a
+import p.a as a
+
+x: a.X
+
+[out]
+import p.a as a
+
+x: a.X
+
+[case testImports_overwrites_fromWithAlias_direct]
+import a
+from p import b as a
+
+x: a.X
+
+[out]
+from p import b as a
+
+x: a.X
+
+[case testImports_direct]
+import p.a
+import pp
+
+x: a.X
+y: p.a.Y
+
+[out]
+import p.a
+
+x: a.X
+y: p.a.Y
+
+[case testOverload_fromTypingImport]
+from typing import Tuple, Union, overload
+
+class A:
+    @overload
+    def f(self, x: int, y: int) -> int:
+        ...
+
+    @overload
+    def f(self, x: Tuple[int, int]) -> int:
+        ...
+
+    def f(self, *args: Union[int, Tuple[int, int]]) -> int:
+        pass
+
+@overload
+def f(x: int, y: int) -> int:
+    ...
+
+@overload
+def f(x: Tuple[int, int]) -> int:
+    ...
+
+def f(*args: Union[int, Tuple[int, int]]) -> int:
+    pass
+
+
+[out]
+from typing import Tuple, overload
+
+class A:
+    @overload
+    def f(self, x: int, y: int) -> int: ...
+    @overload
+    def f(self, x: Tuple[int, int]) -> int: ...
+
+
+@overload
+def f(x: int, y: int) -> int: ...
+@overload
+def f(x: Tuple[int, int]) -> int: ...
+
+[case testOverload_importTyping]
+import typing
+
+class A:
+    @typing.overload
+    def f(self, x: int, y: int) -> int:
+        ...
+
+    @typing.overload
+    def f(self, x: typing.Tuple[int, int]) -> int:
+        ...
+
+    def f(self, *args: typing.Union[int, typing.Tuple[int, int]]) -> int:
+        pass
+
+    @typing.overload
+    @classmethod
+    def g(cls, x: int, y: int) -> int:
+        ...
+
+    @typing.overload
+    @classmethod
+    def g(cls, x: typing.Tuple[int, int]) -> int:
+        ...
+
+    @classmethod
+    def g(self, *args: typing.Union[int, typing.Tuple[int, int]]) -> int:
+        pass
+
+@typing.overload
+def f(x: int, y: int) -> int:
+    ...
+
+@typing.overload
+def f(x: typing.Tuple[int, int]) -> int:
+    ...
+
+def f(*args: typing.Union[int, typing.Tuple[int, int]]) -> int:
+    pass
+
+
+[out]
+import typing
+
+class A:
+    @typing.overload
+    def f(self, x: int, y: int) -> int: ...
+    @typing.overload
+    def f(self, x: typing.Tuple[int, int]) -> int: ...
+    @typing.overload
+    @classmethod
+    def g(cls, x: int, y: int) -> int: ...
+    @typing.overload
+    @classmethod
+    def g(cls, x: typing.Tuple[int, int]) -> int: ...
+
+
+@typing.overload
+def f(x: int, y: int) -> int: ...
+@typing.overload
+def f(x: typing.Tuple[int, int]) -> int: ...
+
+
+[case testOverload_importTypingAs]
+import typing as t
+
+class A:
+    @t.overload
+    def f(self, x: int, y: int) -> int:
+        ...
+
+    @t.overload
+    def f(self, x: t.Tuple[int, int]) -> int:
+        ...
+
+    def f(self, *args: typing.Union[int, t.Tuple[int, int]]) -> int:
+        pass
+
+    @t.overload
+    @classmethod
+    def g(cls, x: int, y: int) -> int:
+        ...
+
+    @t.overload
+    @classmethod
+    def g(cls, x: t.Tuple[int, int]) -> int:
+        ...
+
+    @classmethod
+    def g(self, *args: t.Union[int, t.Tuple[int, int]]) -> int:
+        pass
+
+@t.overload
+def f(x: int, y: int) -> int:
+    ...
+
+@t.overload
+def f(x: t.Tuple[int, int]) -> int:
+    ...
+
+def f(*args: t.Union[int, t.Tuple[int, int]]) -> int:
+    pass
+
+
+[out]
+import typing as t
+
+class A:
+    @t.overload
+    def f(self, x: int, y: int) -> int: ...
+    @t.overload
+    def f(self, x: t.Tuple[int, int]) -> int: ...
+    @t.overload
+    @classmethod
+    def g(cls, x: int, y: int) -> int: ...
+    @t.overload
+    @classmethod
+    def g(cls, x: t.Tuple[int, int]) -> int: ...
+
+
+@t.overload
+def f(x: int, y: int) -> int: ...
+@t.overload
+def f(x: t.Tuple[int, int]) -> int: ...
+
+[case testProtocol_semanal]
+from typing import Protocol, TypeVar
+
+class P(Protocol):
+    def f(self, x: int, y: int) -> str:
+        ...
+
+T = TypeVar('T')
+T2 = TypeVar('T2')
+class PT(Protocol[T, T2]):
+    def f(self, x: T) -> T2:
+        ...
+
+[out]
+from typing import Protocol, TypeVar
+
+class P(Protocol):
+    def f(self, x: int, y: int) -> str: ...
+T = TypeVar('T')
+T2 = TypeVar('T2')
+
+class PT(Protocol[T, T2]):
+    def f(self, x: T) -> T2: ...
+
+[case testNonDefaultKeywordOnlyArgAfterAsterisk]
+def func(*, non_default_kwarg: bool, default_kwarg: bool = True): ...
+[out]
+from basedtyping import Untyped
+
+def func(*, non_default_kwarg: bool, default_kwarg: bool = ...) -> Untyped: ...
+
+[case testNestedGenerator]
+def f():
+    def g():
+        yield 0
+
+    return 0
+[out]
+from basedtyping import Untyped
+
+def f() -> Untyped: ...


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/65446343/168778111-a25c9628-7f99-4f66-90c0-220cf3a7d8c9.png)

- closes #269
- closes #267 

Should `_typeshed.Incomplete` count as `Untyped`?

`Untyped` will cause errors on use.