### PR TITLE
intersection type

### DIFF
--- a/.github/workflows/mypy_primer.yml
+++ b/.github/workflows/mypy_primer.yml
@@ -66,7 +66,7 @@ jobs:
             --output concise \
             `# We don't want to run on spack because it has massive inferred types` \
             `#  https://github.com/KotlinIsland/basedmypy/issues/399` \
-            --project-selector "^(?!https://github.com/spack/spack)" \
+            --project-selector "^(?!https://github.com/(spack/spack|mitmproxy/mitmproxy))" \
             | tee diff_${{ matrix.shard-index }}.txt
           ) || [ $? -eq 1 ]
       - name: Upload mypy_primer diff

--- a/.mypy/baseline.json
+++ b/.mypy/baseline.json
@@ -1987,7 +1987,7 @@
         "code": "no-any-expr",
         "column": 42,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 679,
+        "offset": 681,
         "src": "if isinstance(inner_type, CallableType):",
         "target": "mypy.checker.TypeChecker.check_overlapping_overloads"
       },
@@ -2371,7 +2371,7 @@
         "code": "no-any-expr",
         "column": 56,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 719,
+        "offset": 721,
         "src": "assert isinstance(called_type, (CallableType, Overloaded))",
         "target": "mypy.checker.TypeChecker.find_isinstance_check_helper"
       },
@@ -2427,7 +2427,7 @@
         "code": "no-any-expr",
         "column": 27,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 578,
+        "offset": 591,
         "src": "if isinstance(typ, CallableType):",
         "target": "mypy.checker.TypeChecker.add_any_attribute_to_type"
       },
@@ -2493,7 +2493,7 @@
         "code": "no-any-expr",
         "column": 34,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 347,
+        "offset": 354,
         "src": "if isinstance(result, CallableType) and isinstance(  # type: ignore[misc]",
         "target": "mypy.checkexpr.ExpressionChecker.analyze_ref_expr"
       },
@@ -2621,7 +2621,7 @@
         "code": "no-any-expr",
         "column": 49,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 245,
+        "offset": 249,
         "src": "assert isinstance(node.type, CallableType)",
         "target": "mypy.checkexpr.ExpressionChecker.can_return_none"
       },
@@ -2733,15 +2733,23 @@
         "code": "no-any-expr",
         "column": 33,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 349,
+        "offset": 360,
         "src": "if not all(isinstance(c, CallableType) for c in types):",
         "target": "mypy.checkexpr.ExpressionChecker.combine_function_signatures"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 55,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 198,
+        "src": "if isinstance(get_proper_type(res[1]), CallableType):",
+        "target": "mypy.checkexpr.ExpressionChecker.check_intersection_call"
       },
       {
         "code": "possibly-undefined",
         "column": 16,
         "message": "Name \"left_map\" may be undefined",
-        "offset": 1005,
+        "offset": 851,
         "src": "and left_map is None",
         "target": "mypy.checkexpr"
       },
@@ -2871,7 +2879,7 @@
         "code": "possibly-undefined",
         "column": 26,
         "message": "Name \"impl\" may be undefined",
-        "offset": 362,
+        "offset": 366,
         "src": "if isinstance(impl.type, CallableType)",
         "target": "mypy.checkmember"
       },
@@ -2887,7 +2895,7 @@
         "code": "no-any-expr",
         "column": 48,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 199,
+        "offset": 216,
         "src": "if isinstance(getattr_type, CallableType):",
         "target": "mypy.checkmember.analyze_member_var_access"
       },
@@ -4751,7 +4759,7 @@
         "code": "unreachable",
         "column": 20,
         "message": "Statement is unreachable",
-        "offset": 398,
+        "offset": 399,
         "src": "merged_option = None",
         "target": "mypy.constraints.any_constraints"
       },
@@ -4823,7 +4831,7 @@
         "code": "no-any-expr",
         "column": 35,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 211,
+        "offset": 217,
         "src": "if isinstance(self.actual, CallableType):",
         "target": "mypy.constraints.ConstraintBuilderVisitor.visit_overloaded"
       },
@@ -4841,7 +4849,7 @@
         "code": "no-any-explicit",
         "column": 44,
         "message": "Explicit \"Any\" is not allowed",
-        "offset": 127,
+        "offset": 131,
         "src": "return self.copy_common(t, TypeType(cast(Any, t.item)))",
         "target": "mypy.copytype.TypeShallowCopier.visit_type_type"
       },
@@ -6629,7 +6637,7 @@
         "code": "no-any-expr",
         "column": 26,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 132,
+        "offset": 133,
         "src": "if isinstance(callee, CallableType):",
         "target": "mypy.expandtype.freshen_function_type_vars"
       },
@@ -6687,7 +6695,7 @@
         "code": "no-any-explicit",
         "column": 8,
         "message": "Explicit \"Any\" is not allowed",
-        "offset": 191,
+        "offset": 192,
         "src": "NamedExpr = Any",
         "target": "mypy.fastparse"
       },
@@ -9253,17 +9261,41 @@
       },
       {
         "code": "no-any-expr",
-        "column": 32,
+        "column": 33,
         "message": "Expression type contains \"Any\" (has type \"type[BitOr]\")",
         "offset": 11,
-        "src": "if not isinstance(n.op, ast3.BitOr):",
+        "src": "if not isinstance(n.op, (ast3.BitOr, ast3.BitAnd)):",
+        "target": "mypy.fastparse.TypeConverter.visit_BinOp"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 33,
+        "message": "Expression type contains \"Any\" (has type \"(type[BitOr], type[BitAnd])\")",
+        "offset": 0,
+        "src": "if not isinstance(n.op, (ast3.BitOr, ast3.BitAnd)):",
+        "target": "mypy.fastparse.TypeConverter.visit_BinOp"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 45,
+        "message": "Expression type contains \"Any\" (has type \"type[BitAnd]\")",
+        "offset": 0,
+        "src": "if not isinstance(n.op, (ast3.BitOr, ast3.BitAnd)):",
+        "target": "mypy.fastparse.TypeConverter.visit_BinOp"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 28,
+        "message": "Expression type contains \"Any\" (has type \"type[BitAnd]\")",
+        "offset": 4,
+        "src": "if isinstance(n.op, ast3.BitAnd):",
         "target": "mypy.fastparse.TypeConverter.visit_BinOp"
       },
       {
         "code": "no-any-expr",
         "column": 22,
         "message": "Expression has type \"Any\"",
-        "offset": 14,
+        "offset": 18,
         "src": "if isinstance(n.value, bool):",
         "target": "mypy.fastparse.TypeConverter.visit_NameConstant"
       },
@@ -9539,7 +9571,7 @@
         "code": "truthy-bool",
         "column": 15,
         "message": "Member \"defn\" has type \"ClassDef\" which does not implement __bool__ or __len__ so it could always be true in boolean context",
-        "offset": 70,
+        "offset": 71,
         "src": "if info.defn:",
         "target": "mypy.fixup.NodeFixer.visit_type_info"
       },
@@ -9635,7 +9667,7 @@
         "code": "no-any-explicit",
         "column": 4,
         "message": "Explicit \"Any\" is not allowed",
-        "offset": 63,
+        "offset": 67,
         "src": "def visit_void(self, o: Any) -> None:",
         "target": "mypy.fixup.TypeFixer.visit_void"
       }
@@ -9679,7 +9711,7 @@
         "code": "no-any-expr",
         "column": 30,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 380,
+        "offset": 387,
         "src": "if isinstance(self.s, CallableType) and is_similar_callables(t, self.s):",
         "target": "mypy.join.TypeJoinVisitor.visit_callable_type"
       },
@@ -10549,7 +10581,7 @@
         "code": "no-any-expr",
         "column": 60,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 438,
+        "offset": 441,
         "src": "if isinstance(left, TypeType) and isinstance(right, CallableType):",
         "target": "mypy.meet.is_overlapping_types"
       },
@@ -10589,7 +10621,7 @@
         "code": "no-any-expr",
         "column": 64,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 239,
+        "offset": 244,
         "src": "if isinstance(self.s, Parameters) or isinstance(self.s, CallableType):",
         "target": "mypy.meet.TypeMeetVisitor.visit_parameters"
       },
@@ -10905,7 +10937,7 @@
         "code": "no-any-expr",
         "column": 41,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 410,
+        "offset": 411,
         "src": "if isinstance(original_type, CallableType) and original_type.is_type_obj():",
         "target": "mypy.messages.MessageBuilder.has_no_attr"
       },
@@ -11137,7 +11169,7 @@
         "code": "unreachable",
         "column": 16,
         "message": "Statement is unreachable",
-        "offset": 356,
+        "offset": 359,
         "src": "return",
         "target": "mypy.messages.MessageBuilder.report_protocol_problems"
       },
@@ -11233,7 +11265,7 @@
         "code": "no-any-expr",
         "column": 30,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 323,
+        "offset": 325,
         "src": "elif isinstance(func, CallableType):",
         "target": "mypy.messages.format_type_inner"
       },
@@ -12130,10 +12162,18 @@
         "target": "mypy.options.Options.__init__"
       },
       {
+        "code": "var-annotated",
+        "column": 12,
+        "message": "Need type annotation for \"d\"",
+        "offset": 40,
+        "src": "d = dict(getattr(self, \"__dict__\", ()))",
+        "target": "mypy.options.Options.snapshot"
+      },
+      {
         "code": "no-any-expr",
         "column": 17,
         "message": "Expression type contains \"Any\" (has type \"Any | ()\")",
-        "offset": 40,
+        "offset": 0,
         "src": "d = dict(getattr(self, \"__dict__\", ()))",
         "target": "mypy.options.Options.snapshot"
       },
@@ -12538,7 +12578,7 @@
       {
         "code": "unreachable",
         "column": 20,
-        "message": "Subclass of \"TupleType\" and \"LiteralType\" cannot exist: would have incompatible method signatures",
+        "message": "Intersection of \"TupleType & LiteralType\" cannot exist: would have incompatible method signatures",
         "offset": 465,
         "src": "elif isinstance(ctx.type, LiteralType):",
         "target": "mypy.plugins.default.tuple_mul_callback"
@@ -14049,7 +14089,7 @@
         "code": "unreachable",
         "column": 8,
         "message": "Statement is unreachable",
-        "offset": 224,
+        "offset": 225,
         "src": "if node.type:",
         "target": "mypy.server.astdiff.snapshot_definition"
       }
@@ -14059,7 +14099,7 @@
         "code": "unreachable",
         "column": 12,
         "message": "Statement is unreachable",
-        "offset": 297,
+        "offset": 298,
         "src": "node.analyzed = self.fixup(node.analyzed)",
         "target": "mypy.server.astmerge.NodeReplaceVisitor.visit_call_expr"
       }
@@ -14079,7 +14119,7 @@
         "code": "unreachable",
         "column": 24,
         "message": "Statement is unreachable",
-        "offset": 506,
+        "offset": 507,
         "src": "fname = init.node.fullname",
         "target": "mypy.server.deps.DependencyVisitor.visit_assignment_stmt"
       },
@@ -14095,7 +14135,7 @@
         "code": "no-any-expr",
         "column": 57,
         "message": "Expression type contains \"Any\" (has type \"(Untyped) -> Any\")",
-        "offset": 84,
+        "offset": 90,
         "src": "for trigger, targets in sorted(all_deps.items(), key=lambda x: x[0]):",
         "target": "mypy.server.deps.dump_all_dependencies"
       },
@@ -18997,7 +19037,7 @@
         "code": "no-any-expr",
         "column": 29,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 623,
+        "offset": 630,
         "src": "if isinstance(right, CallableType):",
         "target": "mypy.subtypes.SubtypeVisitor.visit_instance"
       },
@@ -19037,7 +19077,7 @@
         "code": "no-any-expr",
         "column": 29,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 127,
+        "offset": 132,
         "src": "if isinstance(right, CallableType):",
         "target": "mypy.subtypes.SubtypeVisitor.visit_type_type"
       },
@@ -21733,7 +21773,7 @@
         "code": "no-any-expr",
         "column": 29,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 899,
+        "offset": 937,
         "src": "assert isinstance(j, CallableType)",
         "target": "mypy.test.testtypes.JoinSuite.test_simple_type_objects"
       }
@@ -21743,7 +21783,7 @@
         "code": "no-any-explicit",
         "column": 12,
         "message": "Explicit \"Any\" is not allowed",
-        "offset": 248,
+        "offset": 253,
         "src": "cast(Any, t.partial_fallback.accept(self)),",
         "target": "mypy.type_visitor.TypeTranslator.visit_tuple_type"
       },
@@ -21775,7 +21815,7 @@
         "code": "no-any-expr",
         "column": 35,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 25,
+        "offset": 28,
         "src": "assert isinstance(new, CallableType)  # type: ignore[misc]",
         "target": "mypy.type_visitor.TypeTranslator.visit_overloaded"
       },
@@ -21793,7 +21833,7 @@
         "code": "no-any-expr",
         "column": 31,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 1293,
+        "offset": 1310,
         "src": "assert isinstance(ret, CallableType)",
         "target": "mypy.typeanal.TypeAnalyser.analyze_callable_type"
       }
@@ -21803,7 +21843,7 @@
         "code": "no-any-expr",
         "column": 29,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 158,
+        "offset": 159,
         "src": "if isinstance(signature, CallableType):",
         "target": "mypy.typeops.type_object_type_from_function"
       },
@@ -21827,7 +21867,7 @@
         "code": "no-any-expr",
         "column": 34,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 240,
+        "offset": 362,
         "src": "if isinstance(callee, CallableType):",
         "target": "mypy.typeops._get_type_special_method_bool_ret_type"
       },
@@ -23165,6 +23205,62 @@
         "code": "no-any-expr",
         "column": 15,
         "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "offset": 14,
+        "src": "return {",
+        "target": "mypy.types.NamedOverloaded.serialize"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 12,
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "offset": 2,
+        "src": "\"items\": [t.serialize() for t in self.items],",
+        "target": "mypy.types.NamedOverloaded.serialize"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 22,
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "offset": 0,
+        "src": "\"items\": [t.serialize() for t in self.items],",
+        "target": "mypy.types.NamedOverloaded.serialize"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 15,
+        "message": "Expression has type \"Any\"",
+        "offset": 6,
+        "src": "assert data[\".class\"] == \"NamedOverloaded\"",
+        "target": "mypy.types.NamedOverloaded.deserialize"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 32,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "src": "return NamedOverloaded([CallableType.deserialize(t) for t in data[\"items\"]], data[\"_name\"])",
+        "target": "mypy.types.NamedOverloaded.deserialize"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 32,
+        "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
+        "offset": 0,
+        "src": "return NamedOverloaded([CallableType.deserialize(t) for t in data[\"items\"]], data[\"_name\"])",
+        "target": "mypy.types.NamedOverloaded.deserialize"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 57,
+        "message": "Expression has type \"Any\"",
+        "offset": 0,
+        "src": "return NamedOverloaded([CallableType.deserialize(t) for t in data[\"items\"]], data[\"_name\"])",
+        "target": "mypy.types.NamedOverloaded.deserialize"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 15,
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 71,
         "src": "return {",
         "target": "mypy.types.TupleType.serialize"
@@ -23349,6 +23445,54 @@
         "code": "no-any-expr",
         "column": 15,
         "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
+        "offset": 56,
+        "src": "return {\".class\": \"IntersectionType\", \"items\": [t.serialize() for t in self.items]}",
+        "target": "mypy.types.IntersectionType.serialize"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 46,
+        "message": "Expression type contains \"Any\" (has type \"(str, list[Any])\")",
+        "offset": 0,
+        "src": "return {\".class\": \"IntersectionType\", \"items\": [t.serialize() for t in self.items]}",
+        "target": "mypy.types.IntersectionType.serialize"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 56,
+        "message": "Expression type contains \"Any\" (has type \"list[Any]\")",
+        "offset": 0,
+        "src": "return {\".class\": \"IntersectionType\", \"items\": [t.serialize() for t in self.items]}",
+        "target": "mypy.types.IntersectionType.serialize"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 15,
+        "message": "Expression has type \"Any\"",
+        "offset": 4,
+        "src": "assert data[\".class\"] == \"IntersectionType\"",
+        "target": "mypy.types.IntersectionType.deserialize"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 33,
+        "message": "Expression has type \"Any\"",
+        "offset": 1,
+        "src": "return IntersectionType([deserialize_type(t) for t in data[\"items\"]])",
+        "target": "mypy.types.IntersectionType.deserialize"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 50,
+        "message": "Expression has type \"Any\"",
+        "offset": 0,
+        "src": "return IntersectionType([deserialize_type(t) for t in data[\"items\"]])",
+        "target": "mypy.types.IntersectionType.deserialize"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 15,
+        "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
         "offset": 131,
         "src": "return {\".class\": \"TypeType\", \"item\": self.item.serialize()}",
         "target": "mypy.types.TypeType.serialize"
@@ -23413,7 +23557,7 @@
         "code": "no-any-expr",
         "column": 23,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 112,
+        "offset": 115,
         "src": "if isinstance(typ, CallableType):",
         "target": "mypy.types.strip_type"
       },
@@ -23445,7 +23589,7 @@
         "code": "no-any-expr",
         "column": 15,
         "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
-        "offset": 192,
+        "offset": 197,
         "src": "names: Final = globals().copy()",
         "target": "mypy.types"
       },
@@ -25897,7 +26041,7 @@
         "code": "no-any-expr",
         "column": 29,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 114,
+        "offset": 115,
         "src": "elif isinstance(typ, CallableType):",
         "target": "mypyc.irbuild.mapper.Mapper.type_to_rtype"
       },
@@ -25905,7 +26049,7 @@
         "code": "no-any-expr",
         "column": 33,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 40,
+        "offset": 42,
         "src": "if isinstance(fdef.type, CallableType):",
         "target": "mypyc.irbuild.mapper.Mapper.fdef_to_sig"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Basedmypy Changelog
 
 ## [Unreleased]
+### Added
+- `Intersection` type
 
 ## [1.7.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ compatibility with the cringe parts of pep 484.
 Based features include:
 - Typesafe by default (optional and dynamic typing still supported)
 - Baseline functionality
+- Support for `Intersection` types
 - Default return type of `None` instead of `Any`
 - Infer type from default value
 - Infer overload types

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Based  <img src="docs/source/mypy_light.svg" alt="mypy logo" width="300px"/>
 
 [![Discord](https://img.shields.io/discord/948915247073349673?logo=discord)](https://discord.gg/7y9upqPrk2)
+[![Stable Version](https://img.shields.io/pypi/v/basedmypy?color=blue)](https://pypi.org/project/basedmypy/)
+[![Downloads](https://img.shields.io/pypi/dm/basedmypy)](https://pypistats.org/packages/basedmypy)
+[![Checked with basedmypy](https://img.shields.io/badge/basedmypy-checked-green)](https://mypy-lang.org/)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 
 Basedmypy: Based Static Typing for Python
 =========================================
@@ -15,11 +20,11 @@ Based features include:
 - Baseline functionality
 - Support for `Intersection` types
 - Default return type of `None` instead of `Any`
-- Infer type from default value
+- Infer parameter type from default value
 - Infer overload types
 - Bare literals
 
-See the [changelog](CHANGELOG.md) for a comprehensive list.
+See the [features](#features) for a more information.
 
 ## Usage
 
@@ -35,6 +40,180 @@ Basedmypy is installed as an alternative to, and in place of, the `mypy` install
     mypy test.py
 
     python -m mypy test.py
+
+## Features
+
+Ever tried to use pythons type system and thought to yourself "This doesn't seem based".
+
+Well fret no longer as basedmypy got you covered!
+
+### Baseline
+
+Basedmypy has baseline, baseline is based! It allows you to adopt new strictness or features
+without the burden of fixing up every usage, just save all current errors to the baseline
+file and deal with them later.
+
+```py
+def foo(a):
+    print(a)
+```
+```
+> mypy test.py
+error: missing typehints !!!!!
+Epic fail bro!
+
+> mypy --write-baseline test.py
+error: missing typehints
+Baseline successfully written to .mypy/baseline.json
+
+> mypy test.py
+Success: no issues found in 1 source file
+```
+Then on subsequent runs the existing errors will be filtered out.
+
+```py
+def foo(a):
+    print(a)
+
+def bar(b: str, c: int) -> bool:
+    return b + c
+```
+```
+> mypy test.py
+test.py:4:5: error: Returning Any from function declared to return "bool"  [no-any-return]
+test.py:4:16: error: Unsupported operand types for + ("str" and "int")  [operator]
+Found 2 errors in 1 file (checked 1 source file)
+```
+### Intersection Types
+
+Using the `&` operator or `basedtyping.Intersection` you can denote intersection types.
+
+```py
+class Growable(ABC, Generic[T]):
+    @abstractmethod
+    def add(self, item: T): ...
+
+class Resettable(ABC):
+    @abstractmethod
+    def reset(self): ...
+
+def f(x: Resettable & Growable[str]):
+    x.reset()
+    x.add("first")
+```
+### Type Joins
+
+Mypy joins types like so:
+```py
+a: int
+b: str
+reveal_type(a if bool() else b)  # Revealed type is "builtins.object"
+``````
+Basedmypy joins types into unions instead:
+```py
+a: int
+b: str
+reveal_type(a if bool() else b)  # Revealed type is "int | str"
+```
+### Bare Literals
+
+`Literal` is so cumbersome! just use a bare literal instead.
+
+```py
+class Color(Enum):
+    RED = auto()
+
+a: 1 | 2
+b: True | Color.RED
+```
+
+### Default Return Type
+
+With the `default_return` option, the default return type of functions becomes `None` instead of `Any`.
+
+```py
+def f(name: str):
+    print(f"Hello, {name}!")
+
+reveal_type(f)  # (str) -> None
+```
+### Nested TypeVars
+
+With nested `TypeVar`s you are able to have functions with polymorphic generic parameters.
+
+```py
+E = TypeVar("E")
+I = TypeVar("I", bound=Iterable[E])
+
+def foo(i: I, e: E) -> I:
+    assert e not in i
+    return i
+
+reveal_type(foo(["based"], "mypy"))  # N: Revealed type is "list[str]"
+reveal_type(foo({1, 2}, 3))  # N: Revealed type is "set[int]"
+```
+
+### Overload Implementation Inference
+
+Specifying types in overload implementations is completely redundant! basedmypy will infer them.
+
+```py
+@overload
+def f(a: int) -> str: ...
+
+@overload
+def f(a: str) -> int: ...
+
+def f(a):
+    reveal_type(a)  # int | str
+    return None  # error: expected str | int
+
+class A:
+    @property
+    def foo(self) -> int: ...
+    @foo.setter
+    def foo(self, value): ...  # no need for annotations
+```
+
+### Infer Function Parameters
+
+Infer the type of a function parameter from it's default value.
+
+```py
+def f(a=1, b=True):
+    reveal_type((a, b))  # (int, bool)
+```
+### Better Types in Messages
+
+```py
+T = TypeVar("T", bound=int)
+
+def f(a: T, b: list[str | 1 | 2]) -> Never:
+    reveal_type((a, b))
+
+reveal_type(f)
+```
+Mypy shows
+```
+Revealed type is "Tuple[T`-1, Union[builtins.str, Literal[1], Literal[2]]]"
+Revealed type is "def [T <: builtins.int] (a: T`-1, b: Union[builtins.str, Literal[1], Literal[2]]) -> <nothing>"
+```
+Basedmypy shows
+```
+Revealed type is "(T@f, str | 1 | 2)"
+Revealed type is "def [T: int] (a: T, b: str | 1 | 2) -> Never"
+```
+### Ignore Unused Type Ignores
+
+In code that is targeting multiple versions of python or multiple platforms it is difficult
+to work with `type: ignore` comments and use the `warn_unused_ignore` option.
+
+The `unused-ignore` error code can be used for this situation.
+
+```py
+if sys.platform != "linux":
+  foo()  # type: ignore[misc, unused-ignore]
+```
 
 Got a question or found a bug?
 ----------------------------------

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,5 +1,5 @@
 # NOTE: this needs to be kept in sync with the "requires" list in pyproject.toml
-basedtyping>=0.0.2
+basedtyping>=0.0.3
 typing_extensions>=3.10
 mypy_extensions>=1.0.0
 typed_ast>=1.4.0,<2; python_version<'3.8'

--- a/mypy/checker.py
+++ b/mypy/checker.py
@@ -168,6 +168,7 @@ from mypy.typeops import (
     get_type_vars,
     is_literal_type_like,
     is_singleton_type,
+    make_simplified_intersection,
     make_simplified_union,
     map_type_from_supertype,
     true_only,
@@ -188,6 +189,7 @@ from mypy.types import (
     ErasedType,
     FunctionLike,
     Instance,
+    IntersectionType,
     LiteralType,
     NoneType,
     Overloaded,
@@ -279,6 +281,10 @@ class PartialTypeScope(NamedTuple):
     map: dict[Var, Context]
     is_function: bool
     is_local: bool
+
+
+class InvalidTypeType(Exception):
+    """For when an invalid TypeType appears."""
 
 
 class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
@@ -5126,7 +5132,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
 
     def intersect_instances(
         self, instances: tuple[Instance, Instance], errors: list[tuple[str, str]]
-    ) -> Instance | None:
+    ) -> IntersectionType | Instance | None:
         """Try creating an ad-hoc intersection of the given instances.
 
         Note that this function does *not* try and create a full-fledged
@@ -5178,8 +5184,8 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         def _make_fake_typeinfo_and_full_name(
             base_classes_: list[Instance], curr_module_: MypyFile
         ) -> tuple[TypeInfo, str]:
-            names_list = pretty_seq([x.type.name for x in base_classes_], "and")
-            short_name = f"<subclass of {names_list}>"
+            names_list = pretty_seq([x.type.name for x in base_classes_], "&")
+            short_name = f"{names_list}"
             full_name_ = gen_unique_name(short_name, curr_module_.names)
             cdef, info_ = self.make_fake_typeinfo(
                 curr_module_.fullname, full_name_, short_name, base_classes_
@@ -5190,7 +5196,9 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         # We use the pretty_names_list for error messages but can't
         # use it for the real name that goes into the symbol table
         # because it can have dots in it.
-        pretty_names_list = pretty_seq(format_type_distinctly(*base_classes, bare=True), "and")
+        pretty_names_list = " & ".join(format_type_distinctly(*base_classes, bare=True))
+        pretty_names_list = f'"{pretty_names_list}"'
+        bases = base_classes
         try:
             info, full_name = _make_fake_typeinfo_and_full_name(base_classes, curr_module)
             with self.msg.filter_errors() as local_errors:
@@ -5210,7 +5218,7 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
             return None
 
         curr_module.names[full_name] = SymbolTableNode(GDEF, info)
-        return Instance(info, [], extra_attrs=instances[0].extra_attrs or instances[1].extra_attrs)
+        return IntersectionType(bases)
 
     def intersect_instance_callable(self, typ: Instance, callable_type: CallableType) -> Instance:
         """Creates a fake type that represents the intersection of an Instance and a CallableType.
@@ -6659,16 +6667,37 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         if isinstance(vartype, TypeVarType):
             vartype = vartype.upper_bound
         vartype = get_proper_type(vartype)
-        if isinstance(vartype, UnionType):
-            union_list = []
-            for t in get_proper_types(vartype.items):
-                if isinstance(t, TypeType):
-                    union_list.append(t.item)
-                else:
-                    # This is an error that should be reported earlier
-                    # if we reach here, we refuse to do any type inference.
-                    return {}, {}
-            vartype = UnionType(union_list)
+
+        def search_type_type(it: ProperType) -> ProperType:
+            if isinstance(it, UnionType):
+                union_list = []
+                for t in get_proper_types(it.items):
+                    t = search_type_type(t)
+                    if isinstance(t, TypeType):
+                        union_list.append(t.item)
+                    else:
+                        raise InvalidTypeType
+                return UnionType(union_list)
+            elif isinstance(it, IntersectionType):
+                intersection_list = []
+                for t in get_proper_types(it.items):
+                    t = search_type_type(t)
+                    if isinstance(t, TypeType):
+                        intersection_list.append(t.item)
+                    else:
+                        # This is an error that should be reported earlier
+                        # if we reach here, we refuse to do any type inference.
+                        raise InvalidTypeType
+                return IntersectionType(intersection_list)
+            return it
+
+        if isinstance(vartype, (UnionType, IntersectionType)):
+            try:
+                vartype = search_type_type(vartype)
+            except InvalidTypeType:
+                # This is an error that should be reported earlier
+                # if we reach here, we refuse to do any type inference.
+                return {}, {}
         elif isinstance(vartype, TypeType):
             vartype = vartype.item
         elif isinstance(vartype, Instance) and vartype.type.is_metaclass():
@@ -6735,7 +6764,20 @@ class TypeChecker(NodeVisitor[None], CheckerPluginInterface):
         errors: list[tuple[str, str]] = []
         for v in possible_expr_types:
             if not isinstance(v, Instance):
-                return yes_type, no_type
+                if not isinstance(v, IntersectionType):
+                    return yes_type, no_type
+                for t in possible_target_types:
+                    for v_item in v.items:
+                        v_type = get_proper_type(v_item)
+                        if isinstance(v_type, Instance) and self.intersect_instances(
+                            (v_type, t), errors
+                        ):
+                            break
+                    else:
+                        continue
+                    # Not necessarily a valid Intersection, but who asked????
+                    out.append(make_simplified_intersection((*v.items, t)))
+                break
             for t in possible_target_types:
                 intersection = self.intersect_instances((v, t), errors)
                 if intersection is None:
@@ -7189,7 +7231,7 @@ def convert_to_typetype(type_map: TypeMap) -> TypeMap:
         if isinstance(t, TypeVarType):
             t = t.upper_bound
         # TODO: should we only allow unions of instances as per PEP 484?
-        if not isinstance(get_proper_type(t), (UnionType, Instance)):
+        if not isinstance(get_proper_type(t), (UnionType, IntersectionType, Instance)):
             # unknown type; error was likely reported earlier
             return {}
         converted_type_map[expr] = TypeType.make_normalized(typ)

--- a/mypy/copytype.py
+++ b/mypy/copytype.py
@@ -8,6 +8,7 @@ from mypy.types import (
     DeletedType,
     ErasedType,
     Instance,
+    IntersectionType,
     LiteralType,
     NoneType,
     Overloaded,
@@ -118,6 +119,9 @@ class TypeShallowCopier(TypeVisitor[ProperType]):
 
     def visit_union_type(self, t: UnionType) -> ProperType:
         return self.copy_common(t, UnionType(t.items))
+
+    def visit_intersection_type(self, t: IntersectionType) -> ProperType:
+        return self.copy_common(t, IntersectionType(t.items))
 
     def visit_overloaded(self, t: Overloaded) -> ProperType:
         return self.copy_common(t, Overloaded(items=t.items))

--- a/mypy/erasetype.py
+++ b/mypy/erasetype.py
@@ -9,6 +9,7 @@ from mypy.types import (
     DeletedType,
     ErasedType,
     Instance,
+    IntersectionType,
     LiteralType,
     NoneType,
     Overloaded,
@@ -127,6 +128,12 @@ class EraseTypeVisitor(TypeVisitor[ProperType]):
         from mypy.typeops import make_simplified_union
 
         return make_simplified_union(erased_items)
+
+    def visit_intersection_type(self, t: IntersectionType) -> ProperType:
+        erased_items = [erase_type(item) for item in t.items]
+        from mypy.typeops import make_simplified_intersection
+
+        return make_simplified_intersection(erased_items)
 
     def visit_type_type(self, t: TypeType) -> ProperType:
         return TypeType.make_normalized(t.item.accept(self), line=t.line)

--- a/mypy/fastparse.py
+++ b/mypy/fastparse.py
@@ -105,6 +105,7 @@ from mypy.types import (
     CallableType,
     EllipsisType,
     Instance,
+    IntersectionType,
     ProperType,
     RawExpressionType,
     TupleType,
@@ -382,7 +383,7 @@ def parse_type_string(
             node.original_str_expr = expr_string
             node.original_str_fallback = expr_fallback_name
             return node
-        elif isinstance(node, UnionType):
+        elif isinstance(node, (UnionType, IntersectionType)):
             return node
         else:
             return RawExpressionType(expr_string, expr_fallback_name, line, column)
@@ -1903,11 +1904,19 @@ class TypeConverter:
         return UnboundType(n.id, line=self.line, column=self.convert_column(n.col_offset))
 
     def visit_BinOp(self, n: ast3.BinOp) -> Type:
-        if not isinstance(n.op, ast3.BitOr):
+        if not isinstance(n.op, (ast3.BitOr, ast3.BitAnd)):
             return self.invalid_type(n)
-
         left = self.visit(n.left)
         right = self.visit(n.right)
+        if isinstance(n.op, ast3.BitAnd):
+            return IntersectionType(
+                [left, right],
+                line=self.line,
+                column=self.convert_column(n.col_offset),
+                is_evaluated=self.is_evaluated,
+                uses_based_syntax=True,
+            )
+
         return UnionType(
             [left, right],
             line=self.line,

--- a/mypy/fixup.py
+++ b/mypy/fixup.py
@@ -26,6 +26,7 @@ from mypy.types import (
     AnyType,
     CallableType,
     Instance,
+    IntersectionType,
     LiteralType,
     Overloaded,
     Parameters,
@@ -330,6 +331,10 @@ class TypeFixer(TypeVisitor[None]):
         if ut.items:
             for it in ut.items:
                 it.accept(self)
+
+    def visit_intersection_type(self, it: IntersectionType):
+        for item in it.items:
+            item.accept(self)
 
     def visit_void(self, o: Any) -> None:
         pass  # Nothing to descend into.

--- a/mypy/indirection.py
+++ b/mypy/indirection.py
@@ -111,6 +111,9 @@ class TypeIndirectionVisitor(TypeVisitor[Set[str]]):
     def visit_union_type(self, t: types.UnionType) -> set[str]:
         return self._visit(t.items)
 
+    def visit_intersection_type(self, t: types.IntersectionType) -> Set[str]:
+        return self._visit(t.items)
+
     def visit_partial_type(self, t: types.PartialType) -> set[str]:
         return set()
 

--- a/mypy/join.py
+++ b/mypy/join.py
@@ -24,6 +24,7 @@ from mypy.types import (
     ErasedType,
     FunctionLike,
     Instance,
+    IntersectionType,
     LiteralType,
     NoneType,
     Overloaded,
@@ -294,6 +295,12 @@ class TypeJoinVisitor(TypeVisitor[ProperType]):
             return t
         else:
             return mypy.typeops.make_simplified_union([self.s, t])
+
+    def visit_intersection_type(self, t: IntersectionType) -> ProperType:
+        if is_proper_subtype(self.s, t):
+            return t
+        else:
+            return mypy.typeops.make_simplified_intersection([self.s, t])
 
     def visit_any(self, t: AnyType) -> ProperType:
         return t

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -70,6 +70,7 @@ from mypy.types import (
     DeletedType,
     FunctionLike,
     Instance,
+    IntersectionType,
     LiteralType,
     NoneType,
     Overloaded,
@@ -1952,7 +1953,10 @@ class MessageBuilder:
     def impossible_intersection(
         self, formatted_base_class_list: str, reason: str, context: Context
     ) -> None:
-        template = "Subclass of {} cannot exist: would have {}"
+        if mypy.options._based:
+            template = "Intersection of {} cannot exist: would have {}"
+        else:
+            template = "Subclass of {} cannot exist: would have {}"
         self.fail(
             template.format(formatted_base_class_list, reason), context, code=codes.UNREACHABLE
         )
@@ -2487,6 +2491,8 @@ def format_type_inner(
                 s = f"Union[{format_list(typ.items)}]"
 
             return s
+    elif isinstance(typ, IntersectionType):
+        return " & ".join((format(typ) for typ in typ.items))
     elif isinstance(typ, NoneType):
         return "None"
     elif isinstance(typ, AnyType):

--- a/mypy/server/astdiff.py
+++ b/mypy/server/astdiff.py
@@ -80,6 +80,7 @@ from mypy.types import (
     DeletedType,
     ErasedType,
     Instance,
+    IntersectionType,
     LiteralType,
     NoneType,
     Overloaded,
@@ -461,6 +462,13 @@ class SnapshotTypeVisitor(TypeVisitor[SnapshotItem]):
         items = {snapshot_type(item) for item in typ.items}
         normalized = tuple(sorted(items))
         return ("UnionType", normalized)
+
+    def visit_intersection_type(self, typ: IntersectionType) -> SnapshotItem:
+        # Sort and remove duplicates so that we can use equality to test for
+        # equivalent intersection type snapshots.
+        items = {snapshot_type(item) for item in typ.items}
+        normalized = tuple(sorted(items))
+        return "IntersectionType", normalized
 
     def visit_overloaded(self, typ: Overloaded) -> SnapshotItem:
         return ("Overloaded", snapshot_types(typ.items))

--- a/mypy/server/astmerge.py
+++ b/mypy/server/astmerge.py
@@ -87,6 +87,7 @@ from mypy.types import (
     EllipsisType,
     ErasedType,
     Instance,
+    IntersectionType,
     LiteralType,
     NoneType,
     Overloaded,
@@ -523,6 +524,10 @@ class TypeReplaceVisitor(SyntheticTypeVisitor[None]):
         pass
 
     def visit_union_type(self, typ: UnionType) -> None:
+        for item in typ.items:
+            item.accept(self)
+
+    def visit_intersection_type(self, typ: IntersectionType):
         for item in typ.items:
             item.accept(self)
 

--- a/mypy/server/deps.py
+++ b/mypy/server/deps.py
@@ -150,6 +150,7 @@ from mypy.types import (
     ErasedType,
     FunctionLike,
     Instance,
+    IntersectionType,
     LiteralType,
     NoneType,
     Overloaded,
@@ -1083,6 +1084,12 @@ class TypeTriggersVisitor(TypeVisitor[List[str]]):
         return []
 
     def visit_union_type(self, typ: UnionType) -> list[str]:
+        triggers = []
+        for item in typ.items:
+            triggers.extend(self.get_type_triggers(item))
+        return triggers
+
+    def visit_intersection_type(self, typ: IntersectionType) -> List[str]:
         triggers = []
         for item in typ.items:
             triggers.extend(self.get_type_triggers(item))

--- a/mypy/solve.py
+++ b/mypy/solve.py
@@ -64,7 +64,7 @@ def solve_constraints(
                 if top is None:
                     top = c.target
                 else:
-                    top = meet_types(top, c.target)
+                    top = meet_types(top, c.target, intersect=True)
 
         p_top = get_proper_type(top)
         p_bottom = get_proper_type(bottom)

--- a/mypy/test/testconstraints.py
+++ b/mypy/test/testconstraints.py
@@ -5,7 +5,7 @@ import pytest
 from mypy.constraints import SUBTYPE_OF, SUPERTYPE_OF, Constraint, infer_constraints
 from mypy.test.helpers import Suite
 from mypy.test.typefixture import TypeFixture
-from mypy.types import Instance, TupleType, UnpackType
+from mypy.types import Instance, IntersectionType, TupleType, UnpackType
 
 
 class ConstraintsSuite(Suite):
@@ -159,3 +159,16 @@ class ConstraintsSuite(Suite):
             Instance(fx.std_tuplei, [fx.a]),
             SUPERTYPE_OF,
         )
+
+    def test_intersection(self):
+        fx = self.fx
+        assert set(
+            infer_constraints(
+                IntersectionType([fx.t, fx.d]), IntersectionType([fx.a, fx.d]), SUPERTYPE_OF
+            )
+        ) == {Constraint(fx.t, SUPERTYPE_OF, fx.a)}
+        assert set(
+            infer_constraints(
+                IntersectionType([fx.t, fx.d]), IntersectionType([fx.a, fx.d]), SUBTYPE_OF
+            )
+        ) == {Constraint(fx.t, SUBTYPE_OF, fx.a)}

--- a/mypy/test/testtypes.py
+++ b/mypy/test/testtypes.py
@@ -12,11 +12,12 @@ from mypy.state import state
 from mypy.subtypes import is_more_precise, is_proper_subtype, is_same_type, is_subtype
 from mypy.test.helpers import Suite, assert_equal, assert_type, skip
 from mypy.test.typefixture import InterfaceTypeFixture, TypeFixture
-from mypy.typeops import false_only, make_simplified_union, true_only
+from mypy.typeops import false_only, make_simplified_intersection, make_simplified_union, true_only
 from mypy.types import (
     AnyType,
     CallableType,
     Instance,
+    IntersectionType,
     LiteralType,
     NoneType,
     Overloaded,
@@ -326,6 +327,20 @@ class TypeOpsSuite(Suite):
         assert is_proper_subtype(UnionType([fx.a, fx.b]), UnionType([fx.a, fx.b, fx.c]))
         assert not is_proper_subtype(UnionType([fx.a, fx.b]), UnionType([fx.b, fx.c]))
 
+        assert is_proper_subtype(IntersectionType([fx.a, fx.b]), fx.a)
+        assert not is_proper_subtype(fx.a, IntersectionType([fx.a, fx.b]))
+        assert not is_proper_subtype(
+            IntersectionType([fx.a, fx.b]), IntersectionType([fx.a, fx.b, fx.c])
+        )
+        assert is_proper_subtype(IntersectionType([fx.a, fx.b]), IntersectionType([fx.a, fx.b]))
+        assert is_proper_subtype(
+            IntersectionType([fx.a, fx.b, fx.c]), IntersectionType([fx.a, fx.b])
+        )
+        assert not is_proper_subtype(
+            IntersectionType([fx.a, fx.b]), IntersectionType([fx.b, fx.c])
+        )
+        assert is_proper_subtype(IntersectionType([fx.a, fx.b]), IntersectionType([fx.b, fx.a]))
+
     def test_is_proper_subtype_covariance(self) -> None:
         fx_co = self.fx_co
 
@@ -600,6 +615,29 @@ class TypeOpsSuite(Suite):
     def assert_simplified_union(self, original: list[Type], union: Type) -> None:
         assert_equal(make_simplified_union(original), union)
         assert_equal(make_simplified_union(list(reversed(original))), union)
+
+    def test_simplified_intersection(self):
+        fx = self.fx
+
+        self.assert_simplified_intersection([fx.a, fx.a], fx.a)
+        self.assert_simplified_intersection([fx.a, fx.b], fx.b)
+        self.assert_simplified_intersection([fx.a, fx.d], IntersectionType([fx.a, fx.d]))
+        self.assert_simplified_intersection([fx.a, fx.uninhabited], fx.uninhabited)
+        self.assert_simplified_intersection([fx.ga, fx.gs2a], fx.gs2a)
+        self.assert_simplified_intersection([fx.ga, fx.gsab], IntersectionType([fx.ga, fx.gsab]))
+        self.assert_simplified_intersection([fx.ga, fx.gsba], fx.gsba)
+        self.assert_simplified_intersection(
+            [fx.a, IntersectionType([fx.d])], IntersectionType([fx.a, fx.d])
+        )
+        self.assert_simplified_intersection([fx.a, IntersectionType([fx.a])], fx.a)
+        self.assert_simplified_intersection(
+            [fx.b, IntersectionType([fx.c, IntersectionType([fx.d])])],
+            IntersectionType([fx.b, fx.c, fx.d]),
+        )
+
+    def assert_simplified_intersection(self, original: list[Type], intersection: Type) -> None:
+        assert_equal(make_simplified_intersection(original), intersection)
+        assert_equal(make_simplified_intersection(list(reversed(original))), intersection)
 
     # Helpers
 

--- a/mypy/type_visitor.py
+++ b/mypy/type_visitor.py
@@ -27,6 +27,7 @@ from mypy.types import (
     EllipsisType,
     ErasedType,
     Instance,
+    IntersectionType,
     LiteralType,
     NoneType,
     Overloaded,
@@ -128,6 +129,10 @@ class TypeVisitor(Generic[T]):
 
     @abstractmethod
     def visit_union_type(self, t: UnionType) -> T:
+        pass
+
+    @abstractmethod
+    def visit_intersection_type(self, t: IntersectionType) -> T:
         pass
 
     @abstractmethod
@@ -269,6 +274,9 @@ class TypeTranslator(TypeVisitor[Type]):
     def visit_union_type(self, t: UnionType) -> Type:
         return UnionType(self.translate_types(t.items), t.line, t.column)
 
+    def visit_intersection_type(self, t: IntersectionType) -> Type:
+        return IntersectionType(self.translate_types(t.items), t.line, t.column)
+
     def translate_types(self, types: Iterable[Type]) -> list[Type]:
         return [t.accept(self) for t in types]
 
@@ -383,6 +391,9 @@ class TypeQuery(SyntheticTypeVisitor[T]):
         return self.strategy([])
 
     def visit_union_type(self, t: UnionType) -> T:
+        return self.query_types(t.items)
+
+    def visit_intersection_type(self, t: IntersectionType) -> T:
         return self.query_types(t.items)
 
     def visit_overloaded(self, t: Overloaded) -> T:
@@ -523,6 +534,9 @@ class BoolTypeQuery(SyntheticTypeVisitor[bool]):
         return self.default
 
     def visit_union_type(self, t: UnionType) -> bool:
+        return self.query_types(t.items)
+
+    def visit_intersection_type(self, t: IntersectionType) -> bool:
         return self.query_types(t.items)
 
     def visit_overloaded(self, t: Overloaded) -> bool:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2258,6 +2258,29 @@ class Overloaded(FunctionLike):
         return Overloaded([CallableType.deserialize(t) for t in data["items"]])
 
 
+class NamedOverloaded(Overloaded):
+    slots = ("_name",)
+
+    def __init__(self, items: list[CallableType], name: str):
+        self._name = name
+        super().__init__(items)
+
+    def get_name(self) -> str:
+        return self._name
+
+    def serialize(self) -> JsonDict:
+        return {
+            ".class": "NamedOverloaded",
+            "items": [t.serialize() for t in self.items],
+            "_name": self._name,
+        }
+
+    @classmethod
+    def deserialize(cls, data: JsonDict) -> NamedOverloaded:
+        assert data[".class"] == "NamedOverloaded"
+        return NamedOverloaded([CallableType.deserialize(t) for t in data["items"]], data["_name"])
+
+
 class TupleType(ProperType):
     """The tuple type Tuple[T1, ..., Tn] (at least one type argument).
 
@@ -2763,6 +2786,67 @@ class UnionType(ProperType):
         return UnionType([deserialize_type(t) for t in data["items"]])
 
 
+class IntersectionType(ProperType):
+    """Experimental intersection type"""
+
+    __slots__ = ("items", "is_evaluated", "uses_based_syntax")
+
+    def __init__(
+        self,
+        items: Sequence[Type],
+        line: int = -1,
+        column: int = -1,
+        is_evaluated=True,
+        uses_based_syntax=False,
+    ):
+        super().__init__(line, column)
+        self.items = flatten_nested_unions(items, type_type=IntersectionType)
+        self.can_be_true = any(item.can_be_true for item in items)
+        self.can_be_false = any(item.can_be_false for item in items)
+        self.is_evaluated = is_evaluated
+        self.uses_based_syntax = uses_based_syntax
+
+    def __hash__(self) -> int:
+        return hash(frozenset(self.items))
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, IntersectionType):
+            return NotImplemented
+        return frozenset(self.items) == frozenset(other.items)
+
+    @overload
+    @staticmethod
+    def make_intersection(
+        items: Sequence[ProperType], line: int = ..., column: int = ...
+    ) -> ProperType:
+        ...
+
+    @overload
+    @staticmethod
+    def make_intersection(items: Sequence[Type], line: int = ..., column: int = ...) -> Type:
+        ...
+
+    @staticmethod
+    def make_intersection(items: Sequence[Type], line: int = -1, column: int = -1) -> Type:
+        if len(items) > 1:
+            return IntersectionType(items, line, column)
+        elif len(items) == 1:
+            return items[0]
+        else:
+            return UninhabitedType()
+
+    def accept(self, visitor: "TypeVisitor[T]") -> T:
+        return visitor.visit_intersection_type(self)
+
+    def serialize(self) -> JsonDict:
+        return {".class": "IntersectionType", "items": [t.serialize() for t in self.items]}
+
+    @classmethod
+    def deserialize(cls, data: JsonDict) -> "IntersectionType":
+        assert data[".class"] == "IntersectionType"
+        return IntersectionType([deserialize_type(t) for t in data["items"]])
+
+
 class PartialType(ProperType):
     """Type such as List[?] where type arguments are unknown, or partial None type.
 
@@ -2874,6 +2958,12 @@ class TypeType(ProperType):
         if isinstance(item, UnionType):
             return UnionType.make_union(
                 [TypeType.make_normalized(union_item) for union_item in item.items],
+                line=line,
+                column=column,
+            )
+        if isinstance(item, IntersectionType):
+            return IntersectionType.make_intersection(
+                [TypeType.make_normalized(intersection_item) for intersection_item in item.items],
                 line=line,
                 column=column,
             )
@@ -3314,6 +3404,9 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
             return f"Union[{s}]"
         return self.union_str(t.items)
 
+    def visit_intersection_type(self, t: IntersectionType) -> str:
+        return " & ".join(t.accept(self) for t in t.items)
+
     def visit_partial_type(self, t: PartialType) -> str:
         if t.type is None:
             return "<partial None>"
@@ -3540,7 +3633,9 @@ def _flattened(types: Iterable[Type]) -> Iterable[Type]:
 
 
 def flatten_nested_unions(
-    types: Sequence[Type], handle_type_alias_type: bool = True
+    types: Sequence[Type],
+    handle_type_alias_type: bool = True,
+    type_type: type[UnionType | IntersectionType] = UnionType,
 ) -> list[Type]:
     """Flatten nested unions in a type list."""
     if not isinstance(types, list):
@@ -3549,15 +3644,18 @@ def flatten_nested_unions(
         typelist = cast("list[Type]", types)
 
     # Fast path: most of the time there is nothing to flatten
-    if not any(isinstance(t, (TypeAliasType, UnionType)) for t in typelist):  # type: ignore[misc]
+    if not any(isinstance(t, (TypeAliasType, type_type)) for t in typelist):  # type: ignore[misc]
         return typelist
 
     flat_items: list[Type] = []
     for t in typelist:
         tp = get_proper_type(t) if handle_type_alias_type else t
-        if isinstance(tp, ProperType) and isinstance(tp, UnionType):
+        if isinstance(tp, ProperType) and isinstance(tp, type_type):
             flat_items.extend(
-                flatten_nested_unions(tp.items, handle_type_alias_type=handle_type_alias_type)
+                flatten_nested_unions(
+                    cast(Union[UnionType, IntersectionType], tp).items,
+                    handle_type_alias_type=handle_type_alias_type,
+                )
             )
         else:
             # Must preserve original aliases when possible.

--- a/mypy/typetraverser.py
+++ b/mypy/typetraverser.py
@@ -12,6 +12,7 @@ from mypy.types import (
     EllipsisType,
     ErasedType,
     Instance,
+    IntersectionType,
     LiteralType,
     NoneType,
     Overloaded,
@@ -95,6 +96,9 @@ class TypeTraverserVisitor(SyntheticTypeVisitor[None]):
         t.fallback.accept(self)
 
     def visit_union_type(self, t: UnionType) -> None:
+        self.traverse_types(t.items)
+
+    def visit_intersection_type(self, t: IntersectionType) -> None:
         self.traverse_types(t.items)
 
     def visit_overloaded(self, t: Overloaded) -> None:

--- a/mypyc/irbuild/mapper.py
+++ b/mypyc/irbuild/mapper.py
@@ -7,6 +7,7 @@ from mypy.types import (
     AnyType,
     CallableType,
     Instance,
+    IntersectionType,
     LiteralType,
     NoneTyp,
     Overloaded,
@@ -117,6 +118,8 @@ class Mapper:
             return none_rprimitive
         elif isinstance(typ, UnionType):
             return RUnion.make_simplified_union([self.type_to_rtype(item) for item in typ.items])
+        elif isinstance(typ, IntersectionType):
+            return object_rprimitive
         elif isinstance(typ, AnyType):
             return object_rprimitive
         elif isinstance(typ, TypeType):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ Well fret no longer as basedmypy got you covered!
 Baseline
 --------
 
-Basedmypy has baseline, baseline is based! It allows you to adopt new features from basedmypy
+Basedmypy has baseline, baseline is based! It allows you to adopt new strictness or features
 without the burden of fixing up every usage, just save all current errors to the baseline
 file and deal with them later.
 
@@ -49,16 +49,183 @@ file and deal with them later.
 
 .. code-block:: bash
 
-    > mypy .
+    > mypy test.py
     error: missing typehints !!!!!
     Epic fail bro!
 
-    > mypy --write-baseline .
-    error: missing typehints
-    Baseline successfully saved!
+    > mypy --write-baseline test.py
+    test.py:1:1: error: Function is missing a type annotation for one or more arguments  [no-untyped-def]
+    Baseline successfully written to .mypy/baseline.json
 
-    > mypy .
-    Looks good to me, no errors!
+    > mypy test.py
+    Success: no issues found in 1 source file
+
+Then on subsequent runs the existing errors will be filtered out.
+
+.. code-block:: python
+
+    def foo(a):
+        print(a)
+
+    def bar(b: str, c: int) -> bool:
+        return b + c
+
+.. code-block:: bash
+
+    > mypy test.py
+    test.py:4:5: error: Returning Any from function declared to return "bool"  [no-any-return]
+    test.py:4:16: error: Unsupported operand types for + ("str" and "int")  [operator]
+    Found 2 errors in 1 file (checked 1 source file)
+
+Intersection Types
+------------------
+
+Using the `&` operator or `basedtyping.Intersection` you can denote intersection types.
+
+.. code-block:: python
+
+    class Growable(ABC, Generic[T]):
+        @abstractmethod
+        def add(self, item: T): ...
+
+    class Resettable(ABC):
+        @abstractmethod
+        def reset(self): ...
+
+    def f(x: Resettable & Growable[str]):
+        x.reset()
+        x.add("first")
+
+Type Joins
+----------
+
+Mypy joins types like so:
+
+.. code-block:: python
+
+    a: int
+    b: str
+    reveal_type(a if bool() else b)  # Revealed type is "builtins.object"
+
+Basedmypy joins types into unions instead:
+
+.. code-block:: python
+
+    a: int
+    b: str
+    reveal_type(a if bool() else b)  # Revealed type is "int | str"
+
+Bare Literals
+-------------
+
+`Literal` is so cumbersome! just use a bare literal instead.
+
+.. code-block:: python
+
+    class Color(Enum):
+        RED = auto()
+
+    a: 1 | 2
+    b: True | Color.RED
+
+
+Default Return Type
+-------------------
+
+With the `default_return` option, the default return type of functions becomes `None` instead of `Any`.
+
+.. code-block:: python
+
+    def f(name: str):
+        print(f"Hello, {name}!")
+
+    reveal_type(f)  # (str) -> None
+
+Nested TypeVars
+---------------
+
+With nested ``TypeVar``\\s you are able to have functions with polymorphic generic parameters.
+
+.. code-block:: python
+
+    E = TypeVar("E")
+    I = TypeVar("I", bound=Iterable[E])
+
+    def foo(i: I, e: E) -> I:
+        assert e not in i
+        return i
+
+    reveal_type(foo(["based"], "mypy"))  # N: Revealed type is "list[str]"
+    reveal_type(foo({1, 2}, 3))  # N: Revealed type is "set[int]"
+
+Overload Implementation Inference
+---------------------------------
+
+Specifying types in overload implementations is completely redundant! basedmypy will infer them.
+
+.. code-block:: python
+
+    @overload
+    def f(a: int) -> str: ...
+
+    @overload
+    def f(a: str) -> int: ...
+
+    def f(a):
+        reveal_type(a)  # int | str
+        return None  # error: expected str | int
+
+    class A:
+        @property
+        def foo(self) -> int: ...
+        @foo.setter
+        def foo(self, value): ...  # no need for annotations
+
+
+Infer Function Parameters
+-------------------------
+
+Infer the type of a function parameter from it's default value.
+
+.. code-block:: python
+
+    def f(a=1, b=True):
+        reveal_type((a, b))  # (int, bool)
+
+Better Types in Messages
+------------------------
+
+.. code-block:: python
+
+    T = TypeVar("T", bound=int)
+
+    def f(a: T, b: list[str | 1 | 2]) -> Never:
+        reveal_type((a, b))
+
+    reveal_type(f)
+
+Mypy shows::
+
+    Revealed type is "Tuple[T`-1, Union[builtins.str, Literal[1], Literal[2]]]"
+    Revealed type is "def [T <: builtins.int] (a: T`-1, b: Union[builtins.str, Literal[1], Literal[2]]) -> <nothing>"
+
+Basedmypy shows::
+
+    Revealed type is "(T@f, str | 1 | 2)"
+    Revealed type is "def [T: int] (a: T, b: str | 1 | 2) -> Never"
+
+Ignore Unused Type Ignores
+--------------------------
+
+In code that is targeting multiple versions of python or multiple platforms it is difficult
+to work with `type: ignore` comments and use the `warn_unused_ignore` option.
+
+The `unused-ignore` error code can be used for this situation.
+
+.. code-block:: python
+
+    if sys.platform != "linux":
+      foo()  # type: ignore[misc, unused-ignore]
 """.lstrip()
 
 

--- a/setup.py
+++ b/setup.py
@@ -245,7 +245,7 @@ setup(
     # When changing this, also update mypy-requirements.txt.
     install_requires=[
         "typed_ast >= 1.4.0, < 2; python_version<'3.8'",
-        "basedtyping>=0.0.1",
+        "basedtyping>=0.0.3",
         "typing_extensions>=3.10",
         "mypy_extensions >= 1.0.0",
         "tomli>=1.1.0; python_version<'3.11'",

--- a/test-data/unit/check-based-intersection.test
+++ b/test-data/unit/check-based-intersection.test
@@ -1,0 +1,341 @@
+[case testIntersection]
+from basedtyping import Intersection
+i: Intersection[int, str]
+reveal_type(i)  # N: Revealed type is "int & str"
+[builtins fixtures/tuple.pyi]
+
+
+[case testIntersectionSyntax]
+from __future__ import annotations
+i: int & str
+reveal_type(i)  # N: Revealed type is "int & str"
+[builtins fixtures/tuple.pyi]
+
+
+[case testNoIntersectionSyntax]
+i: int & str  # E: "X & Y" syntax for intersections requires __future__.annotations or quoted types  [valid-type]
+
+
+[case testIntersectionAttribute]
+from __future__ import annotations
+class A:
+    a: int
+
+class B:
+    b: str
+
+i: A & B
+reveal_type(i.a)  # N: Revealed type is "int"
+reveal_type(i.b)  # N: Revealed type is "str"
+reveal_type(i.c)  # E: "A & B" has no attribute "c"  [attr-defined] \
+                  # N: Revealed type is "Any (from error)"
+[builtins fixtures/tuple.pyi]
+
+
+[case testIntersectionAssignability]
+# flags: --disallow-redefinition
+from __future__ import annotations
+class A: pass
+class B: pass
+class AB(A, B): pass
+class D: pass
+
+ab: AB
+cd: AB & D
+ab_or_d: AB | D
+d: D
+i: A & B
+i = A()  # E: Incompatible types in assignment (expression has type "A", variable has type "A & B")  [assignment]
+ba: B & A = i
+i = ab
+i = d  # E: Incompatible types in assignment (expression has type "D", variable has type "A & B")  [assignment]
+i = ab_or_d  # E: Incompatible types in assignment (expression has type "AB | D", variable has type "A & B")  [assignment]
+[builtins fixtures/tuple.pyi]
+
+
+[case testIntersectionFromNarrowing]
+from __future__ import annotations
+class A: pass
+class B: pass
+
+i: A
+assert isinstance(i, B)
+reveal_type(i)  # N: Revealed type is "__main__.A & __main__.B"
+[builtins fixtures/tuple.pyi]
+
+
+[case testIntersectionWithBothCallable]
+from __future__ import annotations
+from typing import Callable
+class A:
+    def __call__(self, a: int): ...
+foo: A & Callable[[], int]
+reveal_type(foo())  # N: Revealed type is "int"
+foo("")  # E: No overload variant of "A & () -> int" matches argument type "str"  [call-overload] \
+         # N: Possible overload variants: \
+         # N:     def __call__(self, a: int) -> None \
+         # N:     def () -> int
+[builtins fixtures/tuple.pyi]
+
+
+[case testIntersectionOneCallable]
+from __future__ import annotations
+from typing import Callable
+class A:
+    pass
+foo: A & Callable[[], int]
+reveal_type(foo())  # N: Revealed type is "int"
+foo("")  # E: No overload variant of "A & () -> int" matches argument type "str"  [call-overload] \
+         # N: Possible overload variant: \
+         # N:     def () -> int
+[builtins fixtures/tuple.pyi]
+
+
+[case testIndexable]
+from __future__ import annotations
+
+class A:
+    def __getitem__(self, item: str): ...
+a: list[str] & A
+a[0]
+a["i"]
+a[None]  # E: No overload variant of "(int) -> str & (str) -> None" matches argument type "None"  [call-overload] \
+         # N: Possible overload variants: \
+         # N:     def __getitem__(self, int, /) -> str \
+         # N:     def __getitem__(self, str, /) -> None
+[builtins fixtures/list.pyi]
+
+
+[case testMultipleNarrowedIntersection-xfail]
+from __future__ import annotations
+class A: pass
+class B: pass
+class C: pass
+
+x: A
+reveal_type(x)  # N: Revealed type is "__main__.A"
+assert isinstance(x, B)
+reveal_type(x)  # N: Revealed type is "__main__.A & __main__.B"
+assert isinstance(x, C)
+reveal_type(x)  # N: Revealed type is "__main__.A & __main__.B & __main__.C"
+
+y: (A & B) | (A & C)
+assert isinstance(y, C)
+reveal_type(y)  # N: Revealed type is "__main__.A & __main__.B & __main__.C | __main__.A & __main__.C"
+[builtins fixtures/tuple.pyi]
+
+
+-- This is not implemented yet, maybe next sprint
+[case testInvalidIntersection-xfail]
+from __future__ import annotations
+
+a: int & str  # E: Intersection of "int & str" cannot exist: would have incompatible method signatures  [unreachable]
+a: 1 & 2  # E: Intersection of "1 & 2" cannot exist: would have incompatible method signatures  [unreachable]
+
+
+[case testIntersectionWithAny]
+# flags: --allow-any-expr --allow-any-explicit --disallow-redefinition
+from __future__ import annotations
+
+from typing import Any
+
+a: Any & str
+reveal_type(a)  # N: Revealed type is "Any & str"
+a = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "Any & str")  [assignment]
+a = ""
+
+b: Any
+assert isinstance(b, str)
+reveal_type(b)  # N: Revealed type is "str"
+[builtins fixtures/tuple.pyi]
+
+
+[case testOverrideInIntersection]
+from __future__ import annotations
+
+class A:
+    def foo(self) -> int:
+        return True
+class B(A):
+    def foo(self) -> bool:
+        return True
+
+b: A & B
+reveal_type(b.foo())  # N: Revealed type is "bool"
+[builtins fixtures/tuple.pyi]
+
+
+[case testOverloaded]
+from __future__ import annotations
+from typing import overload
+class A:
+    @overload
+    def foo(self): ...
+    @overload
+    def foo(self, x: int): ...
+    def foo(self, x=1): ...
+class B:
+    def foo(self, x: str): ...
+
+x: A & B
+x.foo(None)  # E: No overload variant of "foo" of "__main__.A & __main__.B" matches argument type "None"  [call-overload] \
+             # N: Possible overload variants: \
+             # N:     def foo(self) -> None \
+             # N:     def foo(self, x: int) -> None \
+             # N:     def foo(self, x: str) -> None
+[builtins fixtures/tuple.pyi]
+
+
+[case testGenericFunction]
+from __future__ import annotations
+
+from typing import TypeVar
+
+T = TypeVar('T')
+U = TypeVar('U')
+
+def foo(x: T, y: U) -> T & U: pass
+a: int
+b: object
+reveal_type(foo(a, b))  # N: Revealed type is "int"
+[builtins fixtures/tuple.pyi]
+
+
+[case testIntersectionInferenceWithTypeVarValues]
+from __future__ import annotations
+from typing import TypeVar
+AnyStr = TypeVar('AnyStr', bytes, str)
+class A: pass
+strA: str & A
+def f(x: AnyStr & A, *a: AnyStr): pass
+f(strA)
+f(strA, 'bar')
+f(strA, b'bar') # E: Value of type variable "AnyStr" of "f" cannot be "str | bytes"  [type-var]
+[builtins fixtures/primitives.pyi]
+[builtins fixtures/tuple.pyi]
+
+-- what's going on here?
+[case testIntersectionTwoPassInference-xfail]
+from __future__ import annotations
+from typing import TypeVar
+T = TypeVar('T')
+U = TypeVar('U')
+def j(x: list[T] & list[U], y: list[T]) -> list[U]: pass
+
+a = [1]
+b = ['b']
+# We could infer: Since list[str] <: list[T], we must have T = str.
+# Then since list[int] <: Union[list[str], list[U]], and list[int] is
+# not a subtype of list[str], we must have U = int.
+# This is not currently implemented.
+j(a, b)
+[builtins fixtures/list.pyi]
+[builtins fixtures/tuple.pyi]
+
+
+[case testIntersectionContext]
+from __future__ import annotations
+
+from typing import TypeVar
+
+class A: pass
+class B: pass
+
+T = TypeVar('T')
+def f() -> list[T]: pass
+d1: list[int] & A = f()  # E: Incompatible types in assignment (expression has type "list[int]", variable has type "list[int] & A")  [assignment]
+d2: A & B = f() # E: Incompatible types in assignment (expression has type "list[Never]", variable has type "A & B")  [assignment]
+[builtins fixtures/list.pyi]
+[builtins fixtures/tuple.pyi]
+
+
+[case testGenericFunctionSubtypingWithIntersections]
+# flags: --disallow-redefinition
+from __future__ import annotations
+from typing import TypeVar
+T = TypeVar('T')
+S = TypeVar('S')
+def k1(x: int, y: list[T]) -> list[T & int]: pass
+def k2(x: S, y: list[T]) -> list[T & int]: pass
+a = k2
+a = k1 # E: Incompatible types in assignment (expression has type "[T] (int, list[T]) -> list[T & int]", variable has type "[S, T] (S, list[T]) -> list[T & int]")  [assignment]
+b = k1
+b = k2
+[builtins fixtures/list.pyi]
+[builtins fixtures/tuple.pyi]
+
+
+[case testEqual-xfail]
+# flags: --disallow-redefinition
+from __future__ import annotations
+from typing import Generic
+
+T = TypeVar("T")
+class A: pass
+class B: pass
+class G(Generic[T]): pass
+
+l1: G[A] & G[B]
+l2: G[A & B]
+
+l1 = l2
+l2 = l1
+[builtins fixtures/tuple.pyi]
+
+
+[case testOverloadIsIntersection-xfail]
+# flags: --disallow-redefinition
+from __future__ import annotations
+from typing import overload
+
+@overload
+def _foo(x: int) -> str: ...
+@overload
+def _foo(x: str) -> int: ...
+def _foo(x): return x
+
+foo = _foo
+bar: Callable[[int], str] & Callable[[int], int]
+
+bar = foo
+foo = bar
+[builtins fixtures/tuple.pyi]
+
+
+[case testNarrowDoesntAddAny]
+from __future__ import annotations
+x: list[int]
+assert isinstance(x, list)
+reveal_type(x)  # N: Revealed type is "list[int]"
+[builtins fixtures/tuple.pyi]
+
+
+
+[case testTypeAttributeAccess]
+from __future__ import annotations
+
+class A:
+    a: int
+class B:
+    pass
+
+x: A & B
+reveal_type(x.a)  # N: Revealed type is "int"
+[builtins fixtures/tuple.pyi]
+
+
+[case testComplexNarrow-xfail]
+from __future__ import annotations
+from typing import Union
+
+class A: pass
+class B: pass
+class C: pass
+
+x: A
+reveal_type(x)  # N: Revealed type is "__main__.A"
+assert isinstance(x, Union[B, C])
+reveal_type(x)  # N: Revealed type is "__main__.A & __main__.B"
+assert isinstance(x, C)
+reveal_type(x)  # N: Revealed type is "__main__.A & __main__.B & __main__.C | __main__.A & __main__.C"
+[builtins fixtures/tuple.pyi]

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -5272,7 +5272,7 @@ reveal_type(Foo().x)
 [builtins fixtures/isinstance.pyi]
 [out]
 [out2]
-tmp/b.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+tmp/b.py:2: note: Revealed type is "a.A & a.B"
 
 [case testIsInstanceAdHocIntersectionIncrementalNoChangeSameName]
 import b
@@ -5295,7 +5295,7 @@ reveal_type(Foo().x)
 [builtins fixtures/isinstance.pyi]
 [out]
 [out2]
-tmp/b.py:2: note: Revealed type is "a.<subclass of "B" and "B">"
+tmp/b.py:2: note: Revealed type is "c.B & a.B"
 
 
 [case testIsInstanceAdHocIntersectionIncrementalNoChangeTuple]
@@ -5317,7 +5317,7 @@ reveal_type(Foo().x)
 [builtins fixtures/isinstance.pyi]
 [out]
 [out2]
-tmp/b.py:2: note: Revealed type is "a.<subclass of "tuple" and "B">"
+tmp/b.py:2: note: Revealed type is "builtins.tuple[builtins.int, ...] & a.B"
 
 [case testIsInstanceAdHocIntersectionIncrementalIsInstanceChange]
 import c
@@ -5351,9 +5351,9 @@ from b import y
 reveal_type(y)
 [builtins fixtures/isinstance.pyi]
 [out]
-tmp/c.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+tmp/c.py:2: note: Revealed type is "a.A & a.B"
 [out2]
-tmp/c.py:2: note: Revealed type is "a.<subclass of "A" and "C">"
+tmp/c.py:2: note: Revealed type is "a.A & a.C"
 
 [case testIsInstanceAdHocIntersectionIncrementalUnderlyingObjChang]
 import c
@@ -5379,9 +5379,9 @@ from b import y
 reveal_type(y)
 [builtins fixtures/isinstance.pyi]
 [out]
-tmp/c.py:2: note: Revealed type is "b.<subclass of "A" and "B">"
+tmp/c.py:2: note: Revealed type is "a.A & a.B"
 [out2]
-tmp/c.py:2: note: Revealed type is "b.<subclass of "A" and "C">"
+tmp/c.py:2: note: Revealed type is "a.A & a.C"
 
 [case testIsInstanceAdHocIntersectionIncrementalIntersectionToUnreachable]
 import c
@@ -5412,7 +5412,7 @@ from b import z
 reveal_type(z)
 [builtins fixtures/isinstance.pyi]
 [out]
-tmp/c.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+tmp/c.py:2: note: Revealed type is "a.A & a.B"
 [out2]
 tmp/c.py:2: note: Revealed type is "a.A"
 
@@ -5447,7 +5447,7 @@ reveal_type(z)
 [out]
 tmp/c.py:2: note: Revealed type is "a.A"
 [out2]
-tmp/c.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+tmp/c.py:2: note: Revealed type is "a.A & a.B"
 
 [case testStubFixupIssues]
 import a

--- a/test-data/unit/check-isinstance.test
+++ b/test-data/unit/check-isinstance.test
@@ -1359,7 +1359,7 @@ class B: pass
 
 x = B()
 if isinstance(x, A):
-    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "B" and "A">"
+    reveal_type(x)  # N: Revealed type is "__main__.B & __main__.A"
 else:
     reveal_type(x)  # N: Revealed type is "__main__.B"
 reveal_type(x)  # N: Revealed type is "__main__.B"
@@ -2166,7 +2166,7 @@ def foo2(x: Optional[str]) -> None:
     if x is None:
         reveal_type(x)      # N: Revealed type is "None"
     elif isinstance(x, A):
-        reveal_type(x)      # N: Revealed type is "__main__.<subclass of "str" and "A">"
+        reveal_type(x)      # N: Revealed type is "builtins.str & __main__.A"
     else:
         reveal_type(x)      # N: Revealed type is "builtins.str"
 [builtins fixtures/isinstance.pyi]
@@ -2190,7 +2190,7 @@ def foo2(x: Optional[str]) -> None:
     if x is None:
         reveal_type(x)      # N: Revealed type is "None"
     elif isinstance(x, A):
-        reveal_type(x)      # N: Revealed type is "__main__.<subclass of "str" and "A">"
+        reveal_type(x)      # N: Revealed type is "builtins.str & __main__.A"
     else:
         reveal_type(x)      # N: Revealed type is "builtins.str"
 [builtins fixtures/isinstance.pyi]
@@ -2302,15 +2302,15 @@ class C:
 
 x: A
 if isinstance(x, B):
-    reveal_type(x)           # N: Revealed type is "__main__.<subclass of "A" and "B">"
+    reveal_type(x)           # N: Revealed type is "__main__.A & __main__.B"
     if isinstance(x, C):
-        reveal_type(x)       # N: Revealed type is "__main__.<subclass of "A", "B", and "C">"
+        reveal_type(x)       # N: Revealed type is "__main__.A & __main__.B & __main__.C"
         reveal_type(x.f1())  # N: Revealed type is "builtins.int"
         reveal_type(x.f2())  # N: Revealed type is "builtins.int"
         reveal_type(x.f3())  # N: Revealed type is "builtins.int"
-        x.bad()              # E: "<subclass of "A", "B", and "C">" has no attribute "bad"
+        x.bad()              # E: "A & B & C" has no attribute "bad"
     else:
-        reveal_type(x)       # N: Revealed type is "__main__.<subclass of "A" and "B">"
+        reveal_type(x)       # N: Revealed type is "__main__.A & __main__.B"
 else:
     reveal_type(x)           # N: Revealed type is "__main__.A"
 [builtins fixtures/isinstance.pyi]
@@ -2323,11 +2323,11 @@ class B: pass
 
 x: A
 if isinstance(x, B):
-    reveal_type(x)      # N: Revealed type is "__main__.<subclass of "A" and "B">"
+    reveal_type(x)      # N: Revealed type is "__main__.A & __main__.B"
     if isinstance(x, A):
-        reveal_type(x)  # N: Revealed type is "__main__.<subclass of "A" and "B">"
+        reveal_type(x)  # N: Revealed type is "__main__.A & __main__.B"
     if isinstance(x, B):
-        reveal_type(x)  # N: Revealed type is "__main__.<subclass of "A" and "B">"
+        reveal_type(x)  # N: Revealed type is "__main__.A & __main__.B"
 [builtins fixtures/isinstance.pyi]
 
 [case testIsInstanceAdHocIntersectionIncompatibleClasses]
@@ -2341,15 +2341,16 @@ class C:
 
 class Example(A, B): pass  # E: Definition of "f" in base class "A" is incompatible with definition in base class "B"
 x: A
-if isinstance(x, B):  # E: Subclass of "A" and "B" cannot exist: would have incompatible method signatures
+if isinstance(x, B):  # E: Subclass of "A & B" cannot exist: would have incompatible method signatures
     reveal_type(x)    # E: Statement is unreachable
 else:
     reveal_type(x)    # N: Revealed type is "__main__.A"
 
 y: C
 if isinstance(y, B):
-    reveal_type(y)        # N: Revealed type is "__main__.<subclass of "C" and "B">"
-    if isinstance(y, A):  # E: Subclass of "C", "B", and "A" cannot exist: would have incompatible method signatures
+    reveal_type(y)        # N: Revealed type is "__main__.C & __main__.B"
+    if isinstance(y, A):  # E: Subclass of "C & A" cannot exist: would have incompatible method signatures \
+                          # E: Subclass of "B & A" cannot exist: would have incompatible method signatures
         reveal_type(y)    # E: Statement is unreachable
 [builtins fixtures/isinstance.pyi]
 
@@ -2377,24 +2378,24 @@ class B:
         ...
 
     def t0(self) -> None:
-        if isinstance(self, A0):        # E: Subclass of "B" and "A0" cannot exist: would have incompatible method signatures
+        if isinstance(self, A0):        # E: Subclass of "B & A0" cannot exist: would have incompatible method signatures
             x0: Literal[0] = self.f()   # E: Statement is unreachable
 
     def t1(self) -> None:
         if isinstance(self, A1):
-            reveal_type(self)           # N: Revealed type is "__main__.<subclass of "A1" and "B">"
+            reveal_type(self)           # N: Revealed type is "__main__.B & __main__.A1"
             x0: Literal[0] = self.f()   # E: Incompatible types in assignment (expression has type "Literal[1]", variable has type "Literal[0]")
             x1: Literal[1] = self.f()
 
     def t2(self) -> None:
         if isinstance(self, (A0, A1)):
-            reveal_type(self)           # N: Revealed type is "__main__.<subclass of "A1" and "B">1"
+            reveal_type(self)           # N: Revealed type is "__main__.B & __main__.A1"
             x0: Literal[0] = self.f()   # E: Incompatible types in assignment (expression has type "Literal[1]", variable has type "Literal[0]")
             x1: Literal[1] = self.f()
 
     def t3(self) -> None:
         if isinstance(self, (A1, A2)):
-            reveal_type(self)           # N: Revealed type is "Union[__main__.<subclass of "A1" and "B">2, __main__.<subclass of "A2" and "B">]"
+            reveal_type(self)           # N: Revealed type is "Union[__main__.B & __main__.A1, __main__.B & __main__.A2]"
             x0: Literal[0] = self.f()   # E: Incompatible types in assignment (expression has type "Literal[1, 2]", variable has type "Literal[0]")
             x1: Literal[1] = self.f()   # E: Incompatible types in assignment (expression has type "Literal[1, 2]", variable has type "Literal[1]")
 
@@ -2414,21 +2415,21 @@ class B:
     def f(self) -> Parent: ...
 
 x: A[int]
-if isinstance(x, B):    # E: Subclass of "A[int]" and "B" cannot exist: would have incompatible method signatures
+if isinstance(x, B):    # E: Subclass of "A[int] & B" cannot exist: would have incompatible method signatures
     reveal_type(x)      # E: Statement is unreachable
 else:
     reveal_type(x)      # N: Revealed type is "__main__.A[builtins.int]"
 
 y: A[Parent]
 if isinstance(y, B):
-    reveal_type(y)      # N: Revealed type is "__main__.<subclass of "A" and "B">"
+    reveal_type(y)      # N: Revealed type is "__main__.A[__main__.Parent] & __main__.B"
     reveal_type(y.f())  # N: Revealed type is "__main__.Parent"
 else:
     reveal_type(y)      # N: Revealed type is "__main__.A[__main__.Parent]"
 
 z: A[Child]
 if isinstance(z, B):
-    reveal_type(z)      # N: Revealed type is "__main__.<subclass of "A" and "B">1"
+    reveal_type(z)      # N: Revealed type is "__main__.A[__main__.Child] & __main__.B"
     reveal_type(z.f())  # N: Revealed type is "__main__.Child"
 else:
     reveal_type(z)      # N: Revealed type is "__main__.A[__main__.Child]"
@@ -2449,10 +2450,10 @@ T1 = TypeVar('T1', A, B)
 def f1(x: T1) -> T1:
     if isinstance(x, A):
         reveal_type(x)      # N: Revealed type is "__main__.A" \
-                            # N: Revealed type is "__main__.<subclass of "B" and "A">"
+                            # N: Revealed type is "__main__.B & __main__.A"
         if isinstance(x, B):
-            reveal_type(x)  # N: Revealed type is "__main__.<subclass of "A" and "B">" \
-                            # N: Revealed type is "__main__.<subclass of "B" and "A">"
+            reveal_type(x)  # N: Revealed type is "__main__.A & __main__.B" \
+                            # N: Revealed type is "__main__.B & __main__.A"
         else:
             reveal_type(x)  # N: Revealed type is "__main__.A"
     else:
@@ -2519,10 +2520,10 @@ def accept_concrete(c: Concrete) -> None: pass
 x: A
 if isinstance(x, B):
     var = x
-    reveal_type(var)      # N: Revealed type is "__main__.<subclass of "A" and "B">"
+    reveal_type(var)      # N: Revealed type is "__main__.A & __main__.B"
     accept_a(var)
     accept_b(var)
-    accept_concrete(var)  # E: Argument 1 to "accept_concrete" has incompatible type "<subclass of "A" and "B">"; expected "Concrete"
+    accept_concrete(var)  # E: Argument 1 to "accept_concrete" has incompatible type "A & B"; expected "Concrete"
 [builtins fixtures/isinstance.pyi]
 
 [case testIsInstanceAdHocIntersectionReinfer]
@@ -2532,14 +2533,14 @@ class B: pass
 
 x: A
 assert isinstance(x, B)
-reveal_type(x)      # N: Revealed type is "__main__.<subclass of "A" and "B">"
+reveal_type(x)      # N: Revealed type is "__main__.A & __main__.B"
 
 y: A
 assert isinstance(y, B)
-reveal_type(y)      # N: Revealed type is "__main__.<subclass of "A" and "B">1"
+reveal_type(y)      # N: Revealed type is "__main__.A & __main__.B"
 
 x = y
-reveal_type(x)      # N: Revealed type is "__main__.<subclass of "A" and "B">1"
+reveal_type(x)      # N: Revealed type is "__main__.A & __main__.B"
 [builtins fixtures/isinstance.pyi]
 
 [case testIsInstanceAdHocIntersectionWithUnions]
@@ -2552,15 +2553,15 @@ class D: pass
 
 v1: A
 if isinstance(v1, (B, C)):
-    reveal_type(v1)  # N: Revealed type is "Union[__main__.<subclass of "A" and "B">, __main__.<subclass of "A" and "C">]"
+    reveal_type(v1)  # N: Revealed type is "Union[__main__.A & __main__.B, __main__.A & __main__.C]"
 
 v2: Union[A, B]
 if isinstance(v2, C):
-    reveal_type(v2)  # N: Revealed type is "Union[__main__.<subclass of "A" and "C">1, __main__.<subclass of "B" and "C">]"
+    reveal_type(v2)  # N: Revealed type is "Union[__main__.A & __main__.C, __main__.B & __main__.C]"
 
 v3: Union[A, B]
 if isinstance(v3, (C, D)):
-    reveal_type(v3)  # N: Revealed type is "Union[__main__.<subclass of "A" and "C">2, __main__.<subclass of "A" and "D">, __main__.<subclass of "B" and "C">1, __main__.<subclass of "B" and "D">]"
+    reveal_type(v3)  # N: Revealed type is "Union[__main__.A & __main__.C, __main__.A & __main__.D, __main__.B & __main__.C, __main__.B & __main__.D]"
 [builtins fixtures/isinstance.pyi]
 
 [case testIsInstanceAdHocIntersectionSameNames]
@@ -2570,7 +2571,7 @@ class A: pass
 
 x: A
 if isinstance(x, A2):
-    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "A" and "A">"
+    reveal_type(x)  # N: Revealed type is "__main__.A & foo.A"
 
 [file foo.py]
 class A: pass
@@ -2584,7 +2585,7 @@ class A(X, Y): pass
 class B(Y, X): pass
 
 foo: A
-if isinstance(foo, B):  # E: Subclass of "A" and "B" cannot exist: would have inconsistent method resolution order
+if isinstance(foo, B):  # E: Subclass of "A & B" cannot exist: would have inconsistent method resolution order
     reveal_type(foo)    # E: Statement is unreachable
 [builtins fixtures/isinstance.pyi]
 
@@ -2600,8 +2601,8 @@ class Ambiguous:
 # We bias towards assuming these two classes could be overlapping
 foo: Concrete
 if isinstance(foo, Ambiguous):
-    reveal_type(foo)    # N: Revealed type is "__main__.<subclass of "Concrete" and "Ambiguous">"
-    reveal_type(foo.x)  # N: Revealed type is "builtins.int"
+    reveal_type(foo)    # N: Revealed type is "__main__.Concrete & __main__.Ambiguous"
+    reveal_type(foo.x)  # N: Revealed type is "builtins.int & Any"
 [builtins fixtures/isinstance.pyi]
 
 [case testIsSubclassAdHocIntersection]
@@ -2617,11 +2618,12 @@ class C:
 
 x: Type[A]
 if issubclass(x, B):
-    reveal_type(x)        # N: Revealed type is "Type[__main__.<subclass of "A" and "B">]"
-    if issubclass(x, C):  # E: Subclass of "A", "B", and "C" cannot exist: would have incompatible method signatures
+    reveal_type(x)        # N: Revealed type is "Type[__main__.A] & Type[__main__.B]"
+    if issubclass(x, C):  # E: Subclass of "A & C" cannot exist: would have incompatible method signatures \
+                          # E: Subclass of "B & C" cannot exist: would have incompatible method signatures
         reveal_type(x)    # E: Statement is unreachable
     else:
-        reveal_type(x)    # N: Revealed type is "Type[__main__.<subclass of "A" and "B">]"
+        reveal_type(x)    # N: Revealed type is "Type[__main__.A] & Type[__main__.B]"
 else:
     reveal_type(x)        # N: Revealed type is "Type[__main__.A]"
 [builtins fixtures/isinstance.pyi]

--- a/test-data/unit/check-protocols.test
+++ b/test-data/unit/check-protocols.test
@@ -1754,7 +1754,7 @@ if isinstance(c1i, P1):
 else:
     reveal_type(c1i) # Unreachable
 if isinstance(c1i, P):
-    reveal_type(c1i) # N: Revealed type is "__main__.<subclass of "C1" and "P">"
+    reveal_type(c1i) # N: Revealed type is "__main__.C1[builtins.int] & __main__.P"
 else:
     reveal_type(c1i) # N: Revealed type is "__main__.C1[builtins.int]"
 
@@ -1766,7 +1766,7 @@ else:
 
 c2: C2
 if isinstance(c2, P):
-    reveal_type(c2) # N: Revealed type is "__main__.<subclass of "C2" and "P">"
+    reveal_type(c2) # N: Revealed type is "__main__.C2 & __main__.P"
 else:
     reveal_type(c2) # N: Revealed type is "__main__.C2"
 

--- a/test-data/unit/check-python310.test
+++ b/test-data/unit/check-python310.test
@@ -64,7 +64,7 @@ m: A
 
 match m:
     case b.b:
-        reveal_type(m)  # N: Revealed type is "__main__.<subclass of "A" and "B">1"
+        reveal_type(m)  # N: Revealed type is "__main__.A & b.B"
 [file b.py]
 class B: ...
 b: B
@@ -833,9 +833,9 @@ m: B
 
 match m:
     case A():
-        reveal_type(m)  # N: Revealed type is "__main__.<subclass of "B" and "A">2"
+        reveal_type(m)  # N: Revealed type is "__main__.B & __main__.A"
     case A(i, j):
-        reveal_type(m)  # N: Revealed type is "__main__.<subclass of "B" and "A">3"
+        reveal_type(m)  # N: Revealed type is "__main__.B & __main__.A"
 [builtins fixtures/tuple.pyi]
 
 [case testMatchClassPatternNonexistentKeyword]
@@ -1145,7 +1145,7 @@ m: str
 
 match m:
     case a if a := 1:  # E: Incompatible types in assignment (expression has type "int", variable has type "str")
-        reveal_type(a)  # N: Revealed type is "<nothing>"
+        reveal_type(a)  # N: Revealed type is "builtins.str & Literal[1]?"
 
 [case testMatchAssigningPatternGuard]
 m: str
@@ -1170,7 +1170,7 @@ m: A
 
 match m:
     case a if isinstance(a, B):
-        reveal_type(a)  # N: Revealed type is "__main__.<subclass of "A" and "B">"
+        reveal_type(a)  # N: Revealed type is "__main__.A & __main__.B"
 [builtins fixtures/isinstancelist.pyi]
 
 [case testMatchUnreachablePatternGuard]
@@ -1487,10 +1487,10 @@ class C: pass
 def f(x: A) -> None:
     match x:
         case B() as y:
-            reveal_type(y)  # N: Revealed type is "__main__.<subclass of "A" and "B">"
+            reveal_type(y)  # N: Revealed type is "__main__.A & __main__.B"
         case C() as y:
-            reveal_type(y)  # N: Revealed type is "__main__.<subclass of "A" and "C">"
-    reveal_type(y)  # N: Revealed type is "Union[__main__.<subclass of "A" and "B">, __main__.<subclass of "A" and "C">]"
+            reveal_type(y)  # N: Revealed type is "__main__.A & __main__.C"
+    reveal_type(y)  # N: Revealed type is "Union[__main__.A & __main__.B, __main__.A & __main__.C]"
 
 [case testMatchWithBreakAndContinue]
 # flags: --strict-optional

--- a/test-data/unit/check-typeguard.test
+++ b/test-data/unit/check-typeguard.test
@@ -433,7 +433,7 @@ def g(x: object) -> None: ...
 def test(x: List[object]) -> None:
     if not(f(x) or isinstance(x, A)):
         return
-    g(reveal_type(x))  # N: Revealed type is "Union[builtins.list[builtins.str], __main__.<subclass of "list" and "A">]"
+    g(reveal_type(x))  # N: Revealed type is "Union[builtins.list[builtins.str], builtins.list[builtins.object] & __main__.A]"
 [builtins fixtures/tuple.pyi]
 
 [case testTypeGuardMultipleCondition-xfail]
@@ -452,12 +452,12 @@ def is_bar(item: object) -> TypeGuard[Bar]:
 def foobar(x: object):
     if not isinstance(x, Foo) or not isinstance(x, Bar):
         return
-    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "Foo" and "Bar">"
+    reveal_type(x)  # N: Revealed type is "__main__.Foo & __main__.Bar"
 
 def foobar_typeguard(x: object):
     if not is_foo(x) or not is_bar(x):
         return
-    reveal_type(x)  # N: Revealed type is "__main__.<subclass of "Foo" and "Bar">"
+    reveal_type(x)  # N: Revealed type is "__main__.Foo & __main__.Bar"
 [builtins fixtures/tuple.pyi]
 
 [case testTypeGuardAsFunctionArgAsBoolSubtype]

--- a/test-data/unit/deps.test
+++ b/test-data/unit/deps.test
@@ -432,8 +432,8 @@ def f(x: A) -> None:
         x.y
 [builtins fixtures/isinstancelist.pyi]
 [out]
-<m.<subclass of "A" and "B">.y> -> m.f
-<m.A> -> <m.f>, m.A, m.f
+<m.A.__await__> -> <m.A>
+<m.A> -> <m.f>, m.A, m.f, typing.Awaitable
 <m.B> -> m.B, m.f
 
 [case testAttributeWithClassType1]

--- a/test-data/unit/fine-grained.test
+++ b/test-data/unit/fine-grained.test
@@ -9581,7 +9581,7 @@ reveal_type(Foo().x)
 [builtins fixtures/isinstance.pyi]
 [out]
 ==
-b.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+b.py:2: note: Revealed type is "a.A & a.B"
 
 [case testIsInstanceAdHocIntersectionFineGrainedIncrementalIsInstanceChange]
 import c
@@ -9615,9 +9615,9 @@ from b import y
 reveal_type(y)
 [builtins fixtures/isinstance.pyi]
 [out]
-c.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+c.py:2: note: Revealed type is "a.A & a.B"
 ==
-c.py:2: note: Revealed type is "a.<subclass of "A" and "C">"
+c.py:2: note: Revealed type is "a.A & a.C"
 
 [case testIsInstanceAdHocIntersectionFineGrainedIncrementalUnderlyingObjChang]
 import c
@@ -9643,9 +9643,9 @@ from b import y
 reveal_type(y)
 [builtins fixtures/isinstance.pyi]
 [out]
-c.py:2: note: Revealed type is "b.<subclass of "A" and "B">"
+c.py:2: note: Revealed type is "a.A & a.B"
 ==
-c.py:2: note: Revealed type is "b.<subclass of "A" and "C">"
+c.py:2: note: Revealed type is "a.A & a.C"
 
 [case testIsInstanceAdHocIntersectionFineGrainedIncrementalIntersectionToUnreachable]
 import c
@@ -9676,7 +9676,7 @@ from b import z
 reveal_type(z)
 [builtins fixtures/isinstance.pyi]
 [out]
-c.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+c.py:2: note: Revealed type is "a.A & a.B"
 ==
 c.py:2: note: Revealed type is "a.A"
 
@@ -9711,7 +9711,7 @@ reveal_type(z)
 [out]
 c.py:2: note: Revealed type is "a.A"
 ==
-c.py:2: note: Revealed type is "a.<subclass of "A" and "B">"
+c.py:2: note: Revealed type is "a.A & a.B"
 
 [case testStubFixupIssues]
 [file a.py]

--- a/test-data/unit/lib-stub/basedtyping.pyi
+++ b/test-data/unit/lib-stub/basedtyping.pyi
@@ -5,3 +5,4 @@
 # will slow down tests.
 
 Untyped = 0
+Intersection = 1

--- a/test-data/unit/pythoneval.test
+++ b/test-data/unit/pythoneval.test
@@ -1534,9 +1534,9 @@ y: str
 if isinstance(x, int):
     reveal_type(x)
 [out]
-_testIsInstanceAdHocIntersectionWithStrAndBytes.py:3: error: Subclass of "str" and "bytes" cannot exist: would have incompatible method signatures
+_testIsInstanceAdHocIntersectionWithStrAndBytes.py:3: error: Subclass of "str & bytes" cannot exist: would have incompatible method signatures
 _testIsInstanceAdHocIntersectionWithStrAndBytes.py:4: error: Statement is unreachable
-_testIsInstanceAdHocIntersectionWithStrAndBytes.py:6: error: Subclass of "str" and "int" cannot exist: would have incompatible method signatures
+_testIsInstanceAdHocIntersectionWithStrAndBytes.py:6: error: Subclass of "str & int" cannot exist: would have incompatible method signatures
 _testIsInstanceAdHocIntersectionWithStrAndBytes.py:7: error: Statement is unreachable
 
 [case testAsyncioFutureWait]


### PR DESCRIPTION
```py
imposter: Among & Us
```

- resolves #42

Follow up:
- intersect at meets
- `Never`ify on invalid intersects #432
- overloads are equal to intersects
- `G[A & B]` equals `G[A] & G[B]`
- more complex narrowing scenarios