### PR TITLE
type render updates

### DIFF
--- a/.mypy/baseline.json
+++ b/.mypy/baseline.json
@@ -2440,7 +2440,7 @@
         "code": "no-any-expr",
         "column": 56,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 241,
+        "offset": 235,
         "target": "mypy.checker.TypeChecker.check_for_missing_annotations"
       },
       {
@@ -11406,7 +11406,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"((...) -> _T) -> _lru_cache_wrapper[_T]\")",
+        "message": "Expression type contains \"Any\" (has type \"[_T] ((...) -> _T) -> _lru_cache_wrapper[_T]\")",
         "offset": 162,
         "target": "mypy.find_sources"
       }
@@ -13194,7 +13194,7 @@
         "code": "no-any-expr",
         "column": 41,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 376,
+        "offset": 378,
         "target": "mypy.messages.MessageBuilder.has_no_attr"
       },
       {
@@ -13488,14 +13488,14 @@
         "code": "no-any-expr",
         "column": 30,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 289,
+        "offset": 294,
         "target": "mypy.messages.format_type_inner"
       },
       {
         "code": "redundant-expr",
         "column": 12,
         "message": "Left operand of \"and\" is always true",
-        "offset": 170,
+        "offset": 173,
         "target": "mypy.messages.pretty_callable"
       },
       {
@@ -13530,7 +13530,7 @@
         "code": "redundant-expr",
         "column": 7,
         "message": "Left operand of \"and\" is always true",
-        "offset": 175,
+        "offset": 178,
         "target": "mypy.messages.find_defining_module"
       },
       {
@@ -13680,7 +13680,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"((...) -> _T) -> _lru_cache_wrapper[_T]\")",
+        "message": "Expression type contains \"Any\" (has type \"[_T] ((...) -> _T) -> _lru_cache_wrapper[_T]\")",
         "offset": 157,
         "target": "mypy.modulefinder"
       },
@@ -19810,7 +19810,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"((...) -> _T) -> _SingleDispatchCallable[_T]\")",
+        "message": "Expression type contains \"Any\" (has type \"[_T] ((...) -> _T) -> _SingleDispatchCallable[_T]\")",
         "offset": 17,
         "target": "mypy.stubtest"
       },
@@ -24264,21 +24264,21 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(_FT) -> _FT\")",
+        "message": "Expression type contains \"Any\" (has type \"[_FT: (...) -> Any] (_FT) -> _FT\")",
         "offset": 49,
         "target": "mypy.test.teststubgen"
       },
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(_FT) -> _FT\")",
+        "message": "Expression type contains \"Any\" (has type \"[_FT: (...) -> Any] (_FT) -> _FT\")",
         "offset": 26,
         "target": "mypy.test.teststubgen"
       },
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(_FT) -> _FT\")",
+        "message": "Expression type contains \"Any\" (has type \"[_FT: (...) -> Any] (_FT) -> _FT\")",
         "offset": 25,
         "target": "mypy.test.teststubgen"
       },
@@ -24306,14 +24306,14 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(_FT) -> _FT\")",
+        "message": "Expression type contains \"Any\" (has type \"[_FT: (...) -> Any] (_FT) -> _FT\")",
         "offset": 436,
         "target": "mypy.test.teststubgen"
       },
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(_FT) -> _FT\")",
+        "message": "Expression type contains \"Any\" (has type \"[_FT: (...) -> Any] (_FT) -> _FT\")",
         "offset": 16,
         "target": "mypy.test.teststubgen"
       },
@@ -25287,7 +25287,7 @@
         "code": "no-any-expr",
         "column": 53,
         "message": "Expression type contains \"Any\" (has type \"type[CallableType]\")",
-        "offset": 75,
+        "offset": 82,
         "target": "mypy.typeops.infer_impl_from_parts"
       },
       {
@@ -25303,7 +25303,7 @@
         "code": "no-any-explicit",
         "column": 0,
         "message": "Explicit \"Any\" is not allowed",
-        "offset": 43,
+        "offset": 44,
         "target": "mypy.types"
       },
       {
@@ -25512,14 +25512,14 @@
       {
         "code": "no-any-return",
         "column": 8,
-        "message": "Returning Any from function declared to return \"T\"",
+        "message": "Returning Any from function declared to return \"T@accept\"",
         "offset": 33,
         "target": "mypy.types.CallableArgument.accept"
       },
       {
         "code": "no-any-return",
         "column": 8,
-        "message": "Returning Any from function declared to return \"T\"",
+        "message": "Returning Any from function declared to return \"T@accept\"",
         "offset": 25,
         "target": "mypy.types.TypeList.accept"
       },
@@ -26597,7 +26597,7 @@
       {
         "code": "no-any-return",
         "column": 8,
-        "message": "Returning Any from function declared to return \"T\"",
+        "message": "Returning Any from function declared to return \"T@accept\"",
         "offset": 124,
         "target": "mypy.types.RawExpressionType.accept"
       },
@@ -26618,7 +26618,7 @@
       {
         "code": "no-any-return",
         "column": 8,
-        "message": "Returning Any from function declared to return \"T\"",
+        "message": "Returning Any from function declared to return \"T@accept\"",
         "offset": 23,
         "target": "mypy.types.StarType.accept"
       },
@@ -26667,7 +26667,7 @@
       {
         "code": "no-any-return",
         "column": 8,
-        "message": "Returning Any from function declared to return \"T\"",
+        "message": "Returning Any from function declared to return \"T@accept\"",
         "offset": 54,
         "target": "mypy.types.EllipsisType.accept"
       },
@@ -26688,7 +26688,7 @@
       {
         "code": "no-any-return",
         "column": 8,
-        "message": "Returning Any from function declared to return \"T\"",
+        "message": "Returning Any from function declared to return \"T@accept\"",
         "offset": 29,
         "target": "mypy.types.PlaceholderType.accept"
       },
@@ -26696,7 +26696,7 @@
         "code": "unreachable",
         "column": 12,
         "message": "Statement is unreachable",
-        "offset": 160,
+        "offset": 165,
         "target": "mypy.types.TypeStrVisitor.visit_type_var"
       },
       {
@@ -26724,7 +26724,7 @@
         "code": "truthy-bool",
         "column": 11,
         "message": "Member \"partial_fallback\" has type \"Instance\" which does not implement __bool__ or __len__ so it could always be true in boolean context",
-        "offset": 84,
+        "offset": 94,
         "target": "mypy.types.TypeStrVisitor.visit_tuple_type"
       },
       {
@@ -31084,21 +31084,21 @@
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression type contains \"Any\" (has type \"(F) -> F\")",
+        "message": "Expression type contains \"Any\" (has type \"[F: (...) -> Any] (F) -> F\")",
         "offset": 0,
         "target": "mypyc.irbuild.main"
       },
       {
         "code": "no-any-expr",
         "column": 22,
-        "message": "Expression type contains \"Any\" (has type \"(F) -> F\")",
+        "message": "Expression type contains \"Any\" (has type \"[F: (...) -> Any] (F) -> F\")",
         "offset": 0,
         "target": "mypyc.irbuild.main"
       },
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"(F) -> F\")",
+        "message": "Expression type contains \"Any\" (has type \"[F: (...) -> Any] (F) -> F\")",
         "offset": 3,
         "target": "mypyc.irbuild.main"
       }
@@ -31347,7 +31347,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(_FT) -> _FT\")",
+        "message": "Expression type contains \"Any\" (has type \"[_FT: (...) -> Any] (_FT) -> _FT\")",
         "offset": 15,
         "target": "mypyc.test.test_external"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## [Unreleased]
 ### Enhancements
 - Similar errors on the same line will now not be removed
+- Render generic upper bound with `: ` instead of ` <: `
 ### Fixes
 - Handle positional only `/` parameters in overload implementation inference
+- Render inferred literal without `?`
 
 ## [1.5.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Enhancements
 - Similar errors on the same line will now not be removed
 - Render generic upper bound with `: ` instead of ` <: `
+- Render uninhabited type as `Never` instead of `<nothing>`
+- Render Callables with `-> None`
 ### Fixes
 - Handle positional only `/` parameters in overload implementation inference
 - Render inferred literal without `?`

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -42,6 +42,7 @@ include pytest.ini
 
 include LICENSE mypyc/README.md
 exclude .gitmodules CONTRIBUTING.md CREDITS ROADMAP.md tox.ini action.yml .editorconfig mypy_self_check_strict.ini CHANGELOG.md .mypy/baseline.json
+exclude .git-blame-ignore-revs .pre-commit-config.yaml
 
 global-exclude *.py[cod]
 global-exclude .DS_Store

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -92,6 +92,7 @@ from mypy.types import (
     TypeOfAny,
     TypeStrVisitor,
     TypeType,
+    TypeVarLikeType,
     TypeVarType,
     UnboundType,
     UninhabitedType,
@@ -2160,25 +2161,26 @@ def format_callable_args(
     return ", ".join(arg_strings)
 
 
-def format_type_inner(typ: Type, verbosity: int, fullnames: Optional[Set[str]]) -> str:
+def format_type_inner(
+    typ: Type,
+    verbosity: int,
+    fullnames: Optional[Set[str]],
+    disable_own_scope: Sequence[TypeVarLikeType] = (),
+) -> str:
     """
     Convert a type to a relatively short string suitable for error messages.
 
     Args:
       verbosity: a coarse grained control on the verbosity of the type
       fullnames: a set of names that should be printed in full
+      disable_own_scope: TypeVars to disable scope names
     """
 
     def format(typ: Type) -> str:
-        return format_type_inner(typ, verbosity, fullnames)
+        return format_type_inner(typ, verbosity, fullnames, disable_own_scope)
 
     def format_list(types: Sequence[Type]) -> str:
         return ", ".join(format(typ) for typ in types)
-
-    def format_union(types: Sequence[Type]) -> str:
-        if not mypy.options._based:
-            return format_list(types)
-        return " | ".join(format(typ) for typ in types)
 
     def format_literal_value(typ: LiteralType) -> str:
         if typ.is_enum_literal():
@@ -2217,7 +2219,7 @@ def format_type_inner(typ: Type, verbosity: int, fullnames: Optional[Set[str]]) 
             return f"{base_str}[{format_list(itype.args)}]"
     elif isinstance(typ, TypeVarType):
         # This is similar to non-generic instance types.
-        if mypy.options._based:
+        if mypy.options._based and typ.scopename and typ not in disable_own_scope:
             return f"{typ.name}@{typ.scopename}"
         return typ.name
     elif isinstance(typ, ParamSpecType):
@@ -2294,11 +2296,11 @@ def format_type_inner(typ: Type, verbosity: int, fullnames: Optional[Set[str]]) 
     elif isinstance(typ, DeletedType):
         return "<deleted>"
     elif isinstance(typ, UninhabitedType):
+        if mypy.options._based:
+            return "Never"
         if typ.is_noreturn:
             return "NoReturn"
         else:
-            if mypy.options._based:
-                return "Never"
             return "<nothing>"
     elif isinstance(typ, TypeType):
         if not mypy.options._based:
@@ -2311,6 +2313,8 @@ def format_type_inner(typ: Type, verbosity: int, fullnames: Optional[Set[str]]) 
             # return type (this always works).
             return format(TypeType.make_normalized(erase_type(func.items[0].ret_type)))
         elif isinstance(func, CallableType):
+            if func.variables:
+                disable_own_scope = func.variables
             if func.type_guard is not None:
                 return_type = f"TypeGuard[{format(func.type_guard)}]"
             else:
@@ -2329,7 +2333,8 @@ def format_type_inner(typ: Type, verbosity: int, fullnames: Optional[Set[str]]) 
             )
             if not mypy.options._based:
                 return f"Callable[[{args}], {return_type}]"
-            return f"({args}) -> {return_type}"
+            args = TypeStrVisitor.render_callable_type_params(func, format) + f"({args})"
+            return f"{args} -> {return_type}"
         else:
             # Use a simple representation for function types; proper
             # function types may result in long and difficult-to-read

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2297,6 +2297,8 @@ def format_type_inner(typ: Type, verbosity: int, fullnames: Optional[Set[str]]) 
         if typ.is_noreturn:
             return "NoReturn"
         else:
+            if mypy.options._based:
+                return "Never"
             return "<nothing>"
     elif isinstance(typ, TypeType):
         if not mypy.options._based:

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -2517,7 +2517,10 @@ def pretty_callable(tp: CallableType) -> str:
                     isinstance(upper_bound, Instance)
                     and upper_bound.type.fullname != "builtins.object"
                 ):
-                    tvars.append(f"{tvar.name} <: {format_type_bare(upper_bound)}")
+                    if mypy.options._based:
+                        tvars.append(f"{tvar.name}: {format_type_bare(upper_bound)}")
+                    else:
+                        tvars.append(f"{tvar.name} <: {format_type_bare(upper_bound)}")
                 elif tvar.values:
                     tvars.append(
                         "{} in ({})".format(

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -3054,6 +3054,8 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
                     s += f" -> TypeGuard[{t.type_guard.accept(self)}]"
                 else:
                     s += f" -> {t.ret_type.accept(self)}"
+            elif mypy.options._based:
+                s += " -> None"
 
             s = self.render_callable_type_params(t, lambda x: x.accept(self)) + s
 

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -5,6 +5,7 @@ import sys
 from abc import abstractmethod
 from typing import (
     Any,
+    Callable,
     Dict,
     Generator,
     Iterable,
@@ -3054,33 +3055,41 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
                 else:
                     s += f" -> {t.ret_type.accept(self)}"
 
-            if t.variables:
-                vs = []
-                for var in t.variables:
-                    if isinstance(var, TypeVarType):
-                        # We reimplement TypeVarType.__repr__ here in order to support id_mapper.
-                        if (
-                            mypy.options._based
-                            and var.scopename
-                            and t.name
-                            and var.scopename != t.name.split(" ")[0]
-                        ):
-                            name = f"{var.name} (from {var.scopename})"
-                        else:
-                            name = var.name
-                        if var.values:
-                            vals = f"({', '.join(val.accept(self) for val in var.values)})"
-                            vs.append(f"{name} in {vals}")
-                        elif not is_named_instance(var.upper_bound, "builtins.object"):
-                            vs.append(f"{name} <: {var.upper_bound.accept(self)}")
-                        else:
-                            vs.append(name)
-                    else:
-                        # For other TypeVarLikeTypes, just use the name
-                        vs.append(var.name)
-                s = f"[{', '.join(vs)}] {s}"
+            s = self.render_callable_type_params(t, lambda x: x.accept(self)) + s
 
             return f"def {s}"
+
+    @staticmethod
+    def render_callable_type_params(t: CallableType, renderer: Callable[[Type], str]) -> str:
+        if not t.variables:
+            return ""
+        vs = []
+        for var in t.variables:
+            if isinstance(var, TypeVarType):
+                # We reimplement TypeVarType.__repr__ here in order to support id_mapper.
+                if (
+                    mypy.options._based
+                    and var.scopename
+                    and t.name
+                    and var.scopename != t.name.split(" ")[0]
+                ):
+                    name = f"{var.name} (from {var.scopename})"
+                else:
+                    name = var.name
+                if var.values:
+                    vals = f"({', '.join(renderer(val) for val in var.values)})"
+                    vs.append(f"{name} in {vals}")
+                elif not is_named_instance(var.upper_bound, "builtins.object"):
+                    if mypy.options._based:
+                        vs.append(f"{name}: {renderer(var.upper_bound)}")
+                    else:
+                        vs.append(f"{name} <: {renderer(var.upper_bound)}")
+                else:
+                    vs.append(name)
+            else:
+                # For other TypeVarLikeTypes, just use the name
+                vs.append(var.name)
+        return f"[{', '.join(vs)}] "
 
     def visit_overloaded(self, t: Overloaded) -> str:
         a = []

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2885,6 +2885,8 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         return "None"
 
     def visit_uninhabited_type(self, t: UninhabitedType) -> str:
+        if mypy.options._based:
+            return "Never"
         return "<nothing>"
 
     def visit_erased_type(self, t: ErasedType) -> str:

--- a/mypy/types.py
+++ b/mypy/types.py
@@ -2900,7 +2900,10 @@ class TypeStrVisitor(SyntheticTypeVisitor[str]):
         if t.last_known_value and not t.args:
             # Instances with a literal fallback should never be generic. If they are,
             # something went wrong so we fall back to showing the full Instance repr.
-            s = f"{t.last_known_value}?"
+            if mypy.options._based:
+                s = str(t.last_known_value)
+            else:
+                s = f"{t.last_known_value}?"
         else:
             s = t.type.fullname or t.type.name or "<???>"
 

--- a/test-data/unit/check-based-default-return.test
+++ b/test-data/unit/check-based-default-return.test
@@ -3,18 +3,18 @@
 
 [case testSimple]
 def f(): ...
-reveal_type(f)  # N: Revealed type is "def ()"
+reveal_type(f)  # N: Revealed type is "def () -> None"
 reveal_type(f())  # N: Revealed type is "None"
 
 def g(i: int): ...
-reveal_type(g)  # N: Revealed type is "def (i: int)"
+reveal_type(g)  # N: Revealed type is "def (i: int) -> None"
 
 class A:
     def f(self): ...
     def g(self, i: int): ...
 
-reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A)"
-reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: int)"
+reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A) -> None"
+reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: int) -> None"
 
 
 [case testUntypedDefs]
@@ -24,7 +24,7 @@ def f(): ...
 reveal_type(f)  # N: Revealed type is "def () -> Untyped"
 
 def g(i: int): ...
-reveal_type(g)  # N: Revealed type is "def (i: int)"
+reveal_type(g)  # N: Revealed type is "def (i: int) -> None"
 
 def h(i: int, j): ...  # E: Function is missing a type annotation for one or more arguments  [no-untyped-def]
 
@@ -36,8 +36,8 @@ class A:
 
 reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A) -> Untyped"
 reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: Untyped) -> Untyped"
-reveal_type(A.h)  # N: Revealed type is "def (self: __main__.A, i: int)"
-reveal_type(A.i)  # N: Revealed type is "def (self: __main__.A, i: int, j: Untyped)"
+reveal_type(A.h)  # N: Revealed type is "def (self: __main__.A, i: int) -> None"
+reveal_type(A.i)  # N: Revealed type is "def (self: __main__.A, i: int, j: Untyped) -> None"
 
 
 [case testIncompleteDefs]
@@ -47,7 +47,7 @@ def f(i): ...
 reveal_type(f)  # N: Revealed type is "def (i: Untyped) -> Untyped"
 
 def g(i: int, j): ...
-reveal_type(g)  # N: Revealed type is "def (i: int, j: Untyped)"
+reveal_type(g)  # N: Revealed type is "def (i: int, j: Untyped) -> None"
 
 class A:
     def f(self): ...
@@ -57,8 +57,8 @@ class A:
 
 reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A) -> Untyped"
 reveal_type(A.g)  # N: Revealed type is "def (self: __main__.A, i: Untyped) -> Untyped"
-reveal_type(A.h)  # N: Revealed type is "def (self: __main__.A, i: int)"
-reveal_type(A.i)  # N: Revealed type is "def (self: __main__.A, i: int, j: Untyped)"
+reveal_type(A.h)  # N: Revealed type is "def (self: __main__.A, i: int) -> None"
+reveal_type(A.i)  # N: Revealed type is "def (self: __main__.A, i: int, j: Untyped) -> None"
 
 
 [case testGenerator]
@@ -144,7 +144,7 @@ class A:
     def f(self, i: int): ...
     def f(self, i: int = 0): ...
 
-reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A), def (self: __main__.A, i: int))"
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A) -> None, def (self: __main__.A, i: int) -> None)"
 
 @overload
 def f(): ...
@@ -152,7 +152,7 @@ def f(): ...
 def f(i: int): ...
 def f(i: int = 0): ...
 
-reveal_type(f)  # N: Revealed type is "Overload(def (), def (i: int))"
+reveal_type(f)  # N: Revealed type is "Overload(def () -> None, def (i: int) -> None)"
 
 
 [case testOverloadIncomplete]
@@ -168,7 +168,7 @@ class A:
     def f(self, i, j: int): ...
     def f(self, i: int = 0, j: int = 0): ...
 
-reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A), def (self: __main__.A, i: Untyped), def (self: __main__.A, i: Untyped, j: int))"
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A) -> None, def (self: __main__.A, i: Untyped) -> None, def (self: __main__.A, i: Untyped, j: int) -> None)"
 
 @overload
 def f(): ...
@@ -178,7 +178,7 @@ def f(i): ...
 def f(i, j: int): ...
 def f(i: int = 0, j: int = 0): ...
 
-reveal_type(f)  # N: Revealed type is "Overload(def (), def (i: Untyped), def (i: Untyped, j: int))"
+reveal_type(f)  # N: Revealed type is "Overload(def () -> None, def (i: Untyped) -> None, def (i: Untyped, j: int) -> None)"
 
 
 [case testOverloadUntyped]
@@ -194,7 +194,7 @@ class A:
     def f(self, *, j: int): ...
     def f(self, i: int = 0, j: int = 0): ...
 
-reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A), def (self: __main__.A, i: Untyped), def (self: __main__.A, *, j: int))"
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A) -> None, def (self: __main__.A, i: Untyped) -> None, def (self: __main__.A, *, j: int) -> None)"
 
 @overload
 def f(): ...
@@ -204,7 +204,7 @@ def f(i): ...
 def f(*, j: int): ...
 def f(i: int = 0, j: int = 0): ...
 
-reveal_type(f)  # N: Revealed type is "Overload(def (), def (i: Untyped), def (*, j: int))"
+reveal_type(f)  # N: Revealed type is "Overload(def () -> None, def (i: Untyped) -> None, def (*, j: int) -> None)"
 
 [case testOverloadOther]
 # flags: --allow-untyped-defs --allow-incomplete-defs --allow-any-expr
@@ -219,7 +219,7 @@ class A:
     def f(self, i, j: int): ...
     def f(self, i: int = 0, j: int = 0) -> object: ...
 
-reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A) -> int, def (self: __main__.A, i: Untyped), def (self: __main__.A, i: Untyped, j: int))"
+reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A) -> int, def (self: __main__.A, i: Untyped) -> None, def (self: __main__.A, i: Untyped, j: int) -> None)"
 
 class B:
     @overload
@@ -230,7 +230,7 @@ class B:
     def f(self, i, j: int) -> int: ...
     def f(self, i: int = 0, j: int = 0) -> object: ...
 
-reveal_type(B.f)  # N: Revealed type is "Overload(def (self: __main__.B) -> str, def (self: __main__.B, i: Untyped), def (self: __main__.B, i: Untyped, j: int) -> int)"
+reveal_type(B.f)  # N: Revealed type is "Overload(def (self: __main__.B) -> str, def (self: __main__.B, i: Untyped) -> None, def (self: __main__.B, i: Untyped, j: int) -> int)"
 
 
 [case testNewHasError]
@@ -238,4 +238,4 @@ reveal_type(B.f)  # N: Revealed type is "Overload(def (self: __main__.B) -> str,
 class A:
     def __new__(cls): ...  # E: "__new__" must return a class instance (got "None")  [misc]
 
-reveal_type(A.__new__)  # N: Revealed type is "def (cls: type[__main__.A])"
+reveal_type(A.__new__)  # N: Revealed type is "def (cls: type[__main__.A]) -> None"

--- a/test-data/unit/check-based-incomplete-defs.test
+++ b/test-data/unit/check-based-incomplete-defs.test
@@ -2,7 +2,7 @@
 # flags: --config-file tmp/mypy.ini
 from b import foo
 foo(1, 2)  # E: Call to incomplete function "foo" in typed context  [no-untyped-call] \
-           # N: Type is "def (a: int, b: Untyped)"
+           # N: Type is "def (a: int, b: Untyped) -> None"
 
 [file b.py]
 def foo(a: int, b): ...

--- a/test-data/unit/check-based-infer-function-types.test
+++ b/test-data/unit/check-based-infer-function-types.test
@@ -20,8 +20,8 @@ class B1(A1):
 
 reveal_type(A1.__new__)  # N: Revealed type is "def (cls: type[__main__.A1]) -> Untyped"
 reveal_type(B1.__new__)  # N: Revealed type is "def (cls: type[__main__.B1]) -> Untyped"
-reveal_type(A1.__init__)  # N: Revealed type is "def (self: __main__.A1)"
-reveal_type(B1.__init__)  # N: Revealed type is "def (self: __main__.B1)"
+reveal_type(A1.__init__)  # N: Revealed type is "def (self: __main__.A1) -> None"
+reveal_type(B1.__init__)  # N: Revealed type is "def (self: __main__.B1) -> None"
 
 class A2:
     def __new__(cls, a: int): ...
@@ -32,8 +32,8 @@ class B2(A2):
 
 reveal_type(A2.__new__)  # N: Revealed type is "def (cls: type[__main__.A2], a: int) -> __main__.A2"
 reveal_type(B2.__new__)  # N: Revealed type is "def (cls: type[__main__.B2], a: int) -> __main__.B2"
-reveal_type(A2.__init__)  # N: Revealed type is "def (self: __main__.A2, a: int)"
-reveal_type(B2.__init__)  # N: Revealed type is "def (self: __main__.B2, a: int)"
+reveal_type(A2.__init__)  # N: Revealed type is "def (self: __main__.A2, a: int) -> None"
+reveal_type(B2.__init__)  # N: Revealed type is "def (self: __main__.B2, a: int) -> None"
 
 
 [case testInferFunctionTypesComplete-xfail]
@@ -46,8 +46,8 @@ class B1(A1):
 
 reveal_type(A1.__new__)  # N: Revealed type is "def (cls: type[__main__.A1]) -> __main__.A1"
 reveal_type(B1.__new__)  # N: Revealed type is "def (cls: type[__main__.B1]) -> __main__.B1"
-reveal_type(A1.__init__)  # N: Revealed type is "def (self: __main__.A1)"
-reveal_type(B1.__init__)  # N: Revealed type is "def (self: __main__.B1)"
+reveal_type(A1.__init__)  # N: Revealed type is "def (self: __main__.A1) -> None"
+reveal_type(B1.__init__)  # N: Revealed type is "def (self: __main__.B1) -> None"
 
 class A2:
     def __new__(cls, a: int): ...
@@ -58,21 +58,21 @@ class B2(A2):
 
 reveal_type(A2.__new__)  # N: Revealed type is "def (cls: type[__main__.A2], a: int) -> __main__.A2"
 reveal_type(B2.__new__)  # N: Revealed type is "def (cls: type[__main__.B2], a: int) -> __main__.B2"
-reveal_type(A2.__init__)  # N: Revealed type is "def (self: __main__.A2, a: int)"
-reveal_type(B2.__init__)  # N: Revealed type is "def (self: __main__.B2, a: int)"
+reveal_type(A2.__init__)  # N: Revealed type is "def (self: __main__.A2, a: int) -> None"
+reveal_type(B2.__init__)  # N: Revealed type is "def (self: __main__.B2, a: int) -> None"
 
 
 [case testDefaultInstance-xfail]
 class A: ...
 def f(a=A()): ...
-reveal_type(f)  # N: Revealed type is "def (a: __main__.A =)"
+reveal_type(f)  # N: Revealed type is "def (a: __main__.A =) -> None"
 
 class B:
     def foo(self, a: object): ...
 class C(B):
     def foo(self, a=A()): ...
 
-reveal_type(C.foo)  # N: Revealed type is "def (self: __main__.C, a: object =)"
+reveal_type(C.foo)  # N: Revealed type is "def (self: __main__.C, a: object =) -> None"
 
 
 [case testDontInferFunctionTypes]
@@ -105,7 +105,7 @@ class B2(A2):
 
 reveal_type(A2.__new__)  # N: Revealed type is "def (cls: type[__main__.A2], a: int) -> Untyped"
 reveal_type(B2.__new__)  # N: Revealed type is "def (cls: type[__main__.B2], a: Untyped) -> Untyped"
-reveal_type(A2.__init__)  # N: Revealed type is "def (self: __main__.A2, a: int)"
+reveal_type(A2.__init__)  # N: Revealed type is "def (self: __main__.A2, a: int) -> None"
 reveal_type(B2.__init__)  # N: Revealed type is "def (self: __main__.B2, a: Untyped) -> Untyped"
 
 
@@ -169,7 +169,7 @@ def foo(a='1') -> None:
 def foo(a="1") -> None:
     reveal_type(a)  # N: Revealed type is "int | str"
 
-reveal_type(foo)  # N: Revealed type is "Overload(def (a: int), def (a: str =))"
+reveal_type(foo)  # N: Revealed type is "Overload(def (a: int) -> None, def (a: str =) -> None)"
 
 
 [case testOverloadMixedPositionalKeyword]
@@ -338,7 +338,7 @@ reveal_type(A.f)  # N: Revealed type is "Overload(def (self: __main__.A, f: int)
 reveal_type(B.f)  # N: Revealed type is "Overload(def (self: __main__.B, f: int) -> str, def (self: __main__.B, f: str) -> int)"
 reveal_type(C.f)  # N: Revealed type is "Overload(def (self: __main__.C, f: int) -> str, def (self: __main__.C, f: str) -> int)"
 reveal_type(D.f)  # N: Revealed type is "Overload(def (self: __main__.D, f: int) -> str, def (self: __main__.D, f: str) -> int)"
-reveal_type(E.f)  # N: Revealed type is "def (self: __main__.E, f: str)"
+reveal_type(E.f)  # N: Revealed type is "def (self: __main__.E, f: str) -> None"
 reveal_type(F.f)  # N: Revealed type is "Overload(def (self: __main__.F, f: int) -> str, def (self: __main__.F, f: str) -> int)"
 reveal_type(G.f)  # N: Revealed type is "Overload(def (self: __main__.G, f: int) -> str, def (self: __main__.G, f: str) -> int)"
 
@@ -367,7 +367,7 @@ def bar(a=1) -> None:
     1 + ""  # E: Unsupported operand types for + ("int" and "str")  [operator]
 
 bar()
-reveal_type(bar)  # N: Revealed type is "def (a: int =)"
+reveal_type(bar)  # N: Revealed type is "def (a: int =) -> None"
 
 
 [case inferPropertyTypes]
@@ -467,4 +467,4 @@ def deco(func: T) -> T: ...
 @deco
 def b(b=True) -> None: ...
 
-reveal_type(b)  # N: Revealed type is "def (b: bool =)"
+reveal_type(b)  # N: Revealed type is "def (b: bool =) -> None"

--- a/test-data/unit/check-based-type-render.test
+++ b/test-data/unit/check-based-type-render.test
@@ -14,6 +14,17 @@ class A(Generic[T2]):
 
 reveal_type(A.f)  # N: Revealed type is "def [T2 (from A), T] (self: __main__.A[T2], t: T, t2: T2) -> T | T2"
 reveal_type(A[int]().f)  # N: Revealed type is "def [T] (t: T, t2: int) -> T | int"
+A.f = 1  # E: Cannot assign to a method  [assignment] \
+         # E: Incompatible types in assignment (expression has type "int", variable has type "[T2 (from A), T] (A[T2], T, T2) -> T | T2")  [assignment]
+
+
+[case testGenericFunction]
+from typing import TypeVar
+T = TypeVar("T", bound=int)
+
+def foo(t: T) -> T: ...
+reveal_type(foo)  # N: Revealed type is "def [T: int] (t: T) -> T"
+foo = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "[T: int] (T) -> T")  [assignment]
 
 
 [case testRenderAny]
@@ -47,14 +58,18 @@ from typing import TypeVar
 T = TypeVar("T", bound=int)
 
 def foo(t: T): ...
-reveal_type(foo)  # N: Revealed type is "def[T: int](t: T)"
+reveal_type(foo)  # N: Revealed type is "def [T: int] (t: T)"
 
 
 [case testInferredNever]
-a: bool
-if a: ...
-elif not a: ...
-else:
-    reveal_type(a)  # N: Revealed type is "Never"
-                    # E: Statement is unreachable  [unreachable]
+a: int = []  # E: Incompatible types in assignment (expression has type "list[Never]", variable has type "int")  [assignment]
+reveal_type([])  # N: Revealed type is "list[Never]"
 
+
+[case testNoReturnAsNever]
+from typing import NoReturn
+a: NoReturn = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "Never")  [assignment]
+def b() -> NoReturn: ...
+reveal_type(a)  # N: Revealed type is "Never"
+reveal_type(b)  # N: Revealed type is "def () -> Never"
+b = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "() -> Never")  [assignment]

--- a/test-data/unit/check-based-type-render.test
+++ b/test-data/unit/check-based-type-render.test
@@ -36,3 +36,15 @@ reveal_type(b)  # N: Revealed type is "1 | 2 | 3"
 c: Literal[1, 2, 3] | str = 4  # E: Incompatible types in assignment (expression has type "4", variable has type "1 | 2 | 3 | str")  [assignment]
 reveal_type(c)  # N: Revealed type is "1 | 2 | 3 | str"
 [typing fixtures/typing-medium.pyi]
+
+
+[case testRenderInferredLiteral]
+reveal_type(1)  # N: Revealed type is "1"
+
+
+[case testRenderGenericUpperBound]
+from typing import TypeVar
+T = TypeVar("T", bound=int)
+
+def foo(t: T): ...
+reveal_type(foo)  # N: Revealed type is "def[T: int](t: T)"

--- a/test-data/unit/check-based-type-render.test
+++ b/test-data/unit/check-based-type-render.test
@@ -48,3 +48,13 @@ T = TypeVar("T", bound=int)
 
 def foo(t: T): ...
 reveal_type(foo)  # N: Revealed type is "def[T: int](t: T)"
+
+
+[case testInferredNever]
+a: bool
+if a: ...
+elif not a: ...
+else:
+    reveal_type(a)  # N: Revealed type is "Never"
+                    # E: Statement is unreachable  [unreachable]
+

--- a/test-data/unit/check-based-type-render.test
+++ b/test-data/unit/check-based-type-render.test
@@ -1,8 +1,8 @@
 [case testGenericMethod]
 from typing import TypeVar, Generic, Union
 
-T = TypeVar('T')
-T2 = TypeVar('T2')
+T = TypeVar('T', bound=str)
+T2 = TypeVar('T2', bound=int)
 
 class A(Generic[T2]):
     def f(self, t: T, t2: T2) -> Union[T, T2]:
@@ -12,10 +12,10 @@ class A(Generic[T2]):
             t = t2  # E: Incompatible types in assignment (expression has type "T2@A", variable has type "T@f")  [assignment]
         return t
 
-reveal_type(A.f)  # N: Revealed type is "def [T2 (from A), T] (self: __main__.A[T2], t: T, t2: T2) -> T | T2"
-reveal_type(A[int]().f)  # N: Revealed type is "def [T] (t: T, t2: int) -> T | int"
+reveal_type(A.f)  # N: Revealed type is "def [T2 (from A): int, T: str] (self: __main__.A[T2], t: T, t2: T2) -> T | T2"
+reveal_type(A[int]().f)  # N: Revealed type is "def [T: str] (t: T, t2: int) -> T | int"
 A.f = 1  # E: Cannot assign to a method  [assignment] \
-         # E: Incompatible types in assignment (expression has type "int", variable has type "[T2 (from A), T] (A[T2], T, T2) -> T | T2")  [assignment]
+         # E: Incompatible types in assignment (expression has type "int", variable has type "[T2 (from A): int, T: str] (A[T2], T, T2) -> T | T2")  [assignment]
 
 
 [case testGenericFunction]
@@ -58,7 +58,7 @@ from typing import TypeVar
 T = TypeVar("T", bound=int)
 
 def foo(t: T): ...
-reveal_type(foo)  # N: Revealed type is "def [T: int] (t: T)"
+reveal_type(foo)  # N: Revealed type is "def [T: int] (t: T) -> None"
 
 
 [case testInferredNever]
@@ -73,3 +73,9 @@ def b() -> NoReturn: ...
 reveal_type(a)  # N: Revealed type is "Never"
 reveal_type(b)  # N: Revealed type is "def () -> Never"
 b = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "() -> Never")  [assignment]
+
+
+[case testRenderNoneReturn]
+def foo(): ...
+reveal_type(foo)  # N: Revealed type is "def () -> None"
+foo = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "() -> None")  [assignment]

--- a/test-data/unit/check-based-untyped.test
+++ b/test-data/unit/check-based-untyped.test
@@ -47,9 +47,9 @@ def f1(a: List): ...
 def f2(a: List[Untyped]): ...
 a = [1]
 f1(a)  # E: Call to incomplete function "f1" in typed context  [no-untyped-call] \
-       # N: Type is "def (a: list[Untyped])"
+       # N: Type is "def (a: list[Untyped]) -> None"
 f2(a)  # E: Call to incomplete function "f2" in typed context  [no-untyped-call] \
-       # N: Type is "def (a: list[Untyped])"
+       # N: Type is "def (a: list[Untyped]) -> None"
 
 
 [case testIncompleteCall]


### PR DESCRIPTION
- Render generic upper bound with `: ` instead of ` <: `
- Render uninhabited type as `Never` instead of `<nothing>`
- Render Callables with `-> None`
- Render Callables in error messages properly
- Render inferred literal without `?`