### PR TITLE
Don't show "X defined here" when error context is hidden.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Enhancements
 ### Fixes
 
+## [Unreleased]
+### Fixes
+- Don't show "X defined here" when error context is hidden (#498)
+
 ## [2.0.0]
 ### Added
 - Deprecate python 3.7 support (#457)

--- a/mypy/messages.py
+++ b/mypy/messages.py
@@ -1040,7 +1040,7 @@ class MessageBuilder:
             msg += f"; did you mean {pretty_seq(matches, 'or')}?"
         self.fail(msg, context, code=codes.CALL_ARG)
         module = find_defining_module(self.modules, callee)
-        if module:
+        if module and (not mypy.options._based or self.options.show_error_context):
             assert callee.definition is not None
             fname = callable_name(callee)
             if not fname:  # an alias to function with a different name

--- a/test-data/unit/check-based-infer-function-types.test
+++ b/test-data/unit/check-based-infer-function-types.test
@@ -481,5 +481,6 @@ def f1():
 
 
 [case testNotesAppearForInferredFunction]
+# flags: --show-error-context
 def f(): ...  # N: "f" defined here
 f(x=1)  # E: Unexpected keyword argument "x" for "f"  [call-arg]

--- a/test-data/unit/check-based-misc.test
+++ b/test-data/unit/check-based-misc.test
@@ -1,0 +1,8 @@
+[case testXDefinedHere]
+# mypy: show-error-context
+import a
+def f(): ...  # N: "f" defined here
+f(a=1)  # E: Unexpected keyword argument "a" for "f"  [call-arg]
+[file a.py]
+def f(): ...
+f(a=1)  # E: Unexpected keyword argument "a" for "f"  [call-arg]

--- a/test-data/unit/cmdline-based-baseline.test
+++ b/test-data/unit/cmdline-based-baseline.test
@@ -528,7 +528,7 @@ foo()
 }
 
 [case testSrcOtherFile]
-# cmd: mypy --write-baseline a.py
+# cmd: mypy --write-baseline a.py --show-error-context
 [file a.py]
 from b import f
 f(a=1)
@@ -544,7 +544,7 @@ Baseline successfully written to .mypy/baseline.json
 == Return code: 0
 
 [case testSrcOtherFile2]
-# cmd: mypy a.py
+# cmd: mypy a.py --show-error-context
 [file a.py]
 from b import f
 f(a=1)


### PR DESCRIPTION
- resolves #387