### PR TITLE
based callable

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -4,8 +4,6 @@ about: Submit a proposal for a based new mypy feature
 labels: "feature"
 ---
 
-Before you raise this, consider if it's better suited to a discussion: https://github.com/KotlinIsland/basedmypy/discussions
-
 <!-- Please explain why this feature is based -->
 
 <!-- Please explain why this feature should be implemented and how it would be used. Please include a full usage example. -->

--- a/.mypy/baseline.json
+++ b/.mypy/baseline.json
@@ -1758,7 +1758,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(self: State) -> CacheMeta\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (self: State) -> CacheMeta\")",
         "offset": 0,
         "src": "def xmeta(self) -> CacheMeta:",
         "target": "mypy.build"
@@ -1839,7 +1839,7 @@
         "code": "no-any-expr",
         "column": 40,
         "message": "Expression type contains \"Any\" (has type \"(str, CacheMeta | None)\")",
-        "offset": 404,
+        "offset": 412,
         "src": "new_interface_hash, self.meta = write_cache(",
         "target": "mypy.build.State.write_cache"
       },
@@ -1969,7 +1969,7 @@
         "code": "explicit-override",
         "column": 4,
         "message": "Method \"type_context\" is not using @override but is overriding a method in class \"mypy.plugin.CheckerPluginInterface\"",
-        "offset": 449,
+        "offset": 454,
         "src": "def type_context(self) -> list[Type | None]:",
         "target": "mypy.checker"
       },
@@ -1993,7 +1993,7 @@
         "code": "explicit-override",
         "column": 4,
         "message": "Method \"visit_func_def\" is not using @override but is overriding a method in class \"mypy.visitor.NodeVisitor\"",
-        "offset": 272,
+        "offset": 283,
         "src": "def visit_func_def(self, defn: FuncDef) -> None:",
         "target": "mypy.checker.TypeChecker.visit_func_def"
       },
@@ -2009,7 +2009,7 @@
         "code": "no-any-expr",
         "column": 12,
         "message": "Expression type contains \"Any\" (has type \"tuple[Any, ...]\")",
-        "offset": 585,
+        "offset": 586,
         "src": "for substitutions in itertools.product(*subst):",
         "target": "mypy.checker.TypeChecker.expand_typevars"
       },
@@ -2030,18 +2030,10 @@
         "target": "mypy.checker.TypeChecker.expand_typevars"
       },
       {
-        "code": "redundant-expr",
-        "column": 11,
-        "message": "Condition is always true",
-        "offset": 306,
-        "src": "if isinstance(override, FunctionLike):",
-        "target": "mypy.checker.TypeChecker.check_override"
-      },
-      {
         "code": "explicit-override",
         "column": 4,
         "message": "Method \"visit_class_def\" is not using @override but is overriding a method in class \"mypy.visitor.NodeVisitor\"",
-        "offset": 128,
+        "offset": 434,
         "src": "def visit_class_def(self, defn: ClassDef) -> None:",
         "target": "mypy.checker.TypeChecker.visit_class_def"
       },
@@ -2113,7 +2105,7 @@
         "code": "truthy-bool",
         "column": 24,
         "message": "\"rvalue_type\" has type \"Type\" which does not implement __bool__ or __len__ so it could always be true in boolean context",
-        "offset": 161,
+        "offset": 220,
         "src": "and rvalue_type",
         "target": "mypy.checker.TypeChecker.check_assignment"
       },
@@ -2353,7 +2345,7 @@
         "code": "explicit-override",
         "column": 4,
         "message": "Method \"visit_with_stmt\" is not using @override but is overriding a method in class \"mypy.visitor.NodeVisitor\"",
-        "offset": 104,
+        "offset": 117,
         "src": "def visit_with_stmt(self, s: WithStmt) -> None:",
         "target": "mypy.checker.TypeChecker.visit_with_stmt"
       },
@@ -2659,7 +2651,7 @@
         "code": "possibly-undefined",
         "column": 23,
         "message": "Name \"actual_types\" may be undefined",
-        "offset": 1718,
+        "offset": 1723,
         "src": "assert len(actual_types) == len(actuals) == len(actual_kinds)",
         "target": "mypy.checkexpr"
       },
@@ -2931,7 +2923,7 @@
         "code": "explicit-override",
         "column": 4,
         "message": "Method \"visit_list_expr\" is not using @override but is overriding a method in class \"mypy.visitor.ExpressionVisitor\"",
-        "offset": 160,
+        "offset": 164,
         "src": "def visit_list_expr(self, e: ListExpr) -> Type:",
         "target": "mypy.checkexpr.ExpressionChecker.visit_list_expr"
       },
@@ -3317,7 +3309,7 @@
         "code": "truthy-bool",
         "column": 7,
         "message": "\"result\" has type \"Type\" which does not implement __bool__ or __len__ so it could always be true in boolean context",
-        "offset": 497,
+        "offset": 498,
         "src": "if result and not mx.is_lvalue and not implicit:",
         "target": "mypy.checkmember.analyze_var"
       },
@@ -7525,7 +7517,7 @@
         "code": "no-any-explicit",
         "column": 8,
         "message": "Explicit \"Any\" is not allowed",
-        "offset": 116,
+        "offset": 139,
         "src": "self.visitor_cache: dict[type, Callable[[AST | None], Any]] = {}",
         "target": "mypy.fastparse.ASTConverter.__init__"
       },
@@ -11321,7 +11313,7 @@
         "code": "no-any-expr",
         "column": 11,
         "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
-        "offset": 24,
+        "offset": 26,
         "src": "if not dummy.__dict__[\"special-opts:strict\"]:",
         "target": "mypy.main.process_options"
       },
@@ -12567,7 +12559,7 @@
         "code": "redundant-expr",
         "column": 9,
         "message": "Condition is always false",
-        "offset": 263,
+        "offset": 274,
         "src": "elif typ is None:",
         "target": "mypy.messages.format_type_inner"
       },
@@ -12607,7 +12599,7 @@
         "code": "no-any-expr",
         "column": 20,
         "message": "Expression type contains \"Any\" (has type \"dict[str, Any]\")",
-        "offset": 74,
+        "offset": 76,
         "src": "first_arg = tp.def_extras.get(\"first_arg\")",
         "target": "mypy.messages.pretty_callable"
       },
@@ -15204,10 +15196,18 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(self: SemanticAnalyzerPluginInterface, name: str, stnode: SymbolTableNode) -> Any\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (self: SemanticAnalyzerPluginInterface, name: str, stnode: SymbolTableNode) -> Any\")",
         "offset": 0,
         "src": "def add_symbol_table_node(self, name: str, stnode: SymbolTableNode) -> Any:",
         "target": "mypy.plugin"
+      },
+      {
+        "code": "no-any-decorated",
+        "column": 4,
+        "message": "See https://kotlinisland.github.io/basedmypy/_refs.html#code-no-any-decorated for more info",
+        "offset": 0,
+        "src": "def add_symbol_table_node(self, name: str, stnode: SymbolTableNode) -> Any:",
+        "target": null
       },
       {
         "code": "explicit-override",
@@ -17041,7 +17041,7 @@
         "code": "explicit-override",
         "column": 4,
         "message": "Method \"visit_func_def\" is not using @override but is overriding a method in class \"mypy.visitor.NodeVisitor\"",
-        "offset": 328,
+        "offset": 334,
         "src": "def visit_func_def(self, defn: FuncDef) -> None:",
         "target": "mypy.semanal.SemanticAnalyzer.visit_func_def"
       },
@@ -23108,7 +23108,7 @@
       {
         "code": "no-any-expr",
         "column": 46,
-        "message": "Expression type contains \"Any\" (has type \"(x: (str, Any)) -> str\")",
+        "message": "Expression type contains \"Any\" (has type \"def (x: (str, Any)) -> str\")",
         "offset": 0,
         "src": "all_items = sorted(all_items, key=lambda x: x[0])",
         "target": "mypy.stubgenc.InspectionStubGenerator.generate_module"
@@ -23410,14 +23410,6 @@
         "target": "mypy.stubgenc"
       },
       {
-        "code": "no-any-decorated",
-        "column": 4,
-        "message": "See https://kotlinisland.github.io/basedmypy/_refs.html#code-no-any-decorated for more info",
-        "offset": 0,
-        "src": "def is_property_readonly(prop: Any) -> bool:",
-        "target": null
-      },
-      {
         "code": "no-any-expr",
         "column": 23,
         "message": "Expression has type \"Any\"",
@@ -23652,7 +23644,7 @@
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"(x: (str, Any)) -> (int, str)\")",
+        "message": "Expression type contains \"Any\" (has type \"def (x: (str, Any)) -> (int, str)\")",
         "offset": 0,
         "src": "items = sorted(items, key=lambda x: method_name_sort_key(x[0]))",
         "target": "mypy.stubgenc.InspectionStubGenerator.generate_class_stub"
@@ -24038,7 +24030,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"[_T] (func: (...) -> _T) -> _SingleDispatchCallable[_T]\")",
+        "message": "Expression type contains \"Any\" (has type \"def [_T] (func: (...) -> _T) -> _SingleDispatchCallable[_T]\")",
         "offset": 13,
         "src": "@singledispatch",
         "target": "mypy.stubtest"
@@ -24046,7 +24038,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"(stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Expression type contains \"Any\" (has type \"def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "@singledispatch",
         "target": "mypy.stubtest"
@@ -24062,7 +24054,7 @@
       {
         "code": "no-any-decorated",
         "column": 0,
-        "message": "Type of decorated function contains type \"Any\" (\"_SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
+        "message": "Type of decorated function contains type \"Any\" (\"_SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
         "offset": 0,
         "src": "def verify(",
         "target": "mypy.stubtest"
@@ -24078,7 +24070,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
         "offset": 64,
         "src": "@verify.register(nodes.MypyFile)",
         "target": "mypy.stubtest"
@@ -24086,7 +24078,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[MypyFile, _SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[MypyFile, _SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
         "offset": 0,
         "src": "@verify.register(nodes.MypyFile)",
         "target": "mypy.stubtest"
@@ -24302,7 +24294,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
         "offset": 6,
         "src": "@verify.register(nodes.TypeInfo)",
         "target": "mypy.stubtest"
@@ -24310,7 +24302,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[TypeInfo, _SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[TypeInfo, _SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
         "offset": 0,
         "src": "@verify.register(nodes.TypeInfo)",
         "target": "mypy.stubtest"
@@ -24318,7 +24310,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"(stub: TypeInfo, runtime: type[Any] | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Expression type contains \"Any\" (has type \"def (stub: TypeInfo, runtime: type[Any] | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "@verify.register(nodes.TypeInfo)",
         "target": "mypy.stubtest"
@@ -24334,7 +24326,7 @@
       {
         "code": "no-any-decorated",
         "column": 0,
-        "message": "Type of decorated function contains type \"Any\" (\"(stub: TypeInfo, runtime: type[Any] | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (stub: TypeInfo, runtime: type[Any] | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "def verify_typeinfo(",
         "target": "mypy.stubtest"
@@ -24536,6 +24528,14 @@
         "column": 43,
         "message": "Expression type contains \"Any\" (has type \"Any | None\")",
         "offset": 3,
+        "src": "probably_class_method = isinstance(getattr(runtime, \"__self__\", None), type)",
+        "target": "mypy.stubtest._verify_static_class_methods"
+      },
+      {
+        "code": "no-any-expr",
+        "column": 51,
+        "message": "Expression type contains \"Any\" (has type \"BuiltinFunctionType[[*Untyped, **Untyped], Untyped]\")",
+        "offset": 0,
         "src": "probably_class_method = isinstance(getattr(runtime, \"__self__\", None), type)",
         "target": "mypy.stubtest._verify_static_class_methods"
       },
@@ -24822,7 +24822,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
         "offset": 6,
         "src": "@verify.register(nodes.FuncItem)",
         "target": "mypy.stubtest"
@@ -24830,7 +24830,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[FuncItem, _SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[FuncItem, _SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
         "offset": 0,
         "src": "@verify.register(nodes.FuncItem)",
         "target": "mypy.stubtest"
@@ -24838,7 +24838,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"(stub: FuncItem, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Expression type contains \"Any\" (has type \"def (stub: FuncItem, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "@verify.register(nodes.FuncItem)",
         "target": "mypy.stubtest"
@@ -24854,7 +24854,7 @@
       {
         "code": "no-any-decorated",
         "column": 0,
-        "message": "Type of decorated function contains type \"Any\" (\"(stub: FuncItem, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (stub: FuncItem, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "def verify_funcitem(",
         "target": "mypy.stubtest"
@@ -25014,7 +25014,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
         "offset": 5,
         "src": "@verify.register(Missing)",
         "target": "mypy.stubtest"
@@ -25022,7 +25022,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[Missing, _SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[Missing, _SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
         "offset": 0,
         "src": "@verify.register(Missing)",
         "target": "mypy.stubtest"
@@ -25030,7 +25030,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"(stub: Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Expression type contains \"Any\" (has type \"def (stub: Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "@verify.register(Missing)",
         "target": "mypy.stubtest"
@@ -25046,7 +25046,7 @@
       {
         "code": "no-any-decorated",
         "column": 0,
-        "message": "Type of decorated function contains type \"Any\" (\"(stub: Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (stub: Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "def verify_none(",
         "target": "mypy.stubtest"
@@ -25062,7 +25062,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
         "offset": 3,
         "src": "@verify.register(nodes.Var)",
         "target": "mypy.stubtest"
@@ -25070,7 +25070,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[Var, _SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[Var, _SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
         "offset": 0,
         "src": "@verify.register(nodes.Var)",
         "target": "mypy.stubtest"
@@ -25078,7 +25078,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"(stub: Var, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Expression type contains \"Any\" (has type \"def (stub: Var, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "@verify.register(nodes.Var)",
         "target": "mypy.stubtest"
@@ -25094,7 +25094,7 @@
       {
         "code": "no-any-decorated",
         "column": 0,
-        "message": "Type of decorated function contains type \"Any\" (\"(stub: Var, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (stub: Var, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "def verify_var(",
         "target": "mypy.stubtest"
@@ -25166,7 +25166,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
         "offset": 4,
         "src": "@verify.register(nodes.OverloadedFuncDef)",
         "target": "mypy.stubtest"
@@ -25174,7 +25174,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[OverloadedFuncDef, _SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[OverloadedFuncDef, _SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
         "offset": 0,
         "src": "@verify.register(nodes.OverloadedFuncDef)",
         "target": "mypy.stubtest"
@@ -25182,7 +25182,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"(stub: OverloadedFuncDef, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Expression type contains \"Any\" (has type \"def (stub: OverloadedFuncDef, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "@verify.register(nodes.OverloadedFuncDef)",
         "target": "mypy.stubtest"
@@ -25198,7 +25198,7 @@
       {
         "code": "no-any-decorated",
         "column": 0,
-        "message": "Type of decorated function contains type \"Any\" (\"(stub: OverloadedFuncDef, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (stub: OverloadedFuncDef, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "def verify_overloadedfuncdef(",
         "target": "mypy.stubtest"
@@ -25318,7 +25318,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
         "offset": 6,
         "src": "@verify.register(nodes.TypeVarExpr)",
         "target": "mypy.stubtest"
@@ -25326,7 +25326,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[TypeVarExpr, _SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[TypeVarExpr, _SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
         "offset": 0,
         "src": "@verify.register(nodes.TypeVarExpr)",
         "target": "mypy.stubtest"
@@ -25334,7 +25334,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"(stub: TypeVarExpr, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Expression type contains \"Any\" (has type \"def (stub: TypeVarExpr, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "@verify.register(nodes.TypeVarExpr)",
         "target": "mypy.stubtest"
@@ -25350,7 +25350,7 @@
       {
         "code": "no-any-decorated",
         "column": 0,
-        "message": "Type of decorated function contains type \"Any\" (\"(stub: TypeVarExpr, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (stub: TypeVarExpr, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "def verify_typevarexpr(",
         "target": "mypy.stubtest"
@@ -25382,7 +25382,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
         "offset": 4,
         "src": "@verify.register(nodes.ParamSpecExpr)",
         "target": "mypy.stubtest"
@@ -25390,7 +25390,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[ParamSpecExpr, _SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[ParamSpecExpr, _SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
         "offset": 0,
         "src": "@verify.register(nodes.ParamSpecExpr)",
         "target": "mypy.stubtest"
@@ -25398,7 +25398,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"(stub: ParamSpecExpr, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Expression type contains \"Any\" (has type \"def (stub: ParamSpecExpr, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "@verify.register(nodes.ParamSpecExpr)",
         "target": "mypy.stubtest"
@@ -25414,7 +25414,7 @@
       {
         "code": "no-any-decorated",
         "column": 0,
-        "message": "Type of decorated function contains type \"Any\" (\"(stub: ParamSpecExpr, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (stub: ParamSpecExpr, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "def verify_paramspecexpr(",
         "target": "mypy.stubtest"
@@ -25662,7 +25662,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
         "offset": 60,
         "src": "@verify.register(nodes.Decorator)",
         "target": "mypy.stubtest"
@@ -25670,7 +25670,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[Decorator, _SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[Decorator, _SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
         "offset": 0,
         "src": "@verify.register(nodes.Decorator)",
         "target": "mypy.stubtest"
@@ -25678,7 +25678,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"(stub: Decorator, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Expression type contains \"Any\" (has type \"def (stub: Decorator, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "@verify.register(nodes.Decorator)",
         "target": "mypy.stubtest"
@@ -25694,7 +25694,7 @@
       {
         "code": "no-any-decorated",
         "column": 0,
-        "message": "Type of decorated function contains type \"Any\" (\"(stub: Decorator, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (stub: Decorator, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "def verify_decorator(",
         "target": "mypy.stubtest"
@@ -25766,7 +25766,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]\")",
         "offset": 3,
         "src": "@verify.register(nodes.TypeAlias)",
         "target": "mypy.stubtest"
@@ -25774,7 +25774,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[TypeAlias, _SingleDispatchCallable[Iterator[Error], (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
+        "message": "Expression type contains \"Any\" (has type \"_SingleDispatchRegisterCallable[TypeAlias, _SingleDispatchCallable[Iterator[Error], def (stub: Node | Missing, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]]]\")",
         "offset": 0,
         "src": "@verify.register(nodes.TypeAlias)",
         "target": "mypy.stubtest"
@@ -25782,7 +25782,7 @@
       {
         "code": "no-any-expr",
         "column": 1,
-        "message": "Expression type contains \"Any\" (has type \"(stub: TypeAlias, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Expression type contains \"Any\" (has type \"def (stub: TypeAlias, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "@verify.register(nodes.TypeAlias)",
         "target": "mypy.stubtest"
@@ -25798,7 +25798,7 @@
       {
         "code": "no-any-decorated",
         "column": 0,
-        "message": "Type of decorated function contains type \"Any\" (\"(stub: TypeAlias, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (stub: TypeAlias, runtime: Any | Missing, object_path: list[str]) -> Iterator[Error]\")",
         "offset": 0,
         "src": "def verify_typealias(",
         "target": "mypy.stubtest"
@@ -26427,14 +26427,14 @@
         "code": "no-any-explicit",
         "column": 4,
         "message": "Explicit \"Any\" is not allowed",
-        "offset": 792,
+        "offset": 801,
         "src": "def report(*args: Any) -> None:",
         "target": "mypy.subtypes.unify_generic_callable"
       },
       {
         "code": "no-any-expr",
         "column": 38,
-        "message": "Expression type contains \"Any\" (has type \"(*args: Any) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (*args: Any) -> None\")",
         "offset": 9,
         "src": "type, non_none_inferred_vars, report, context=target",
         "target": "mypy.subtypes.unify_generic_callable"
@@ -27001,7 +27001,7 @@
         "code": "no-any-expr",
         "column": 7,
         "message": "Expression has type \"Untyped\"",
-        "offset": 121,
+        "offset": 123,
         "src": "if testcase.config.getoption(\"--mypy-verbose\"):",
         "target": "mypy.test.helpers.parse_options"
       },
@@ -28096,7 +28096,7 @@
       {
         "code": "no-any-expr",
         "column": 32,
-        "message": "Expression type contains \"Any\" (has type \"(self: Any) -> str\")",
+        "message": "Expression type contains \"Any\" (has type \"def (self: Any) -> str\")",
         "offset": 458,
         "src": "test.__doc__ = property(lambda self: \"test(arg0: str) -> None\")  # type: ignore[assignment]",
         "target": "mypy.test.teststubgen.StubgencSuite.test_generate_c_function_no_crash_for_non_str_docstring"
@@ -28163,8 +28163,8 @@
         "code": "no-any-explicit",
         "column": 0,
         "message": "Explicit \"Any\" is not allowed",
-        "offset": 186,
-        "src": "def collect_cases(fn: Callable[..., Iterator[Case]]) -> Callable[..., None]:",
+        "offset": 189,
+        "src": "def collect_cases(fn: Callable[..., Iterator[Case]]) -> FunctionType[..., None]:",
         "target": "mypy.test.teststubtest.collect_cases"
       },
       {
@@ -28194,7 +28194,7 @@
       {
         "code": "no-any-expr",
         "column": 11,
-        "message": "Expression type contains \"Any\" (has type \"(*args: Any, **kwargs: Any) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (*args: Any, **kwargs: Any) -> None\")",
         "offset": 24,
         "src": "return test",
         "target": "mypy.test.teststubtest.collect_cases"
@@ -28202,7 +28202,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 4,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28210,7 +28210,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_basic_good(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28218,7 +28218,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 18,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28226,7 +28226,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_types(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28234,7 +28234,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 21,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28242,7 +28242,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_coroutines(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28250,7 +28250,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 9,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28258,7 +28258,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_arg_name(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28266,7 +28266,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 39,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28274,7 +28274,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_arg_kind(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28282,7 +28282,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 32,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28290,7 +28290,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_default_presence(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28298,7 +28298,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 34,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28306,7 +28306,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_default_value(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28314,7 +28314,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 62,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28322,7 +28322,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_static_class_method(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28330,7 +28330,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 64,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28338,7 +28338,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_arg_mismatch(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28346,7 +28346,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 17,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28354,7 +28354,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_varargs_varkwargs(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28362,7 +28362,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 66,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28370,7 +28370,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_overload(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28378,7 +28378,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 72,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28386,7 +28386,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_property(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28394,7 +28394,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 103,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28402,7 +28402,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_var(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28410,7 +28410,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 63,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28418,7 +28418,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_type_alias(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28426,7 +28426,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 190,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28434,7 +28434,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_enum(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28442,7 +28442,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 98,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28450,7 +28450,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_decorator(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28458,7 +28458,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 16,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28466,7 +28466,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_all_at_runtime_not_stub(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28474,7 +28474,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 9,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28482,7 +28482,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_all_in_stub_not_at_runtime(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28490,7 +28490,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 3,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28498,7 +28498,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_all_in_stub_different_to_all_at_runtime(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28506,7 +28506,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 16,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28514,7 +28514,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_missing(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28522,7 +28522,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 33,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28530,7 +28530,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_missing_no_runtime_all(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28538,7 +28538,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 8,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28546,7 +28546,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_non_public_1(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28554,7 +28554,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 6,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28562,7 +28562,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_non_public_2(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28570,7 +28570,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 5,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28578,7 +28578,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_dunders(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28586,7 +28586,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 28,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28594,7 +28594,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_not_subclassable(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28602,7 +28602,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 10,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28610,7 +28610,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_has_runtime_final_decorator(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28618,7 +28618,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 256,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28626,7 +28626,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_name_mangling(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28634,7 +28634,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 58,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28642,7 +28642,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_mro(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28650,7 +28650,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 31,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28658,7 +28658,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_good_literal(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28666,7 +28666,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 33,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28674,7 +28674,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_bad_literal(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28682,7 +28682,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 35,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28690,7 +28690,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_special_subtype(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28698,7 +28698,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 34,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28706,7 +28706,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_runtime_typing_objects(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28714,7 +28714,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 31,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28722,7 +28722,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_named_tuple(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28730,7 +28730,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 35,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28738,7 +28738,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_named_tuple_typing_and_collections(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28746,7 +28746,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 29,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28754,7 +28754,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_type_var(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28762,7 +28762,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 14,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28770,7 +28770,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_metaclass_match(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28778,7 +28778,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 48,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28786,7 +28786,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_metaclass_abcmeta(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28794,7 +28794,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 13,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28802,7 +28802,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_abstract_methods(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28810,7 +28810,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 97,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28818,7 +28818,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_abstract_properties(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28826,7 +28826,7 @@
       {
         "code": "no-any-expr",
         "column": 5,
-        "message": "Expression type contains \"Any\" (has type \"(fn: (...) -> Iterator[Case]) -> (...) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
         "offset": 66,
         "src": "@collect_cases",
         "target": "mypy.test.teststubtest"
@@ -28834,7 +28834,7 @@
       {
         "code": "no-any-decorated",
         "column": 4,
-        "message": "Type of decorated function contains type \"Any\" (\"(...) -> None\")",
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
         "offset": 1,
         "src": "def test_type_check_only(self) -> Iterator[Case]:",
         "target": "mypy.test.teststubtest"
@@ -28850,7 +28850,7 @@
       {
         "code": "no-any-expr",
         "column": 81,
-        "message": "Expression type contains \"Any\" (has type \"(a: int, b: int, *, c: int, d: int = ..., **kwargs: Any) -> None\")",
+        "message": "Expression type contains \"Any\" (has type \"def (a: int, b: int, *, c: int, d: int = ..., **kwargs: Any) -> None\")",
         "offset": 4,
         "src": "str(mypy.stubtest.Signature.from_inspect_signature(inspect.signature(f)))",
         "target": "mypy.test.teststubtest.StubtestMiscUnit.test_signature"
@@ -31497,7 +31497,7 @@
         "code": "explicit-override",
         "column": 4,
         "message": "Method \"visit_unbound_type\" is not using @override but is overriding a method in class \"mypy.type_visitor.TypeVisitor\"",
-        "offset": 264,
+        "offset": 270,
         "src": "def visit_unbound_type(self, t: UnboundType, defining_literal: bool = False) -> Type:",
         "target": "mypy.typeanal.TypeAnalyser.visit_unbound_type"
       },
@@ -31505,7 +31505,7 @@
         "code": "explicit-override",
         "column": 4,
         "message": "Method \"visit_any\" is not using @override but is overriding a method in class \"mypy.type_visitor.TypeVisitor\"",
-        "offset": 664,
+        "offset": 673,
         "src": "def visit_any(self, t: AnyType) -> Type:",
         "target": "mypy.typeanal.TypeAnalyser.visit_any"
       },
@@ -31625,7 +31625,7 @@
         "code": "explicit-override",
         "column": 4,
         "message": "Method \"visit_overloaded\" is not using @override but is overriding a method in class \"mypy.type_visitor.TypeVisitor\"",
-        "offset": 138,
+        "offset": 153,
         "src": "def visit_overloaded(self, t: Overloaded) -> Type:",
         "target": "mypy.typeanal.TypeAnalyser.visit_overloaded"
       },
@@ -31721,7 +31721,7 @@
         "code": "explicit-override",
         "column": 4,
         "message": "Method \"analyze_callable_args\" is not using @override but is overriding a method in class \"mypy.plugin.TypeAnalyzerPluginInterface\"",
-        "offset": 171,
+        "offset": 173,
         "src": "def analyze_callable_args(",
         "target": "mypy.typeanal.TypeAnalyser.analyze_callable_args"
       },
@@ -31843,7 +31843,7 @@
         "code": "redundant-expr",
         "column": 19,
         "message": "Condition is always true",
-        "offset": 485,
+        "offset": 492,
         "src": "if extra_attrs_set is None:",
         "target": "mypy.typeops.make_simplified_union"
       },
@@ -33317,7 +33317,7 @@
         "code": "no-any-expr",
         "column": 43,
         "message": "Expression has type \"Any\"",
-        "offset": 101,
+        "offset": 125,
         "src": "arg_types: Bogus[Sequence[Type]] = _dummy,",
         "target": "mypy.types.Parameters.copy_modified"
       },
@@ -35197,7 +35197,7 @@
         "code": "explicit-override",
         "column": 4,
         "message": "Method \"visit_overloaded\" is not using @override but is overriding a method in class \"mypy.type_visitor.TypeVisitor\"",
-        "offset": 96,
+        "offset": 108,
         "src": "def visit_overloaded(self, t: Overloaded) -> str:",
         "target": "mypy.types.TypeStrVisitor.visit_overloaded"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 ### Added
+- `Callable` syntax (`(int) -> str`) (#619)
+- `FunctionType` syntax (`def (int) -> str`) (#619)
+### Fixes
+- `Callable` is no longer `types.FunctionType` (#619)
+
+## [2.4.0]
+
+## [2.3.0]
+### Added
 - f-string format specs are checked (#543)
 - Narrow type on initial assignment (#547)
 - Annotations in function bodies are not analyzed as evaluated (#564)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Discord](https://img.shields.io/discord/948915247073349673?logo=discord)](https://discord.gg/7y9upqPrk2)
+[![Playground](https://img.shields.io/badge/🛝%20playground-blue)](https://mypy-play.net/?mypy=basedmypy-latest)
 [![Stable Version](https://img.shields.io/pypi/v/basedmypy?color=blue)](https://pypi.org/project/basedmypy/)
 [![Downloads](https://img.shields.io/pypi/dm/basedmypy)](https://pypistats.org/packages/basedmypy)
 [![Documentation](https://img.shields.io/badge/📚%20docs-blue)](https://KotlinIsland.github.io/basedmypy)

--- a/docs/source/error_code_list3.rst
+++ b/docs/source/error_code_list3.rst
@@ -116,4 +116,35 @@ Casting between two non-overlapping types is often a mistake:
     a: int
     cast(str, a)  # Conversion of type "int" to type "str" may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to "object" first.  [bad-cast]
 
+.. _code-callable-functiontype:
+
+Check for bad usages of callabes and function types [callable-functiontype]
+---------------------------------------------------------------------------
+
+Because functions can create methods when accessed in certain ways,
+basedmypy has checks regarding their usages:
+
+.. code-block:: python
+
+    class A:
+        a: "(int) -> object" = lambda i: i + 1  # Assigning a "FunctionType" on the class will become a "MethodType"  [callable-functiontype]
+
+    A().a(1)  # runtime TypeError: <lambda>() takes 1 positional argument but 2 were given
+
+.. _code-possible-function:
+
+Check that callables are valid [possible-function]
+--------------------------------------------------
+
+Because a function can create methods when accessed in certain ways,
+basedmypy has lint rules regarding their validity as ``Callable``\s:
+
+.. code-block:: python
+
+    c: "(int) -> object" = lambda i: i + 1
+    class A:
+        a: "(int) -> object" = c  # This "CallableType" could be a "FunctionType", which when assigned via the class, would produce a "MethodType"  [possible-function]
+
+    A().a(1)  # runtime TypeError: <lambda>() takes 1 positional argument but 2 were given
+
 .. _code-reveal:

--- a/docs/source/kinds_of_types.rst
+++ b/docs/source/kinds_of_types.rst
@@ -146,8 +146,30 @@ purpose. Example:
 
 .. _callable-types:
 
-Callable types (and lambdas)
-****************************
+Callable types
+**************
+
+A callable type is a type that conforms to the ``collections.abc.Callable`` protocol, i.e. it has a ``__call__`` attribute (invoked with the call operator: ``X()``).
+There are three main kinds of these:
+
+- functions and lambdas (``types.FunctionType``/``builtins.function``)
+- ``type`` objects. (i.e. the ``int`` class)
+- instances that define a ``__call__`` method
+
+A callable type can be denoted as ``"(int, str) -> None"``. A function type (``types.FunctionType``) can be denoted as ``"def (int, str) -> None"``.
+
+``FunctionType`` does have some problematic behavior due to it's implementation of ``__get__``:
+
+.. code-block:: python
+
+    def f(a, b): ...
+    class A:
+        f = f
+
+    A.f(1, 2)
+    A().f(1, 2)  # TypeError: f() takes 2 positional arguments but 3 were given
+
+This is because when the class attribute is accessed through an instance, ``FunctionType`` will instead return a ``MethodType``, with the ``self`` argument pre-filled.
 
 You can pass around function objects and bound methods in statically
 typed code. The type of a function that accepts arguments ``A1``, ..., ``An``

--- a/mypy-requirements.txt
+++ b/mypy-requirements.txt
@@ -1,5 +1,5 @@
 # NOTE: this needs to be kept in sync with the "requires" list in pyproject.toml
-basedtyping>=0.0.3
+basedtyping>=0.1.4
 typing_extensions>=4.1.0
 mypy_extensions>=1.0.0
 tomli>=1.1.0; python_version<'3.11'

--- a/mypy/build.py
+++ b/mypy/build.py
@@ -2236,6 +2236,14 @@ class State:
         if not temporary:
             self.manager.modules[self.id] = self.tree
             self.manager.add_stats(fresh_trees=1)
+        if self.id == "typing":
+            # For cringe reasons, we extract _Callable as soon as it's loaded
+            from mypy import typeanal
+            from mypy.types import Instance
+
+            typeanal.CALLABLE_TYPE = Instance(
+                cast(TypeInfo, self.tree.names["_Callable"].node), []
+            )
 
     def fix_cross_refs(self) -> None:
         assert self.tree is not None, "Internal error: method must be called on parsed file only"

--- a/mypy/errorcodes.py
+++ b/mypy/errorcodes.py
@@ -292,6 +292,15 @@ TYPEGUARD_LIMITATION: Final[ErrorCode] = ErrorCode(
 BAD_CAST: Final[ErrorCode] = ErrorCode(
     "bad-cast", "cast of non-overlapping types", "General", default_enabled=False
 )
+CALLABLE_FUNCTIONTYPE: Final[ErrorCode] = ErrorCode(
+    "callable-functiontype",
+    "usages of Callable and FunctionType",
+    "General",
+    default_enabled=False,
+)
+POSSIBLE_FUNCTION: Final[ErrorCode] = ErrorCode(
+    "possible-function", "possible FunctionType on class", "General", default_enabled=False
+)
 
 REGEX: Final = ErrorCode("regex", "Regex related errors", "General")
 REVEAL: Final = ErrorCode("reveal", "Reveal types at check time", "General")

--- a/mypy/main.py
+++ b/mypy/main.py
@@ -1348,6 +1348,8 @@ def process_options(
             "unused-awaitable",
             "redundant-self",
             "explicit-override",
+            "callable-functiontype",
+            "possible-function",
             "bad-cast",
         }
         if mypy.options._based

--- a/mypy/nodes.py
+++ b/mypy/nodes.py
@@ -3416,7 +3416,7 @@ class FakeInfo(TypeInfo):
 
     def __getattribute__(self, attr: str) -> type:
         # Handle __class__ so that isinstance still works...
-        if attr == "__class__":
+        if attr in ("__class__", "msg"):
             return object.__getattribute__(self, attr)  # type: ignore[no-any-return]
         raise AssertionError(object.__getattribute__(self, "msg"))
 

--- a/mypy/semanal.py
+++ b/mypy/semanal.py
@@ -606,6 +606,12 @@ class SemanticAnalyzer(
             else:
                 self.recurse_into_functions = True
                 self.accept(node)
+
+        # For cringe reasons, we import the fake 'typing._Callable' as soon at it is loaded
+        from mypy import typeanal
+
+        if node.fullname == "typing" and not typeanal.CALLABLE_TYPE:
+            typeanal.CALLABLE_TYPE = self.named_type(typeanal.CALLABLE_NAME)
         del self.patches
 
     def refresh_top_level(self, file_node: MypyFile) -> None:

--- a/mypy/semanal_infer.py
+++ b/mypy/semanal_infer.py
@@ -56,7 +56,7 @@ def infer_decorator_signature_if_simple(
     if decorator_preserves_type:
         # No non-identity decorators left. We can trivially infer the type
         # of the function here.
-        dec.var.type = function_type(dec.func, analyzer.named_type("builtins.function"))
+        dec.var.type = function_type(dec.func, analyzer.named_type("typing._Callable"))
     if dec.decorators:
         return_type = calculate_return_type(dec.decorators[0])
         if return_type and isinstance(return_type, AnyType):

--- a/mypy/suggestions.py
+++ b/mypy/suggestions.py
@@ -1020,7 +1020,7 @@ def refine_callable(t: CallableType, s: CallableType) -> CallableType:
 
     See comments for refine_type.
     """
-    if t.fallback != s.fallback:
+    if (t.is_type_obj() or s.is_type_obj()) and t.fallback != s.fallback:
         return t
 
     if t.is_ellipsis_args and not is_tricky_callable(s):

--- a/mypy/test/data.py
+++ b/mypy/test/data.py
@@ -402,7 +402,7 @@ class DataDrivenTestCase(pytest.Item):
             excinfo.traceback = self.parent._traceback_filter(excinfo)
             excrepr = excinfo.getrepr(style="short")
 
-        return f"data: {self.file}:{self.line}:\n{excrepr}"
+        return f"data: {Path(self.file).as_uri()}:{self.line}:\n{excrepr}"
 
     def find_steps(self) -> list[list[FileOperation]]:
         """Return a list of descriptions of file operations for each incremental step.

--- a/mypy/test/helpers.py
+++ b/mypy/test/helpers.py
@@ -113,10 +113,10 @@ def assert_string_arrays_equal(expected: list[str], actual: list[str], msg: str)
     if expected != actual:
         expected_ranges, actual_ranges = diff_ranges(expected, actual)
         sys.stderr.write("Expected:\n")
-        red = "\033[31m" if sys.platform != "win32" else None
+        red = "\033[31m"
         render_diff_range(expected_ranges, expected, colour=red)
         sys.stderr.write("Actual:\n")
-        green = "\033[32m" if sys.platform != "win32" else None
+        green = "\033[32m"
         render_diff_range(actual_ranges, actual, colour=green)
 
         sys.stderr.write("\n")
@@ -382,6 +382,8 @@ def parse_options(
                     errorcodes.BAD_CAST,
                     errorcodes.REDUNDANT_EXPR,
                     errorcodes.HELPFUL_STRING,
+                    errorcodes.CALLABLE_FUNCTIONTYPE,
+                    errorcodes.POSSIBLE_FUNCTION,
                 }
             )
         else:

--- a/mypy/test/testparse.py
+++ b/mypy/test/testparse.py
@@ -6,6 +6,7 @@ import sys
 
 from pytest import skip
 
+import mypy.options
 from mypy import defaults
 from mypy.config_parser import parse_mypy_comments
 from mypy.errors import CompileError
@@ -53,7 +54,13 @@ def test_parser(testcase: DataDrivenTestCase) -> None:
         n = parse(
             bytes(source, "ascii"), fnam="main", module="__main__", errors=None, options=options
         )
-        a = n.str_with_options(options).split("\n")
+
+        based = mypy.options._based
+        mypy.options._based = False
+        try:
+            a = n.str_with_options(options).split("\n")
+        finally:
+            mypy.options._based = based
     except CompileError as e:
         a = e.messages
     assert_string_arrays_equal(

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 import textwrap
 import unittest
+from types import FunctionType
 from typing import Any, Callable, Iterator
 
 import mypy.stubtest
@@ -61,6 +62,12 @@ _K = TypeVar("_K")
 _V = TypeVar("_V")
 _S = TypeVar("_S", contravariant=True)
 _R = TypeVar("_R", covariant=True)
+
+class _Callable:
+    def __call__(self): ...
+class _NamedCallable(_Callable):
+    __name__: str
+    __qualname__: str
 
 class Coroutine(Generic[_T_co, _S, _R]): ...
 class Iterable(Generic[_T_co]): ...
@@ -183,7 +190,7 @@ class Case:
         self.error = error
 
 
-def collect_cases(fn: Callable[..., Iterator[Case]]) -> Callable[..., None]:
+def collect_cases(fn: Callable[..., Iterator[Case]]) -> FunctionType[..., None]:
     """run_stubtest used to be slow, so we used this decorator to combine cases.
 
     If you're reading this and bored, feel free to refactor this and make it more like

--- a/mypy/test/testsubtypes.py
+++ b/mypy/test/testsubtypes.py
@@ -274,6 +274,22 @@ class SubtypingSuite(Suite):
             Instance(self.fx.gvi, [UnpackType(Instance(self.fx.std_tuplei, [self.fx.a]))]),
         )
 
+    def test_callables(self):
+        c = self.fx.callable(self.fx.nonet)
+        n = self.fx.named_callable()
+        f = self.fx.function_()
+
+        self.assert_subtype(c, c)
+        self.assert_subtype(n, n)
+        self.assert_subtype(n, c)
+        self.assert_subtype(f, n)
+        self.assert_subtype(f, c)
+        self.assert_subtype(f, f)
+
+        self.assert_not_subtype(c, n)
+        self.assert_not_subtype(c, f)
+        self.assert_not_subtype(n, f)
+
     # IDEA: Maybe add these test cases (they are tested pretty well in type
     #       checker tests already):
     #  * more interface subtyping test cases

--- a/mypy/test/typefixture.py
+++ b/mypy/test/typefixture.py
@@ -96,7 +96,9 @@ class TypeFixture:
         self.type_typei = self.make_type_info("builtins.type")  # class type
         self.bool_type_info = self.make_type_info("builtins.bool")
         self.str_type_info = self.make_type_info("builtins.str")
-        self.functioni = self.make_type_info("builtins.function")  # function TODO
+        self.functioni = self.make_type_info("typing._Callable")  # function TODO
+        self.defi = self.make_type_info("types.FunctionType")
+        self.named_callablei = self.make_type_info("typing._NamedCallable")
         self.ai = self.make_type_info("A", mro=[self.oi])  # class A
         self.bi = self.make_type_info("B", mro=[self.ai, self.oi])  # class B(A)
         self.ci = self.make_type_info("C", mro=[self.ai, self.oi])  # class C(A)
@@ -143,6 +145,8 @@ class TypeFixture:
         self.std_tuple = Instance(self.std_tuplei, [self.anyt])  # tuple
         self.type_type = Instance(self.type_typei, [])  # type
         self.function = Instance(self.functioni, [])  # function TODO
+        self.def_ = Instance(self.defi, [])  # function TODO
+        self._named_callable = Instance(self.named_callablei, [])  # function TODO
         self.str_type = Instance(self.str_type_info, [])
         self.bool_type = Instance(self.bool_type_info, [])
         self.a = Instance(self.ai, [])  # A
@@ -258,6 +262,18 @@ class TypeFixture:
         return CallableType(
             list(a[:-1]), [ARG_POS] * (len(a) - 1), [None] * (len(a) - 1), a[-1], self.function
         )
+
+    def named_callable(self) -> CallableType:
+        """callable(a1, ..., an, r) constructs a callable with argument types
+        a1, ... an and return type r.
+        """
+        return CallableType([], [], [], self.nonet, self._named_callable)
+
+    def function_(self) -> CallableType:
+        """callable(a1, ..., an, r) constructs a callable with argument types
+        a1, ... an and return type r.
+        """
+        return CallableType([], [], [], self.nonet, self.def_)
 
     def callable_type(self, *a: Type) -> CallableType:
         """callable_type(a1, ..., an, r) constructs a callable with

--- a/mypy/typeshed/stdlib/asyncio/format_helpers.pyi
+++ b/mypy/typeshed/stdlib/asyncio/format_helpers.pyi
@@ -6,9 +6,9 @@ from typing import Any, overload
 from typing_extensions import TypeAlias
 
 class _HasWrapper:
-    __wrapper__: _HasWrapper | FunctionType
+    __wrapper__: _HasWrapper | FunctionType[..., Any]
 
-_FuncType: TypeAlias = FunctionType | _HasWrapper | functools.partial[Any] | functools.partialmethod[Any]
+_FuncType: TypeAlias = FunctionType[..., Any] | _HasWrapper | functools.partial[Any] | functools.partialmethod[Any]
 
 @overload
 def _get_function_source(func: _FuncType) -> tuple[str, int]: ...

--- a/mypy/typeshed/stdlib/builtins.pyi
+++ b/mypy/typeshed/stdlib/builtins.pyi
@@ -31,10 +31,11 @@ from _typeshed import (
 )
 from collections.abc import Awaitable, Callable, Iterable, Iterator, MutableSet, Reversible, Set as AbstractSet, Sized
 from io import BufferedRandom, BufferedReader, BufferedWriter, FileIO, TextIOWrapper
-from types import CodeType, TracebackType, _Cell
+from types import CodeType, TracebackType, _Cell, BuiltinFunctionType
 
 # mypy crashes if any of {ByteString, Sequence, MutableSequence, Mapping, MutableMapping} are imported from collections.abc in builtins.pyi
 from typing import (  # noqa: Y022
+    _NamedCallable,
     IO,
     Any,
     BinaryIO,
@@ -134,9 +135,9 @@ class staticmethod(Generic[_P, _R_co]):
     def __isabstractmethod__(self) -> bool: ...
     def __init__(self, __f: Callable[_P, _R_co]) -> None: ...
     @overload
-    def __get__(self, __instance: None, __owner: type) -> Callable[_P, _R_co]: ...
+    def __get__(self, __instance: None, __owner: type) -> _NamedCallable[_P, _R_co]: ...
     @overload
-    def __get__(self, __instance: _T, __owner: type[_T] | None = None) -> Callable[_P, _R_co]: ...
+    def __get__(self, __instance: _T, __owner: type[_T] | None = None) -> _NamedCallable[_P, _R_co]: ...
     if sys.version_info >= (3, 10):
         __name__: str
         __qualname__: str
@@ -1173,13 +1174,23 @@ class _NotImplementedType(Any):
 
 NotImplemented: _NotImplementedType
 
+@type_check_only
+def _as_builtin(fn: Callable[_P, _T]) -> BuiltinFunctionType[_P, _T]: ...
+
+@_as_builtin
 def abs(__x: SupportsAbs[_T]) -> _T: ...
+@_as_builtin
 def all(__iterable: Iterable[object]) -> bool: ...
+@_as_builtin
 def any(__iterable: Iterable[object]) -> bool: ...
+@_as_builtin
 def ascii(__obj: object) -> str: ...
+@_as_builtin
 def bin(__number: int | SupportsIndex) -> str: ...
+@_as_builtin
 def breakpoint(*args: Any, **kws: Any) -> None: ...
-def callable(__obj: object) -> TypeGuard[Callable[..., object]]: ...
+callable: BuiltinFunctionType[[object], TypeGuard[Callable[..., object]]]
+@_as_builtin
 def chr(__i: int) -> str: ...
 
 # We define this here instead of using os.PathLike to avoid import cycle issues.
@@ -1188,16 +1199,19 @@ class _PathLike(Protocol[AnyStr_co]):
     def __fspath__(self) -> AnyStr_co: ...
 
 if sys.version_info >= (3, 10):
+    @_as_builtin
     def aiter(__async_iterable: SupportsAiter[_SupportsAnextT]) -> _SupportsAnextT: ...
 
     class _SupportsSynchronousAnext(Protocol[_AwaitableT_co]):
         def __anext__(self) -> _AwaitableT_co: ...
 
+    @_as_builtin
     @overload
     # `anext` is not, in fact, an async function. When default is not provided
     # `anext` is just a passthrough for `obj.__anext__`
     # See discussion in #7491 and pure-Python implementation of `anext` at https://github.com/python/cpython/blob/ea786a882b9ed4261eafabad6011bc7ef3b5bf94/Lib/test/test_asyncgen.py#L52-L80
     def anext(__i: _SupportsSynchronousAnext[_AwaitableT]) -> _AwaitableT: ...
+    @_as_builtin
     @overload
     async def anext(__i: SupportsAnext[_T], __default: _VT) -> _T | _VT: ...
 
@@ -1205,6 +1219,7 @@ if sys.version_info >= (3, 10):
 # in which case it returns ast.AST. We have overloads for flag 0 (the default) and for
 # explicitly passing PyCF_ONLY_AST. We fall back to Any for other values of flags.
 if sys.version_info >= (3, 8):
+    @_as_builtin
     @overload
     def compile(
         source: str | ReadableBuffer | _ast.Module | _ast.Expression | _ast.Interactive,
@@ -1216,6 +1231,7 @@ if sys.version_info >= (3, 8):
         *,
         _feature_version: int = -1,
     ) -> CodeType: ...
+    @_as_builtin
     @overload
     def compile(
         source: str | ReadableBuffer | _ast.Module | _ast.Expression | _ast.Interactive,
@@ -1226,6 +1242,7 @@ if sys.version_info >= (3, 8):
         optimize: int = -1,
         _feature_version: int = -1,
     ) -> CodeType: ...
+    @_as_builtin
     @overload
     def compile(
         source: str | ReadableBuffer | _ast.Module | _ast.Expression | _ast.Interactive,
@@ -1237,6 +1254,7 @@ if sys.version_info >= (3, 8):
         *,
         _feature_version: int = -1,
     ) -> _ast.AST: ...
+    @_as_builtin
     @overload
     def compile(
         source: str | ReadableBuffer | _ast.Module | _ast.Expression | _ast.Interactive,
@@ -1250,6 +1268,7 @@ if sys.version_info >= (3, 8):
     ) -> Any: ...
 
 else:
+    @_as_builtin
     @overload
     def compile(
         source: str | ReadableBuffer | _ast.Module | _ast.Expression | _ast.Interactive,
@@ -1259,6 +1278,7 @@ else:
         dont_inherit: bool = False,
         optimize: int = -1,
     ) -> CodeType: ...
+    @_as_builtin
     @overload
     def compile(
         source: str | ReadableBuffer | _ast.Module | _ast.Expression | _ast.Interactive,
@@ -1268,6 +1288,7 @@ else:
         dont_inherit: bool = False,
         optimize: int = -1,
     ) -> CodeType: ...
+    @_as_builtin
     @overload
     def compile(
         source: str | ReadableBuffer | _ast.Module | _ast.Expression | _ast.Interactive,
@@ -1277,6 +1298,7 @@ else:
         dont_inherit: bool = False,
         optimize: int = -1,
     ) -> _ast.AST: ...
+    @_as_builtin
     @overload
     def compile(
         source: str | ReadableBuffer | _ast.Module | _ast.Expression | _ast.Interactive,
@@ -1287,17 +1309,24 @@ else:
         optimize: int = -1,
     ) -> Any: ...
 
+@_as_builtin
 def copyright() -> None: ...
+@_as_builtin
 def credits() -> None: ...
+@_as_builtin
 def delattr(__obj: object, __name: str) -> None: ...
+@_as_builtin
 def dir(__o: object = ...) -> list[str]: ...
+@_as_builtin
 @overload
 def divmod(__x: SupportsDivMod[_T_contra, _T_co], __y: _T_contra) -> _T_co: ...
+@_as_builtin
 @overload
 def divmod(__x: _T_contra, __y: SupportsRDivMod[_T_contra, _T_co]) -> _T_co: ...
 
 # The `globals` argument to `eval` has to be `dict[str, Any]` rather than `dict[str, object]` due to invariance.
 # (The `globals` argument has to be a "real dict", rather than any old mapping, unlike the `locals` argument.)
+@_as_builtin
 def eval(
     __source: str | ReadableBuffer | CodeType,
     __globals: dict[str, Any] | None = None,
@@ -1306,6 +1335,7 @@ def eval(
 
 # Comment above regarding `eval` applies to `exec` as well
 if sys.version_info >= (3, 11):
+    @_as_builtin
     def exec(
         __source: str | ReadableBuffer | CodeType,
         __globals: dict[str, Any] | None = None,
@@ -1315,12 +1345,14 @@ if sys.version_info >= (3, 11):
     ) -> None: ...
 
 else:
+    @_as_builtin
     def exec(
         __source: str | ReadableBuffer | CodeType,
         __globals: dict[str, Any] | None = None,
         __locals: Mapping[str, object] | None = None,
     ) -> None: ...
 
+@_as_builtin
 def exit(code: sys._ExitCode = None) -> NoReturn: ...
 
 class filter(Iterator[_T]):
@@ -1333,40 +1365,58 @@ class filter(Iterator[_T]):
     def __iter__(self) -> Self: ...
     def __next__(self) -> _T: ...
 
+@_as_builtin
 def format(__value: object, __format_spec: str = "") -> str: ...
+@_as_builtin
 @overload
 def getattr(__o: object, __name: str) -> Any: ...
 
 # While technically covered by the last overload, spelling out the types for None, bool
 # and basic containers help mypy out in some tricky situations involving type context
 # (aka bidirectional inference)
+@_as_builtin
 @overload
 def getattr(__o: object, __name: str, __default: None) -> Any | None: ...
+@_as_builtin
 @overload
 def getattr(__o: object, __name: str, __default: bool) -> Any | bool: ...
+@_as_builtin
 @overload
 def getattr(__o: object, __name: str, __default: list[Any]) -> Any | list[Any]: ...
+@_as_builtin
 @overload
 def getattr(__o: object, __name: str, __default: dict[Any, Any]) -> Any | dict[Any, Any]: ...
+@_as_builtin
 @overload
 def getattr(__o: object, __name: str, __default: _T) -> Any | _T: ...
+@_as_builtin
 def globals() -> dict[str, Any]: ...
+@_as_builtin
 def hasattr(__obj: object, __name: str) -> bool: ...
+@_as_builtin
 def hash(__obj: object) -> int: ...
+@_as_builtin
 def help(request: object = ...) -> None: ...
+@_as_builtin
 def hex(__number: int | SupportsIndex) -> str: ...
+@_as_builtin
 def id(__obj: object) -> int: ...
+@_as_builtin
 def input(__prompt: object = "") -> str: ...
 
 class _GetItemIterable(Protocol[_T_co]):
     def __getitem__(self, __i: int) -> _T_co: ...
 
+@_as_builtin
 @overload
 def iter(__object: SupportsIter[_SupportsNextT]) -> _SupportsNextT: ...
+@_as_builtin
 @overload
 def iter(__object: _GetItemIterable[_T]) -> Iterator[_T]: ...
+@_as_builtin
 @overload
 def iter(__object: Callable[[], _T | None], __sentinel: None) -> Iterator[_T]: ...
+@_as_builtin
 @overload
 def iter(__object: Callable[[], _T], __sentinel: object) -> Iterator[_T]: ...
 
@@ -1376,10 +1426,15 @@ if sys.version_info >= (3, 10):
 else:
     _ClassInfo: TypeAlias = type | tuple[_ClassInfo, ...]
 
+@_as_builtin
 def isinstance(__obj: object, __class_or_tuple: _ClassInfo) -> bool: ...
+@_as_builtin
 def issubclass(__cls: type, __class_or_tuple: _ClassInfo) -> bool: ...
+@_as_builtin
 def len(__obj: Sized) -> int: ...
+@_as_builtin
 def license() -> None: ...
+@_as_builtin
 def locals() -> dict[str, Any]: ...
 
 class map(Iterator[_S]):
@@ -1425,42 +1480,58 @@ class map(Iterator[_S]):
     def __iter__(self) -> Self: ...
     def __next__(self) -> _S: ...
 
+@_as_builtin
 @overload
 def max(
     __arg1: SupportsRichComparisonT, __arg2: SupportsRichComparisonT, *_args: SupportsRichComparisonT, key: None = None
 ) -> SupportsRichComparisonT: ...
+@_as_builtin
 @overload
 def max(__arg1: _T, __arg2: _T, *_args: _T, key: Callable[[_T], SupportsRichComparison]) -> _T: ...
+@_as_builtin
 @overload
 def max(__iterable: Iterable[SupportsRichComparisonT], *, key: None = None) -> SupportsRichComparisonT: ...
+@_as_builtin
 @overload
 def max(__iterable: Iterable[_T], *, key: Callable[[_T], SupportsRichComparison]) -> _T: ...
+@_as_builtin
 @overload
 def max(__iterable: Iterable[SupportsRichComparisonT], *, key: None = None, default: _T) -> SupportsRichComparisonT | _T: ...
+@_as_builtin
 @overload
 def max(__iterable: Iterable[_T1], *, key: Callable[[_T1], SupportsRichComparison], default: _T2) -> _T1 | _T2: ...
+@_as_builtin
 @overload
 def min(
     __arg1: SupportsRichComparisonT, __arg2: SupportsRichComparisonT, *_args: SupportsRichComparisonT, key: None = None
 ) -> SupportsRichComparisonT: ...
+@_as_builtin
 @overload
 def min(__arg1: _T, __arg2: _T, *_args: _T, key: Callable[[_T], SupportsRichComparison]) -> _T: ...
+@_as_builtin
 @overload
 def min(__iterable: Iterable[SupportsRichComparisonT], *, key: None = None) -> SupportsRichComparisonT: ...
+@_as_builtin
 @overload
 def min(__iterable: Iterable[_T], *, key: Callable[[_T], SupportsRichComparison]) -> _T: ...
+@_as_builtin
 @overload
 def min(__iterable: Iterable[SupportsRichComparisonT], *, key: None = None, default: _T) -> SupportsRichComparisonT | _T: ...
+@_as_builtin
 @overload
 def min(__iterable: Iterable[_T1], *, key: Callable[[_T1], SupportsRichComparison], default: _T2) -> _T1 | _T2: ...
+@_as_builtin
 @overload
 def next(__i: SupportsNext[_T]) -> _T: ...
+@_as_builtin
 @overload
 def next(__i: SupportsNext[_T], __default: _VT) -> _T | _VT: ...
+@_as_builtin
 def oct(__number: int | SupportsIndex) -> str: ...
 
 _Opener: TypeAlias = Callable[[str, int], int]
 
+# `open` is a `BuiltinFunctionType`, but isn't typed correctly due to a type cycle with `io`
 # Text mode: always returns a TextIOWrapper
 @overload
 def open(
@@ -1547,10 +1618,12 @@ def open(
     closefd: bool = True,
     opener: _Opener | None = None,
 ) -> IO[Any]: ...
+@_as_builtin
 def ord(__c: str | bytes | bytearray) -> int: ...
 
 class _SupportsWriteAndFlush(SupportsWrite[_T_contra], SupportsFlush, Protocol[_T_contra]): ...
 
+@_as_builtin
 @overload
 def print(
     *values: object,
@@ -1559,6 +1632,7 @@ def print(
     file: SupportsWrite[str] | None = None,
     flush: Literal[False] = False,
 ) -> None: ...
+@_as_builtin
 @overload
 def print(
     *values: object, sep: str | None = " ", end: str | None = "\n", file: _SupportsWriteAndFlush[str] | None = None, flush: bool
@@ -1583,74 +1657,105 @@ _SupportsSomeKindOfPow = (  # noqa: Y026  # TODO: Use TypeAlias once mypy bugs a
 if sys.version_info >= (3, 8):
     # TODO: `pow(int, int, Literal[0])` fails at runtime,
     # but adding a `NoReturn` overload isn't a good solution for expressing that (see #8566).
+    @_as_builtin
     @overload
     def pow(base: int, exp: int, mod: int) -> int: ...
+    @_as_builtin
     @overload
     def pow(base: int, exp: Literal[0], mod: None = None) -> Literal[1]: ...
+    @_as_builtin
     @overload
     def pow(base: int, exp: _PositiveInteger, mod: None = None) -> int: ...
+    @_as_builtin
     @overload
     def pow(base: int, exp: _NegativeInteger, mod: None = None) -> float: ...
     # int base & positive-int exp -> int; int base & negative-int exp -> float
     # return type must be Any as `int | float` causes too many false-positive errors
+    @_as_builtin
     @overload
     def pow(base: int, exp: int, mod: None = None) -> Any: ...
+    @_as_builtin
     @overload
     def pow(base: _PositiveInteger, exp: float, mod: None = None) -> float: ...
+    @_as_builtin
     @overload
     def pow(base: _NegativeInteger, exp: float, mod: None = None) -> complex: ...
+    @_as_builtin
     @overload
     def pow(base: float, exp: int, mod: None = None) -> float: ...
     # float base & float exp could return float or complex
     # return type must be Any (same as complex base, complex exp),
     # as `float | complex` causes too many false-positive errors
+    @_as_builtin
     @overload
     def pow(base: float, exp: complex | _SupportsSomeKindOfPow, mod: None = None) -> Any: ...
+    @_as_builtin
     @overload
     def pow(base: complex, exp: complex | _SupportsSomeKindOfPow, mod: None = None) -> complex: ...
+    @_as_builtin
     @overload
     def pow(base: _SupportsPow2[_E, _T_co], exp: _E, mod: None = None) -> _T_co: ...
+    @_as_builtin
     @overload
     def pow(base: _SupportsPow3NoneOnly[_E, _T_co], exp: _E, mod: None = None) -> _T_co: ...
+    @_as_builtin
     @overload
     def pow(base: _SupportsPow3[_E, _M, _T_co], exp: _E, mod: _M) -> _T_co: ...
+    @_as_builtin
     @overload
     def pow(base: _SupportsSomeKindOfPow, exp: float, mod: None = None) -> Any: ...
+    @_as_builtin
     @overload
     def pow(base: _SupportsSomeKindOfPow, exp: complex, mod: None = None) -> complex: ...
 
 else:
+    @_as_builtin
     @overload
     def pow(__x: int, __y: int, __z: int) -> int: ...
+    @_as_builtin
     @overload
     def pow(__x: int, __y: Literal[0], __z: None = None) -> Literal[1]: ...
+    @_as_builtin
     @overload
     def pow(__x: int, __y: _PositiveInteger, __z: None = None) -> int: ...
+    @_as_builtin
     @overload
     def pow(__x: int, __y: _NegativeInteger, __z: None = None) -> float: ...
+    @_as_builtin
     @overload
     def pow(__x: int, __y: int, __z: None = None) -> Any: ...
+    @_as_builtin
     @overload
     def pow(__x: _PositiveInteger, __y: float, __z: None = None) -> float: ...
+    @_as_builtin
     @overload
     def pow(__x: _NegativeInteger, __y: float, __z: None = None) -> complex: ...
+    @_as_builtin
     @overload
     def pow(__x: float, __y: int, __z: None = None) -> float: ...
+    @_as_builtin
     @overload
     def pow(__x: float, __y: complex | _SupportsSomeKindOfPow, __z: None = None) -> Any: ...
+    @_as_builtin
     @overload
     def pow(__x: complex, __y: complex | _SupportsSomeKindOfPow, __z: None = None) -> complex: ...
+    @_as_builtin
     @overload
     def pow(__x: _SupportsPow2[_E, _T_co], __y: _E, __z: None = None) -> _T_co: ...
+    @_as_builtin
     @overload
     def pow(__x: _SupportsPow3NoneOnly[_E, _T_co], __y: _E, __z: None = None) -> _T_co: ...
+    @_as_builtin
     @overload
     def pow(__x: _SupportsPow3[_E, _M, _T_co], __y: _E, __z: _M) -> _T_co: ...
+    @_as_builtin
     @overload
     def pow(__x: _SupportsSomeKindOfPow, __y: float, __z: None = None) -> Any: ...
+    @_as_builtin
     @overload
     def pow(__x: _SupportsSomeKindOfPow, __y: complex, __z: None = None) -> complex: ...
 
+@_as_builtin
 def quit(code: sys._ExitCode = None) -> NoReturn: ...
 
 class reversed(Iterator[_T]):
@@ -1662,6 +1767,7 @@ class reversed(Iterator[_T]):
     def __next__(self) -> _T: ...
     def __length_hint__(self) -> int: ...
 
+@_as_builtin
 def repr(__obj: object) -> str: ...
 
 # See https://github.com/python/typeshed/pull/9141
@@ -1674,18 +1780,23 @@ class _SupportsRound1(Protocol[_T_co]):
 class _SupportsRound2(Protocol[_T_co]):
     def __round__(self, __ndigits: int) -> _T_co: ...
 
+@_as_builtin
 @overload
 def round(number: _SupportsRound1[_T], ndigits: None = None) -> _T: ...
+@_as_builtin
 @overload
 def round(number: _SupportsRound2[_T], ndigits: SupportsIndex) -> _T: ...
 
 # See https://github.com/python/typeshed/pull/6292#discussion_r748875189
 # for why arg 3 of `setattr` should be annotated with `Any` and not `object`
+@_as_builtin
 def setattr(__obj: object, __name: str, __value: Any) -> None: ...
+@_as_builtin
 @overload
 def sorted(
     __iterable: Iterable[SupportsRichComparisonT], *, key: None = None, reverse: bool = False
 ) -> list[SupportsRichComparisonT]: ...
+@_as_builtin
 @overload
 def sorted(__iterable: Iterable[_T], *, key: Callable[[_T], SupportsRichComparison], reverse: bool = False) -> list[_T]: ...
 
@@ -1701,29 +1812,36 @@ _SupportsSumNoDefaultT = TypeVar("_SupportsSumNoDefaultT", bound=_SupportsSumWit
 # without creating many false-positive errors (see #7578).
 # Instead, we special-case the most common examples of this: bool and literal integers.
 if sys.version_info >= (3, 8):
+    @_as_builtin
     @overload
     def sum(__iterable: Iterable[bool], start: int = 0) -> int: ...  # type: ignore[overload-overlap]
 
 else:
+    @_as_builtin
     @overload
     def sum(__iterable: Iterable[bool], __start: int = 0) -> int: ...  # type: ignore[overload-overlap]
 
+@_as_builtin
 @overload
 def sum(__iterable: Iterable[_SupportsSumNoDefaultT]) -> _SupportsSumNoDefaultT | Literal[0]: ...
 
 if sys.version_info >= (3, 8):
+    @_as_builtin
     @overload
     def sum(__iterable: Iterable[_AddableT1], start: _AddableT2) -> _AddableT1 | _AddableT2: ...
 
 else:
+    @_as_builtin
     @overload
     def sum(__iterable: Iterable[_AddableT1], __start: _AddableT2) -> _AddableT1 | _AddableT2: ...
 
 # The argument to `vars()` has to have a `__dict__` attribute, so the second overload can't be annotated with `object`
 # (A "SupportsDunderDict" protocol doesn't work)
 # Use a type: ignore to make complaints about overlapping overloads go away
+@_as_builtin
 @overload
 def vars(__object: type) -> types.MappingProxyType[str, Any]: ...  # type: ignore[overload-overlap]
+@_as_builtin
 @overload
 def vars(__object: Any = ...) -> dict[str, Any]: ...
 
@@ -1811,6 +1929,7 @@ class zip(Iterator[_T_co]):
 
 # Signature of `builtins.__import__` should be kept identical to `importlib.__import__`
 # Return type of `__import__` should be kept the same as return type of `importlib.import_module`
+@_as_builtin
 def __import__(
     name: str,
     globals: Mapping[str, object] | None = None,
@@ -1818,6 +1937,7 @@ def __import__(
     fromlist: Sequence[str] = (),
     level: int = 0,
 ) -> types.ModuleType: ...
+@_as_builtin
 def __build_class__(__func: Callable[[], _Cell | Any], __name: str, *bases: Any, metaclass: Any = ..., **kwds: Any) -> Any: ...
 
 if sys.version_info >= (3, 10):

--- a/mypy/typeshed/stdlib/contextlib.pyi
+++ b/mypy/typeshed/stdlib/contextlib.pyi
@@ -3,7 +3,7 @@ import sys
 from _typeshed import FileDescriptorOrPath, Unused
 from abc import abstractmethod
 from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Generator, Iterator
-from types import TracebackType
+from types import TracebackType, FunctionType
 from typing import IO, Any, Generic, Protocol, TypeVar, overload, runtime_checkable
 from typing_extensions import ParamSpec, Self, TypeAlias
 
@@ -73,7 +73,7 @@ class _GeneratorContextManager(AbstractContextManager[_T_co], ContextDecorator):
             self, type: type[BaseException] | None, value: BaseException | None, traceback: TracebackType | None
         ) -> bool | None: ...
 
-def contextmanager(func: Callable[_P, Iterator[_T_co]]) -> Callable[_P, _GeneratorContextManager[_T_co]]: ...
+def contextmanager(func: Callable[_P, Iterator[_T_co]]) -> FunctionType[_P, _GeneratorContextManager[_T_co]]: ...
 
 if sys.version_info >= (3, 10):
     _AF = TypeVar("_AF", bound=Callable[..., Awaitable[Any]])
@@ -104,7 +104,7 @@ else:
             self, typ: type[BaseException] | None, value: BaseException | None, traceback: TracebackType | None
         ) -> bool | None: ...
 
-def asynccontextmanager(func: Callable[_P, AsyncIterator[_T_co]]) -> Callable[_P, _AsyncGeneratorContextManager[_T_co]]: ...
+def asynccontextmanager(func: Callable[_P, AsyncIterator[_T_co]]) -> FunctionType[_P, _AsyncGeneratorContextManager[_T_co]]: ...
 
 class _SupportsClose(Protocol):
     def close(self) -> object: ...

--- a/mypy/typeshed/stdlib/inspect.pyi
+++ b/mypy/typeshed/stdlib/inspect.pyi
@@ -195,7 +195,7 @@ def getmodulename(path: StrPath) -> str | None: ...
 def ismodule(object: object) -> TypeGuard[ModuleType]: ...
 def isclass(object: object) -> TypeGuard[type[Any]]: ...
 def ismethod(object: object) -> TypeGuard[MethodType]: ...
-def isfunction(object: object) -> TypeGuard[FunctionType]: ...
+def isfunction(object: object) -> TypeGuard[FunctionType[..., Any]]: ...
 
 if sys.version_info >= (3, 12):
     def markcoroutinefunction(func: _F) -> _F: ...
@@ -270,7 +270,7 @@ if sys.version_info >= (3, 11):
 def isroutine(
     object: object,
 ) -> TypeGuard[
-    FunctionType
+    FunctionType[..., Any]
     | LambdaType
     | MethodType
     | BuiltinFunctionType
@@ -289,7 +289,7 @@ def isdatadescriptor(object: object) -> TypeGuard[_SupportsSet[Any, Any] | _Supp
 # Retrieving source code
 #
 _SourceObjectType: TypeAlias = (
-    ModuleType | type[Any] | MethodType | FunctionType | TracebackType | FrameType | CodeType | Callable[..., Any]
+    ModuleType | type[Any] | MethodType | FunctionType[..., Any] | TracebackType | FrameType | CodeType | Callable[..., Any]
 )
 
 def findsource(object: _SourceObjectType) -> tuple[list[str], int]: ...

--- a/mypy/typeshed/stdlib/typing.pyi
+++ b/mypy/typeshed/stdlib/typing.pyi
@@ -193,6 +193,23 @@ Generic: _SpecialForm
 # Protocol is only present in 3.8 and later, but mypy needs it unconditionally
 Protocol: _SpecialForm
 Callable: _SpecialForm
+
+# Internal mypy fallback type for callables (does not exist at runtime)
+@type_check_only
+class _Callable:
+    """Fake representation of _collections_abc.Callable"""
+
+    @abstractmethod
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
+
+# Internal mypy fallback type for named callables (does not exist at runtime)
+@type_check_only
+class _NamedCallable(_Callable, metaclass=ABCMeta):
+    """Fake protocol for the different representations of functions that have names"""
+
+    __name__: str
+    __qualname__: str
+
 Type: _SpecialForm
 NoReturn: _SpecialForm
 ClassVar: _SpecialForm
@@ -804,7 +821,7 @@ ByteString: typing_extensions.TypeAlias = bytes | bytearray | memoryview
 _get_type_hints_obj_allowed_types: typing_extensions.TypeAlias = (  # noqa: Y042
     object
     | Callable[..., Any]
-    | FunctionType
+    | FunctionType[..., Any]
     | BuiltinFunctionType
     | MethodType
     | ModuleType

--- a/mypy/version.py
+++ b/mypy/version.py
@@ -14,7 +14,7 @@ base_version = __version__
 
 # friendly version information
 based_version_info = VersionInfo(
-    2, 3, 0, "dev", 0, __version__.split("+dev")[0], "dev" if "+dev" in __version__ else "final"
+    2, 5, 0, "dev", 0, __version__.split("+dev")[0], "dev" if "+dev" in __version__ else "final"
 )
 # simple string version with git info
 __based_version__ = based_version_info.simple_str()

--- a/mypyc/test-data/fixtures/typing-full.pyi
+++ b/mypyc/test-data/fixtures/typing-full.pyi
@@ -41,6 +41,11 @@ S = TypeVar('S')
 # Note: definitions below are different from typeshed, variances are declared
 # to silence the protocol variance checks. Maybe it is better to use type: ignore?
 
+class _Callable:
+    def __call__(self): pass
+class _NamedCallable(_Callable):
+    __name__: str
+    __qualname__: str
 @runtime_checkable
 class Container(Protocol[T_co]):
     @abstractmethod

--- a/mypyc/test-data/run-attrs.test
+++ b/mypyc/test-data/run-attrs.test
@@ -3,6 +3,7 @@
 [case testRunAttrsclass]
 import attr
 from typing import Set, List, Callable, Any
+from types import FunctionType
 
 @attr.s(auto_attribs=True)
 class Person1:
@@ -44,7 +45,7 @@ class Person3:
     def get_friendIDs(self) -> List[int]:
         return self.friendIDs
 
-def get_next_age(g: Callable[[Any], int]) -> Callable[[Any], int]:
+def get_next_age(g: Callable[[Any], int]) -> "FunctionType[[Any], int]":
     def f(a: Any) -> int:
         return g(a) + 1
     return f
@@ -167,6 +168,7 @@ assert isinstance(Person3().get_age, BuiltinMethodType)
 [case testRunAttrsclassNonAuto]
 import attr
 from typing import Set, List, Callable, Any
+from types import FunctionType
 
 @attr.s
 class Person1:
@@ -208,7 +210,7 @@ class Person3:
     def get_friendIDs(self) -> List[int]:
         return self.friendIDs
 
-def get_next_age(g: Callable[[Any], int]) -> Callable[[Any], int]:
+def get_next_age(g: Callable[[Any], int]) -> "FunctionType[[Any], int]":
     def f(a: Any) -> int:
         return g(a) + 1
     return f

--- a/mypyc/test-data/run-python37.test
+++ b/mypyc/test-data/run-python37.test
@@ -4,6 +4,7 @@
 import dataclasses
 from dataclasses import dataclass, field
 from typing import Set, FrozenSet, List, Callable, Any
+from types import FunctionType
 
 @dataclass
 class Person1:
@@ -50,7 +51,7 @@ class Person3:
     def get_friendIDs(self) -> List[int]:
         return self.friendIDs
 
-def get_next_age(g: Callable[[Any], int]) -> Callable[[Any], int]:
+def get_next_age(g: Callable[[Any], int]) -> "FunctionType[[Any], int]":
     def f(a: Any) -> int:
         return g(a) + 1
     return f

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
     "setuptools >= 40.6.2",
     "wheel >= 0.30.0",
     # the following is from mypy-requirements.txt
-    "basedtyping>=0.0.3",
+    "basedtyping>=0.1.4",
     "typing_extensions>=4.1.0",
     "mypy_extensions>=1.0.0",
     "tomli>=1.1.0; python_version<'3.11'",

--- a/setup.py
+++ b/setup.py
@@ -415,7 +415,7 @@ setup(
     cmdclass=cmdclass,
     # When changing this, also update mypy-requirements.txt.
     install_requires=[
-        "basedtyping>=0.0.3",
+        "basedtyping>=0.1.4",
         "typing_extensions>=4.1.0",
         "mypy_extensions >= 1.0.0",
         "tomli>=1.1.0; python_version<'3.11'",

--- a/test-data/unit/check-based-callable.test
+++ b/test-data/unit/check-based-callable.test
@@ -1,0 +1,273 @@
+[case testCallableSyntax]
+c: "(str) -> int"
+reveal_type(c)  # N: Revealed type is "(str) -> int"
+f: "def (str) -> int"
+reveal_type(f)  # N: Revealed type is "def (str) -> int"
+[builtins fixtures/tuple.pyi]
+
+
+[case testCallableSyntaxBreak]
+# ensure things that look a lot like Callable syntax are handled as not that
+from typing import Literal
+t: "(Literal['->'])"
+reveal_type(t)  # N: Revealed type is "'->'"
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-medium.pyi]
+
+
+[case testCallableIsntFunction]
+c: "(str) -> int"
+c.__name__  # E: "(str) -> int" has no attribute "__name__"  [attr-defined]
+f: "def (str) -> int"
+reveal_type(f.__name__)  # N: Revealed type is "str"
+[builtins fixtures/tuple.pyi]
+[typing fixtures/typing-medium.pyi]
+
+
+[case testFunctionTypeSubtypesCallable]
+c: "(str) -> int"
+f: "def (str) -> int" = c  # E: Incompatible types in assignment (expression has type "(str) -> int", variable has type "def (str) -> int")  [assignment]
+c2: "(str) -> int" = f
+[builtins fixtures/tuple.pyi]
+
+
+[case testFunctiontypeInferred]
+def f(): ...
+reveal_type(f)  # N: Revealed type is "def () -> None"
+[builtins fixtures/tuple.pyi]
+
+
+[case testRuntimeFunctionType]
+from types import FunctionType
+import future
+
+a: FunctionType[[int], str]  # E: Type parameters for "FunctionType" requires __future__.annotations or quoted types  [valid-type]
+FunctionType[[int], str]  # E: The type "type[FunctionType]" is not generic and not indexable  [misc]
+[file future.py]
+from __future__ import annotations
+from types import FunctionType
+a: FunctionType[[int], str]
+FunctionType[[int], str]  # E: The type "type[FunctionType]" is not generic and not indexable  [misc]
+[builtins fixtures/tuple.pyi]
+
+
+[case testFunctionTypeOnInstance]
+from typing import ClassVar
+class A:
+    a: ClassVar["def (A) -> int"]
+a = A()
+A.a(a)
+a.a()
+[builtins fixtures/tuple.pyi]
+
+
+[case testMethodType]
+import types
+class A:
+    def f(self): ...
+reveal_type(A().f)  # N: Revealed type is "_NamedCallable & () -> None"
+b: int = A().f  # E: Incompatible types in assignment (expression has type "_NamedCallable & () -> None", variable has type "int")  [assignment]
+[builtins fixtures/tuple.pyi]
+
+
+[case testTypeType]
+class A: ...
+reveal_type(A)  # N: Revealed type is "() -> __main__.A"
+b: int = A  # E: Incompatible types in assignment (expression has type "type[A]", variable has type "int")  [assignment]
+[builtins fixtures/tuple.pyi]
+
+
+[case testClassAssignments]
+from __future__ import annotations
+from typing import Callable, ClassVar
+from types import FunctionType
+
+some_callable: Callable[['C'], int]
+some_function: FunctionType[['C'], int]
+
+class C:
+    c1: Callable[['C'], int]  # callable attribute
+    c2: FunctionType[['C'], int]  # callable attribute
+    c3: Callable[['C'], int] = some_function  # E: Assigning a "FunctionType" on the class will become a "MethodType"  [callable-functiontype] \
+                                              # N: Consider setting it on the instance, or using "ClassVar"
+    c4: FunctionType[['C'], int] = some_function  # E: Assigning a "FunctionType" on the class will become a "MethodType"  [callable-functiontype] \
+                                                  # N: Consider setting it on the instance, or using "ClassVar"
+
+    m1 = some_function  # method, because of assignment
+    def m2(self) -> int: return 1
+    m3 = some_callable  # method, because of assignment
+
+    a1: ClassVar[Callable[['C'], int]]
+    a2: ClassVar[FunctionType[['C'], int]]
+
+    def __init__(self):
+        self.c5: Callable[[], int]  # callable attribute
+        self.c6 = some_function  # callable attribute
+        self.m1 = some_function  # E: Cannot assign to a method  [method-assign] \
+                                 # E: Incompatible types in assignment (expression has type "def (C) -> int", variable has type "_NamedCallable & () -> int")  [assignment]
+
+C.c1 = lambda x: 1  # error, too sus  # E: Assigning a "FunctionType" on the class will become a "MethodType"  [callable-functiontype] \
+                                      # N: Consider setting it on the instance, or using "ClassVar"
+C.c2 = lambda x: 1  # error, too sus  # E: Assigning a "FunctionType" on the class will become a "MethodType"  [callable-functiontype] \
+                                      # N: Consider setting it on the instance, or using "ClassVar"
+C.c3 = lambda x: 1  # error, too sus  # E: Assigning a "FunctionType" on the class will become a "MethodType"  [callable-functiontype] \
+                                      # N: Consider setting it on the instance, or using "ClassVar"
+C.c4 = lambda x: 1  # error, too sus  # E: Assigning a "FunctionType" on the class will become a "MethodType"  [callable-functiontype] \
+                                      # N: Consider setting it on the instance, or using "ClassVar"
+C.c5 = lambda x: 1  # error, too sus  # E: Cannot infer type of lambda  [misc] \
+                                      # E: Incompatible types in assignment (expression has type "def (x: Untyped) -> int", variable has type "() -> int")  [assignment] \
+                                      # E: Assigning a "FunctionType" on the class will become a "MethodType"  [callable-functiontype] \
+                                      # N: Consider setting it on the instance, or using "ClassVar"
+C.c6 = lambda x: 1  # error, too sus  # E: Assigning a "FunctionType" on the class will become a "MethodType"  [callable-functiontype] \
+                                      # N: Consider setting it on the instance, or using "ClassVar"
+
+C.m1 = lambda x: 1  # E: Assigning a "FunctionType" on the class will become a "MethodType"  [callable-functiontype] \
+                    # N: Consider setting it on the instance, or using "ClassVar"
+C.m2 = lambda x: 1  # error, can't assign to a method  # E: Cannot assign to a method  [method-assign] \
+                                                       # E: Incompatible types in assignment (expression has type "def (x: C) -> int", variable has type "def (self: C) -> int")  [assignment] \
+                                                       # E: Assigning a "FunctionType" on the class will become a "MethodType"  [callable-functiontype] \
+                                                       # N: Consider setting it on the instance, or using "ClassVar"
+
+C.a1 = lambda x: 1  # E: Assigning a "FunctionType" on the class will become a "MethodType"  [callable-functiontype]
+C.a1 = some_callable  # E: This "CallableType" could be a "FunctionType", which when assigned via the class, would produce a "MethodType"  [possible-function] \
+                      # N: Consider changing the type to "FunctionType"
+C.a2 = lambda x: 1
+
+c: C
+reveal_type(c.c1)  # N: Revealed type is "(__main__.C) -> int"
+reveal_type(c.c2)  # N: Revealed type is "def (__main__.C) -> int"
+reveal_type(c.c3)  # N: Revealed type is "(__main__.C) -> int"
+reveal_type(c.c4)  # N: Revealed type is "def (__main__.C) -> int"
+reveal_type(c.c5)  # N: Revealed type is "() -> int"
+reveal_type(c.c6)  # N: Revealed type is "def (__main__.C) -> int"
+
+reveal_type(c.m1)  # N: Revealed type is "_NamedCallable & () -> int"
+reveal_type(c.m2)  # N: Revealed type is "_NamedCallable & () -> int"
+
+reveal_type(c.a1)  # N: Revealed type is "(__main__.C) -> int"
+reveal_type(c.a2)  # N: Revealed type is "_NamedCallable & () -> int"
+[builtins fixtures/tuple.pyi]
+
+
+[case testCallableDecorator]
+from typing import Callable, TypeVar
+from types import FunctionType
+
+T = TypeVar("T")
+def as_functiontype(fn: Callable[[T], None]) -> "FunctionType[[T], None]": ...
+
+def dec(fn: Callable[[T], None]) -> Callable[[T], None]: ...
+
+class A:
+    def m1(self): ...
+    @dec  # E: This decorator returns a "Callable", not a "FunctionType". Decorate this decorator with "basedtyping.as_functiontype", or add a 'type: ignore' it if it's intentional  [callable-functiontype]
+    def m2(self): ...
+    @as_functiontype
+    @dec
+    def m3(self): ...
+    @dec
+    @classmethod
+    def m4(cls): ...
+    @dec
+    @staticmethod
+    def m5(arg: int): ...
+@dec
+def f(a: A): ...
+a: A
+a.m1()
+a.m2(a)
+a.m3()
+a.m4()
+a.m5(1)
+[builtins fixtures/classmethod.pyi]
+
+
+[case testClassVarCallable]
+from typing import ClassVar
+class A:
+    a: ClassVar["(A) -> None"]
+    m: ClassVar["def (A) -> None"]
+
+a: A
+a.a(a)
+a.m()
+
+
+[case testCallableNew]
+# mypy: no-infer-function-types, allow-untyped-defs, allow-incomplete-defs, allow-any-expr, no-default-return
+
+class A:
+    def __new__(cls, a: int): ...
+class B:
+    def __new__(cls, a): ...
+
+reveal_type(A.__new__)  # N: Revealed type is "def (cls: type[__main__.A], a: int) -> Untyped"
+reveal_type(B.__new__)  # N: Revealed type is "def (cls: type[__main__.B], a: Untyped) -> Untyped"
+a: A
+b: B
+reveal_type(a.__new__)  # N: Revealed type is "def (cls: type[__main__.A], a: int) -> Untyped"
+reveal_type(b.__new__)  # N: Revealed type is "def (cls: type[__main__.B], a: Untyped) -> Untyped"
+
+import strict
+
+[file strict.py]
+class A:
+    def __new__(cls, a: int): ...
+
+reveal_type(A.__new__)  # N: Revealed type is "def (cls: type[strict.A], a: int) -> strict.A"
+reveal_type(A(1).__new__)  # N: Revealed type is "def (cls: type[strict.A], a: int) -> strict.A"
+
+
+[case testOverloadNotFunctionType]
+from typing import Callable, overload
+
+class A:
+    def __init__(self, _: object): ...
+    def __call__(self, a: int=1): ...
+
+@overload
+def f(): ...
+
+@overload
+def f(a: int): ...
+
+@A
+def f(): ...
+
+
+[case testNamedCallable]
+# flags: --disallow-redefinition
+class A:
+    def f(self): ...
+
+class C1:
+    __name__: str
+    __qualname__: str
+    def __call__(self): ...
+class C2:
+    def __call__(self): ...
+
+f = A().f
+reveal_type(f)  # N: Revealed type is "_NamedCallable & () -> None"
+f = C1()
+f = C2()  # E: Incompatible types in assignment (expression has type "C2", variable has type "_NamedCallable & () -> None")  [assignment] \
+          # N: "C2.__call__" has type "() -> None"
+
+
+[case testVariousMethods]
+class A:
+    def f(self): ...
+
+    @classmethod
+    def c(cls): ...
+
+    @staticmethod
+    def s(): ...
+
+reveal_type(A.f)  # N: Revealed type is "def (self: __main__.A) -> None"
+reveal_type(A.c)  # N: Revealed type is "_NamedCallable & () -> None"
+reveal_type(A.s)  # N: Revealed type is "_NamedCallable & () -> None"
+reveal_type(A().f)  # N: Revealed type is "_NamedCallable & () -> None"
+reveal_type(A().c)  # N: Revealed type is "_NamedCallable & () -> None"
+reveal_type(A().s)  # N: Revealed type is "_NamedCallable & () -> None"
+[builtins fixtures/callable.pyi]

--- a/test-data/unit/check-based-format.test
+++ b/test-data/unit/check-based-format.test
@@ -103,11 +103,11 @@ f"{n}"  # E: The string for "None" isn't helpful in a user-facing or semantic st
 def f(o: object): ...
 f"{f}"  # E: The type "def (o: object) -> None" doesn't define a __format__, __str__ or __repr__ method  [helpful-string]
 class A: ...
-f"{A}"  # E: The type "def () -> __main__.A" doesn't define a __format__, __str__ or __repr__ method  [helpful-string]
+f"{A}"  # E: The type "() -> __main__.A" doesn't define a __format__, __str__ or __repr__ method  [helpful-string]
 f"{A()}"  # E: The type "__main__.A" doesn't define a __format__, __str__ or __repr__ method  [helpful-string]
 class F:
     def __format__(self, format_spec: str) -> str: ...
-f"{F}"  # E: The type "def () -> __main__.F" doesn't define a __format__, __str__ or __repr__ method  [helpful-string]
+f"{F}"  # E: The type "() -> __main__.F" doesn't define a __format__, __str__ or __repr__ method  [helpful-string]
 f"{F()}"
 class S:
     @override
@@ -115,7 +115,7 @@ class S:
 
 class R:
     def __repr__(self) -> str: ...
-f"{R}"  # E: The type "def () -> __main__.R" doesn't define a __format__, __str__ or __repr__ method  [helpful-string]
+f"{R}"  # E: The type "() -> __main__.R" doesn't define a __format__, __str__ or __repr__ method  [helpful-string]
 f"{R()}"
 f"{1}"
 i: int

--- a/test-data/unit/check-based-infer-function-types.test
+++ b/test-data/unit/check-based-infer-function-types.test
@@ -351,8 +351,8 @@ def foo(a=1):
     1 + ""
 
 foo()  # E: Call to untyped function "foo" in typed context  [no-untyped-call]
-reveal_type(foo)  # E: Expression type contains "Any" (has type "(a: int=...) -> Untyped")  [no-any-expr] \
-                  # E: Expression type contains "Any" (has type "(a: int=...) -> Untyped")  [no-any-expr] \
+reveal_type(foo)  # E: Expression type contains "Any" (has type "def (a: int=...) -> Untyped")  [no-any-expr] \
+                  # E: Expression type contains "Any" (has type "def (a: int=...) -> Untyped")  [no-any-expr] \
                   # N: Revealed type is "def (a: int =) -> Untyped"
 
 def bar(a=1) -> None:
@@ -381,7 +381,7 @@ class B:
     @property
     def f(self): ...  # E: Function is missing a return type annotation  [no-untyped-def] \
                       # N: Use "-> None" if function does not return a value \
-                      # E: Type of decorated function contains type "Any" ("(self: B) -> Untyped")  [no-any-decorated]
+                      # E: Type of decorated function contains type "Any" ("def (self: B) -> Untyped")  [no-any-decorated]
     @f.setter
     def f(self, value):
         1 + ""

--- a/test-data/unit/check-based-intersection.test
+++ b/test-data/unit/check-based-intersection.test
@@ -74,7 +74,7 @@ reveal_type(foo())  # N: Revealed type is "int"
 foo("")  # E: No overload variant of "A & () -> int" matches argument type "str"  [call-overload] \
          # N: Possible overload variants: \
          # N:     def __call__(self, a: int) -> None \
-         # N:     def () -> int
+         # N:     () -> int
 [builtins fixtures/tuple.pyi]
 
 
@@ -87,7 +87,7 @@ foo: A & Callable[[], int]
 reveal_type(foo())  # N: Revealed type is "int"
 foo("")  # E: No overload variant of "A & () -> int" matches argument type "str"  [call-overload] \
          # N: Possible overload variant: \
-         # N:     def () -> int
+         # N:     () -> int
 [builtins fixtures/tuple.pyi]
 
 
@@ -99,7 +99,7 @@ class A:
 a: list[str] & A
 a[0]
 a["i"]
-a[None]  # E: No overload variant of "(int) -> str & (str) -> None" matches argument type "None"  [call-overload] \
+a[None]  # E: No overload variant of "_NamedCallable & (int) -> str & _NamedCallable & (str) -> None" matches argument type "None"  [call-overload] \
          # N: Possible overload variants: \
          # N:     def __getitem__(self, int, /) -> str \
          # N:     def __getitem__(self, str, /) -> None
@@ -255,7 +255,7 @@ S = TypeVar('S')
 def k1(x: int, y: list[T]) -> list[T & int]: pass
 def k2(x: S, y: list[T]) -> list[T & int]: pass
 a = k2
-a = k1 # E: Incompatible types in assignment (expression has type "[T] (x: int, y: list[T]) -> list[T & int]", variable has type "[S, T] (x: S, y: list[T]) -> list[T & int]")  [assignment]
+a = k1 # E: Incompatible types in assignment (expression has type "def [T] (x: int, y: list[T]) -> list[T & int]", variable has type "def [S, T] (x: S, y: list[T]) -> list[T & int]")  [assignment]
 b = k1
 b = k2
 [builtins fixtures/list.pyi]

--- a/test-data/unit/check-based-type-render.test
+++ b/test-data/unit/check-based-type-render.test
@@ -13,9 +13,9 @@ class A(Generic[T2]):
         return t
 
 reveal_type(A.f)  # N: Revealed type is "def [T2 (from A): int, T: str] (self: __main__.A[T2], t: T, t2: T2) -> T | T2"
-reveal_type(A[int]().f)  # N: Revealed type is "def [T: str] (t: T, t2: int) -> T | int"
+reveal_type(A[int]().f)  # N: Revealed type is "_NamedCallable & [T: str] (t: T, t2: int) -> T | int"
 A.f = 1  # E: Cannot assign to a method  [method-assign] \
-         # E: Incompatible types in assignment (expression has type "int", variable has type "[T2 (from A): int, T: str] (self: A[T2], t: T, t2: T2) -> T | T2")  [assignment]
+         # E: Incompatible types in assignment (expression has type "int", variable has type "def [T2 (from A): int, T: str] (self: A[T2], t: T, t2: T2) -> T | T2")  [assignment]
 
 
 [case testGenericFunction]
@@ -24,7 +24,7 @@ T = TypeVar("T", bound=int)
 
 def foo(t: T) -> T: ...
 reveal_type(foo)  # N: Revealed type is "def [T: int] (t: T) -> T"
-foo = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "[T: int] (t: T) -> T")  [assignment]
+foo = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "def [T: int] (t: T) -> T")  [assignment]
 
 
 [case testRenderAny]
@@ -72,13 +72,13 @@ a: NoReturn = 1  # E: Incompatible types in assignment (expression has type "int
 def b() -> NoReturn: ...
 reveal_type(a)  # N: Revealed type is "Never"
 reveal_type(b)  # N: Revealed type is "def () -> Never"
-b = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "() -> Never")  [assignment]
+b = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "def () -> Never")  [assignment]
 
 
 [case testRenderNoneReturn]
 def foo(): ...
 reveal_type(foo)  # N: Revealed type is "def () -> None"
-foo = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "() -> None")  [assignment]
+foo = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "def () -> None")  [assignment]
 
 
 [case testRenderErrorStar]
@@ -90,7 +90,7 @@ def f(fn: Callable[P, None]): ...
 f(1)  # E: Argument 1 to "f" has incompatible type "int"; expected "(*Never, **Never) -> None"  [arg-type]
 def f2(*args: int, **kwargs: str): ...
 a = f2
-a = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "(*args: int, **kwargs: str) -> None")  [assignment]
+a = 1  # E: Incompatible types in assignment (expression has type "int", variable has type "def (*args: int, **kwargs: str) -> None")  [assignment]
 [builtins fixtures/tuple.pyi]
 
 

--- a/test-data/unit/check-based-typeguard.test
+++ b/test-data/unit/check-based-typeguard.test
@@ -33,7 +33,7 @@ def typeguard1(x: object) -> "x is int": ...
 def typeguard2(x: object, y: object) -> "y is int": ...
 
 takes_typeguard(typeguard1)
-takes_typeguard(typeguard2)  # E: Argument 1 to "takes_typeguard" has incompatible type "(x: object, y: object) -> y is int"; expected "(object) -> first argument is int"  [arg-type]
+takes_typeguard(typeguard2)  # E: Argument 1 to "takes_typeguard" has incompatible type "def (x: object, y: object) -> y is int"; expected "(object) -> first argument is int"  [arg-type]
 [builtins fixtures/tuple.pyi]
 
 
@@ -278,7 +278,7 @@ class B(A): ...
 def guard(a: object, /) -> "a is B": ...
 
 f1 = guard
-f1 = A().guard  # E: Incompatible types in assignment (expression has type "(object) -> instance argument is B", variable has type "(object) -> argument 1 is B")  [assignment]
+f1 = A().guard  # E: Incompatible types in assignment (expression has type "_NamedCallable & (object) -> instance argument is B", variable has type "def (object) -> argument 1 is B")  [assignment]
 
 f2 = A().guard
 f2 = guard
@@ -383,8 +383,8 @@ if a.guard(o):  # E: type-guard on positional class function is unsupported  [ty
 class A:
     def guard(self, b: object, /) -> 'b is int': ...
 
-# Actually expect "def (object) -> argument 1 is int"
-reveal_type(A().guard)  # N: Revealed type is "def (object) -> argument 2 is int"
+# Actually expect "_NamedCallable & (object) -> argument 1 is int"
+reveal_type(A().guard)  # N: Revealed type is "_NamedCallable & (object) -> argument 2 is int"
 [builtins fixtures/tuple.pyi]
 
 
@@ -455,7 +455,7 @@ x = f2
 x = f1
 
 y = f1
-y = f2  # E: Incompatible types in assignment (expression has type "(x: object) -> x is int if True else False", variable has type "(x: object) -> x is int")  [assignment]
+y = f2  # E: Incompatible types in assignment (expression has type "def (x: object) -> x is int if True else False", variable has type "def (x: object) -> x is int")  [assignment]
 [builtins fixtures/tuple.pyi]
 
 

--- a/test-data/unit/check-based-union-join.test
+++ b/test-data/unit/check-based-union-join.test
@@ -50,7 +50,7 @@ class B(Base):
 class C(Base):
     pass
 
-reveal_type([A, B, C])  # N: Revealed type is "list[def () -> __main__.A | def () -> __main__.B | def () -> __main__.C]"
+reveal_type([A, B, C])  # N: Revealed type is "list[() -> __main__.A | () -> __main__.B | () -> __main__.C]"
 
 
 [case testTypeInIf]

--- a/test-data/unit/check-classes.test
+++ b/test-data/unit/check-classes.test
@@ -505,10 +505,10 @@ class B(A):  # E: Missing positional argument "x" in call to "__init_subclass__"
     def __init_subclass__(cls) -> None: pass
 
 [case testOverrideWithDecorator]
-from typing import Callable
+from types import FunctionType
 
-def int_to_none(f: Callable[..., int]) -> Callable[..., None]: ...
-def str_to_int(f: Callable[..., str]) -> Callable[..., int]: ...
+def int_to_none(f: "FunctionType[..., int]") -> "FunctionType[..., None]": ...
+def str_to_int(f: "FunctionType[..., str]") -> "FunctionType[..., int]": ...
 
 class A:
     def f(self) -> None: pass
@@ -523,6 +523,7 @@ class B(A):
     @int_to_none
     @str_to_int
     def h(self) -> str: pass
+[builtins fixtures/tuple.pyi]
 [out]
 main:15: error: Signature of "g" incompatible with supertype "A"
 main:15: note:      Superclass:
@@ -531,9 +532,9 @@ main:15: note:      Subclass:
 main:15: note:          def g(*Any, **Any) -> int
 
 [case testOverrideDecorated]
-from typing import Callable
+from types import FunctionType
 
-def str_to_int(f: Callable[..., str]) -> Callable[..., int]: ...
+def str_to_int(f: "FunctionType[..., str]") -> "FunctionType[..., int]": ...
 
 class A:
     @str_to_int
@@ -548,6 +549,7 @@ class B(A):
     def g(self) -> str: pass # Fail
     @str_to_int
     def h(self) -> str: pass
+[builtins fixtures/tuple.pyi]
 [out]
 main:15: error: Signature of "g" incompatible with supertype "A"
 main:15: note:      Superclass:
@@ -6575,6 +6577,7 @@ reveal_type(c.spec3)  # N: Revealed type is "Any"
 
 [case testDecoratedDunderSet]
 from typing import Any, Callable, TypeVar, Type
+from types import FunctionType
 
 F = TypeVar('F', bound=Callable)
 T = TypeVar('T')
@@ -6582,7 +6585,7 @@ T = TypeVar('T')
 def decorator(f: F) -> F:
     return f
 
-def change(f: Callable) -> Callable[[Any, Any, int], None]:
+def change(f: Callable) -> "FunctionType[[Any, Any, int], None]":
     pass
 
 def untyped(f):

--- a/test-data/unit/check-dataclasses.test
+++ b/test-data/unit/check-dataclasses.test
@@ -637,7 +637,7 @@ class Two:
 
 c = Two()
 x = c.S
-reveal_type(x)  # N: Revealed type is "typing._SpecialForm"
+reveal_type(x)  # N: Revealed type is "def () -> typing._Callable"
 [builtins fixtures/dataclasses.pyi]
 [typing fixtures/typing-medium.pyi]
 

--- a/test-data/unit/check-dynamic-typing.test
+++ b/test-data/unit/check-dynamic-typing.test
@@ -152,6 +152,8 @@ class function: pass
 class str: pass
 class dict: pass
 
+
+
 [case testBinaryOperationsWithDynamicAsRightOperand]
 from typing import Any
 d: Any

--- a/test-data/unit/check-functions.test
+++ b/test-data/unit/check-functions.test
@@ -161,9 +161,10 @@ if int():
 
 [case testSubtypingFunctionsArgsKwargs]
 from typing import Any, Callable
+from types import FunctionType
 
 def everything(*args: Any, **kwargs: Any) -> None: pass
-everywhere: Callable[..., None]
+everywhere: "FunctionType[..., None]"
 
 def specific_1(a: int, b: str) -> None: pass
 def specific_2(a: int, *, b: str) -> None: pass
@@ -579,37 +580,61 @@ A().f('') # E: Argument 1 to "f" of "A" has incompatible type "str"; expected "i
 
 [case testMethodAsDataAttribute]
 from typing import Any, Callable, ClassVar
+from types import FunctionType
 class B: pass
 x: Any
 class A:
     f = x # type: ClassVar[Callable[[A], None]]
     g = x # type: ClassVar[Callable[[A, B], None]]
+    f2: ClassVar["FunctionType[[A], None]"] = x
+    g2: ClassVar["FunctionType[[A, B], None]"] = x
 a: A
-a.f()
-a.g(B())
-a.f(a) # E: Too many arguments
+a.f(a)
+a.g(a, B())
+a.f(a)
 a.g()  # E: Too few arguments
+
+a.f2()
+a.g2(B())
+a.f2(a) # E: Too many arguments
+a.g2()  # E: Too few arguments
+[builtins fixtures/tuple.pyi]
 
 [case testMethodWithInvalidMethodAsDataAttribute]
 from typing import Any, Callable, ClassVar
+from types import FunctionType
 class B: pass
 x: Any
 class A:
     f = x # type: ClassVar[Callable[[], None]]
     g = x # type: ClassVar[Callable[[B], None]]
+
+    f2: ClassVar['FunctionType[[], None]'] = x
+    g2: ClassVar['FunctionType[[B], None]'] = x
 a: A
-a.f() # E: Attribute function "f" with type "Callable[[], None]" does not accept self argument
-a.g() # E: Invalid self argument "A" to attribute function "g" with type "Callable[[B], None]"
+a.f() # E:
+a.g() # E: Too few arguments
+
+a.f2() # E: Attribute function "f2" with type "Callable[[], None]" does not accept self argument
+a.g2() # E: Invalid self argument "A" to attribute function "g2" with type "Callable[[B], None]"
+[builtins fixtures/tuple.pyi]
+
 
 [case testMethodWithDynamicallyTypedMethodAsDataAttribute]
 from typing import Any, Callable, ClassVar
+from types import FunctionType
 class B: pass
 x: Any
 class A:
     f = x # type: ClassVar[Callable[[Any], Any]]
+    f2 = x # type: ClassVar["FunctionType[[Any], Any]"]
 a: A
-a.f()
-a.f(a) # E: Too many arguments
+a.f() # E: Too few arguments
+a.f(a)
+
+a.f2()
+a.f2(a) # E: Too many arguments
+[builtins fixtures/tuple.pyi]
 
 [case testMethodWithInferredMethodAsDataAttribute]
 from typing import Any
@@ -665,34 +690,39 @@ a.g(a)   # E: Argument 1 has incompatible type "A[B]"; expected "B"
 
 [case testInvalidMethodAsDataAttributeInGenericClass]
 from typing import Any, TypeVar, Generic, Callable, ClassVar
+from types import FunctionType
 t = TypeVar('t')
 class B: pass
 class C: pass
 x: Any
 class A(Generic[t]):
-    f = x # type: ClassVar[Callable[[A[B]], None]]
+    f = x # type: ClassVar["FunctionType[[A[B]], None]"]
 ab: A[B]
 ac: A[C]
 ab.f()
 ac.f()   # E: Invalid self argument "A[C]" to attribute function "f" with type "Callable[[A[B]], None]"
+[builtins fixtures/tuple.pyi]
 
 [case testPartiallyTypedSelfInMethodDataAttribute]
 from typing import Any, TypeVar, Generic, Callable, ClassVar
+from types import FunctionType
 t = TypeVar('t')
 class B: pass
 class C: pass
 x: Any
 class A(Generic[t]):
-    f = x # type: ClassVar[Callable[[A], None]]
+    f = x # type: ClassVar["FunctionType[[A], None]"]
 ab: A[B]
 ac: A[C]
 ab.f()
 ac.f()
+[builtins fixtures/tuple.pyi]
 
 [case testCallableDataAttribute]
 from typing import Callable, ClassVar
+from types import FunctionType
 class A:
-    g: ClassVar[Callable[[A], None]]
+    g: ClassVar["FunctionType[[A], None]"]
     def __init__(self, f: Callable[[], None]) -> None:
         self.f = f
 a = A(lambda: None)
@@ -700,7 +730,7 @@ a.f()
 a.g()
 a.f(a) # E: Too many arguments
 a.g(a) # E: Too many arguments
-
+[builtins fixtures/tuple.pyi]
 
 -- Nested functions
 -- ----------------
@@ -897,14 +927,16 @@ f()
 f(None) # E: Too many arguments for "f"
 
 [case testDecoratorThatSwitchesTypeWithMethod]
-from typing import Any, Callable
-def dec(x) -> Callable[[Any], None]: pass
+from typing import Any
+from types import FunctionType
+def dec(x) -> "FunctionType[[Any], None]": pass
 class A:
     @dec
     def f(self, a, b, c): pass
 a: A
 a.f()
 a.f(None) # E: Too many arguments for "f" of "A"
+[builtins fixtures/tuple.pyi]
 
 [case testNestedDecorators]
 from typing import Any, Callable
@@ -2246,6 +2278,7 @@ with a:
 
 [case testNameForDecoratorMethod]
 from typing import Callable
+from types import FunctionType
 
 class A:
     def f(self) -> None:
@@ -2255,8 +2288,8 @@ class A:
     @dec
     def g(self, x: str) -> None: pass
 
-def dec(f: Callable[[A, str], None]) -> Callable[[A, int], None]: pass
-[out]
+def dec(f: Callable[[A, str], None]) -> "FunctionType[[A, int], None]": pass
+[builtins fixtures/tuple.pyi]
 
 [case testUnknownFunctionNotCallable]
 def f() -> None:

--- a/test-data/unit/check-functools.test
+++ b/test-data/unit/check-functools.test
@@ -25,11 +25,12 @@ Ord() >= 1  # E: Unsupported operand types for >= ("Ord" and "int")
 [case testTotalOrderingLambda]
 from functools import total_ordering
 from typing import Any, Callable, ClassVar
+from types import FunctionType
 
 @total_ordering
 class Ord:
-    __eq__: Callable[[Any, object], bool] = lambda self, other: False
-    __lt__: Callable[[Any, "Ord"], bool] = lambda self, other: False
+    __eq__: ClassVar["FunctionType[[Any, object], bool]"] = lambda self, other: False
+    __lt__: ClassVar['FunctionType[[Any, "Ord"], bool]'] = lambda self, other: False
 
 reveal_type(Ord() < Ord())  # N: Revealed type is "builtins.bool"
 reveal_type(Ord() <= Ord())  # N: Revealed type is "builtins.bool"

--- a/test-data/unit/check-generics.test
+++ b/test-data/unit/check-generics.test
@@ -1060,7 +1060,7 @@ CA = Callable[[T], int]
 TA = Tuple[T, int]
 UA = Union[T, int]
 
-cs = CA + 1 # E: Unsupported left operand type for + ("<typing special form>")
+cs = CA + 1 # E: Unsupported left operand type for + ("Type[_Callable]")
 reveal_type(cs) # N: Revealed type is "Any"
 
 ts = TA() # E: "<typing special form>" not callable
@@ -2878,12 +2878,13 @@ reveal_type(comb(id, id))  # N: Revealed type is "def [T] (T`1) -> T`1"
 [case testInferenceAgainstGenericCallableGenericNonLinear]
 # flags: --new-type-inference
 from typing import TypeVar, Callable, List
+from types import FunctionType
 
 S = TypeVar('S')
 T = TypeVar('T')
 U = TypeVar('U')
 
-def mix(fs: List[Callable[[S], T]]) -> Callable[[S], List[T]]:
+def mix(fs: List["FunctionType[[S], T]"]) -> "FunctionType[[S], List[T]]":
     def inner(x: S) -> List[T]:
         return [f(x) for f in fs]
     return inner

--- a/test-data/unit/check-incremental.test
+++ b/test-data/unit/check-incremental.test
@@ -6120,12 +6120,12 @@ import c
 def foo(arg: c.C) -> None: pass
 
 [file c.py]
-from types import C
+from types1 import C
 
-[file types.py]
+[file types1.py]
 import pb1
 C = pb1.C
-[file types.py.2]
+[file types1.py.2]
 import pb1, pb2
 C = pb2.C
 

--- a/test-data/unit/check-inference.test
+++ b/test-data/unit/check-inference.test
@@ -2152,6 +2152,7 @@ x = 1+int()
 
 [case testMultipassAndDecoratedMethod]
 from typing import Callable, TypeVar
+from types import FunctionType
 
 T = TypeVar('T')
 
@@ -2162,8 +2163,9 @@ class A:
     @dec
     def g(self, x: str) -> None: pass
 
-def dec(f: Callable[[A, str], T]) -> Callable[[A, int], T]: pass
+def dec(f: Callable[[A, str], T]) -> "FunctionType[[A, int], T]": pass
 [out]
+[builtins fixtures/tuple.pyi]
 
 [case testMultipassAndDefineAttributeBasedOnNotReadyAttribute]
 class A:

--- a/test-data/unit/check-literal.test
+++ b/test-data/unit/check-literal.test
@@ -1772,7 +1772,7 @@ arr4 = [a, d]
 arr5 = [a, e]
 
 reveal_type(arr1)  # N: Revealed type is "builtins.list[def (Literal[1]) -> builtins.int]"
-reveal_type(arr2)  # N: Revealed type is "builtins.list[builtins.function]"
+reveal_type(arr2)  # N: Revealed type is "builtins.list[typing._Callable]"
 reveal_type(arr3)  # N: Revealed type is "builtins.list[def (Literal[1]) -> builtins.object]"
 reveal_type(arr4)  # N: Revealed type is "builtins.list[def (Literal[1]) -> builtins.object]"
 reveal_type(arr5)  # N: Revealed type is "builtins.list[def (Literal[1]) -> builtins.object]"
@@ -1811,7 +1811,7 @@ b: Callable[[Literal[2]], str]
 lit: Literal[1]
 
 arr = [a, b]
-reveal_type(arr)  # N: Revealed type is "builtins.list[builtins.function]"
+reveal_type(arr)  # N: Revealed type is "builtins.list[typing._Callable]"
 reveal_type(arr[0](lit))  # E: Cannot call function of unknown type \
                           # N: Revealed type is "Any"
 

--- a/test-data/unit/check-parameter-specification.test
+++ b/test-data/unit/check-parameter-specification.test
@@ -367,7 +367,7 @@ def join(x: T, y: T) -> T: ...
 class C(Generic[P, P2]):
     def m(self, f: Callable[P, None], g: Callable[P2, None]) -> None:
         reveal_type(join(f, f))  # N: Revealed type is "def (*P.args, **P.kwargs)"
-        reveal_type(join(f, g))  # N: Revealed type is "builtins.function"
+        reveal_type(join(f, g))  # N: Revealed type is "typing._Callable"
 
     def m2(self, *args: P.args, **kwargs: P.kwargs) -> None:
         reveal_type(join(args, args))  # N: Revealed type is "P.args`1"

--- a/test-data/unit/check-selftype.test
+++ b/test-data/unit/check-selftype.test
@@ -577,6 +577,7 @@ reveal_type(x.f)  # N: Revealed type is "builtins.int"
 
 [case testSelfTypeProperSupertypeAttribute]
 from typing import Callable, TypeVar, ClassVar
+from types import FunctionType
 class K: pass
 T = TypeVar('T', bound=K)
 class A(K):
@@ -584,8 +585,8 @@ class A(K):
     def g(self: K) -> int: return 0
     @property
     def gt(self: T) -> T: return self
-    f: ClassVar[Callable[[object], int]]
-    ft: ClassVar[Callable[[T], T]]
+    f: ClassVar["FunctionType[[object], int]"]
+    ft: ClassVar["FunctionType[[T], T]"]
 
 class B(A):
     pass
@@ -603,14 +604,15 @@ reveal_type(B().ft())  # N: Revealed type is "__main__.B"
 
 [case testSelfTypeProperSupertypeAttributeTuple]
 from typing import Callable, TypeVar, Tuple, ClassVar
+from types import FunctionType
 T = TypeVar('T')
 class A(Tuple[int, int]):
     @property
     def g(self: object) -> int: return 0
     @property
     def gt(self: T) -> T: return self
-    f: ClassVar[Callable[[object], int]]
-    ft: ClassVar[Callable[[T], T]]
+    f: ClassVar["FunctionType[[object], int]"]
+    ft: ClassVar["FunctionType[[T], T]"]
 
 class B(A):
     pass
@@ -628,14 +630,15 @@ reveal_type(B().ft())  # N: Revealed type is "Tuple[builtins.int, builtins.int, 
 
 [case testSelfTypeProperSupertypeAttributeMeta]
 from typing import Callable, TypeVar, Type, ClassVar
+from types import FunctionType
 T = TypeVar('T')
 class A(type):
     @property
     def g(cls: object) -> int: return 0
     @property
     def gt(cls: T) -> T: return cls
-    f: ClassVar[Callable[[object], int]]
-    ft: ClassVar[Callable[[T], T]]
+    f: ClassVar["FunctionType[[object], int]"]
+    ft: ClassVar["FunctionType[[T], T]"]
 
 class B(A):
     pass
@@ -661,6 +664,7 @@ reveal_type(X1.ft())  # N: Revealed type is "Type[__main__.X]"
 
 [case testSelfTypeProperSupertypeAttributeGeneric]
 from typing import Callable, TypeVar, Generic, ClassVar
+from types import FunctionType
 Q = TypeVar('Q', covariant=True)
 class K(Generic[Q]):
     q: Q
@@ -670,8 +674,8 @@ class A(K[Q]):
     def g(self: K[object]) -> int: return 0
     @property
     def gt(self: K[T]) -> T: return self.q
-    f: ClassVar[Callable[[object], int]]
-    ft: ClassVar[Callable[[T], T]]
+    f: ClassVar["FunctionType[[object], int]"]
+    ft: ClassVar["FunctionType[[T], T]"]
 
 class B(A[Q]):
     pass
@@ -1887,25 +1891,32 @@ class C:
 
 [case testTypingSelfCallableClassVar]
 from typing import Self, ClassVar, Callable, TypeVar
+from types import FunctionType
 
 class C:
-    f: ClassVar[Callable[[Self], Self]]
+    f1: ClassVar[Callable[[Self], Self]]
+    f2: ClassVar["FunctionType[[Self], Self]"]
 class D(C): ...
 
-reveal_type(D.f)  # N: Revealed type is "def (__main__.D) -> __main__.D"
-reveal_type(D().f)  # N: Revealed type is "def () -> __main__.D"
+reveal_type(D.f1)  # N: Revealed type is "def (__main__.D) -> __main__.D"
+reveal_type(D().f1)  # N: Revealed type is "def (__main__.D) -> __main__.D"
+
+reveal_type(D.f2)  # N: Revealed type is "def (__main__.D) -> __main__.D"
+reveal_type(D().f2)  # N: Revealed type is "def () -> __main__.D"
+[builtins fixtures/tuple.pyi]
 
 [case testSelfTypeCallableClassVarOldStyle]
 from typing import ClassVar, Callable, TypeVar
-
+from types import FunctionType
 T = TypeVar("T")
 class C:
-    f: ClassVar[Callable[[T], T]]
+    f: ClassVar["FunctionType[[T], T]"]
 
 class D(C): ...
 
 reveal_type(D.f)  # N: Revealed type is "def [T] (T`1) -> T`1"
 reveal_type(D().f)  # N: Revealed type is "def () -> __main__.D"
+[builtins fixtures/tuple.pyi]
 
 [case testTypingSelfOnSuperTypeVarValues]
 from typing import Self, Generic, TypeVar
@@ -1978,13 +1989,14 @@ class B(A):
 [case testSelfTypesWithParamSpecExtract]
 from typing import Any, Callable, Generic, TypeVar
 from typing_extensions import ParamSpec
+from types import FunctionType
 
 P = ParamSpec("P")
 F = TypeVar("F", bound=Callable[..., Any])
 class Example(Generic[F]):
     def __init__(self, fn: F) -> None:
         ...
-    def __call__(self: Example[Callable[P, Any]], *args: P.args, **kwargs: P.kwargs) -> None:
+    def __call__(self: Example["FunctionType[P, Any]"], *args: P.args, **kwargs: P.kwargs) -> None:
         ...
 
 def test_fn(a: int, b: str) -> None:

--- a/test-data/unit/fixtures/typing-async.pyi
+++ b/test-data/unit/fixtures/typing-async.pyi
@@ -36,6 +36,11 @@ S = TypeVar('S')
 # Note: definitions below are different from typeshed, variances are declared
 # to silence the protocol variance checks. Maybe it is better to use type: ignore?
 
+class _Callable:
+    def __call__(self): pass
+class _NamedCallable(_Callable):
+    __name__: str
+    __qualname__: str
 class Container(Protocol[T_co]):
     @abstractmethod
     # Use int because bool isn't in the default test builtins

--- a/test-data/unit/fixtures/typing-full.pyi
+++ b/test-data/unit/fixtures/typing-full.pyi
@@ -39,6 +39,11 @@ U = TypeVar('U')
 V = TypeVar('V')
 S = TypeVar('S')
 
+class _Callable:
+    def __call__(self): pass
+class _NamedCallable(_Callable):
+    __name__: str
+    __qualname__: str
 class NamedTuple(tuple[Any, ...]): ...
 
 # Note: definitions below are different from typeshed, variances are declared

--- a/test-data/unit/fixtures/typing-medium.pyi
+++ b/test-data/unit/fixtures/typing-medium.pyi
@@ -40,6 +40,11 @@ S = TypeVar('S')
 # Note: definitions below are different from typeshed, variances are declared
 # to silence the protocol variance checks. Maybe it is better to use type: ignore?
 
+class _Callable:
+    def __call__(self): pass
+class _NamedCallable(_Callable):
+    __name__: str
+    __qualname__: str
 class Sized(Protocol):
     def __len__(self) -> int: pass
 
@@ -69,6 +74,7 @@ class ContextManager(Generic[T]):
     def __enter__(self) -> T: pass
     # Use Any because not all the precise types are in the fixtures.
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Any: pass
+
 
 class _SpecialForm: pass
 

--- a/test-data/unit/fixtures/typing-namedtuple.pyi
+++ b/test-data/unit/fixtures/typing-namedtuple.pyi
@@ -13,6 +13,11 @@ T = TypeVar('T')
 T_co = TypeVar('T_co', covariant=True)
 KT = TypeVar('KT')
 
+class _Callable:
+    def __call__(self): pass
+class _NamedCallable(_Callable):
+    __name__: str
+    __qualname__: str
 class Iterable(Generic[T_co]): pass
 class Iterator(Iterable[T_co]): pass
 class Sequence(Iterable[T_co]): pass

--- a/test-data/unit/fixtures/typing-override.pyi
+++ b/test-data/unit/fixtures/typing-override.pyi
@@ -14,6 +14,11 @@ T = TypeVar('T')
 T_co = TypeVar('T_co', covariant=True)
 KT = TypeVar('KT')
 
+class _Callable:
+    def __call__(self): pass
+class _NamedCallable(_Callable):
+    __name__: str
+    __qualname__: str
 class Iterable(Generic[T_co]): pass
 class Iterator(Iterable[T_co]): pass
 class Sequence(Iterable[T_co]): pass

--- a/test-data/unit/fixtures/typing-typeddict-iror.pyi
+++ b/test-data/unit/fixtures/typing-typeddict-iror.pyi
@@ -36,6 +36,11 @@ V = TypeVar('V')
 # Note: definitions below are different from typeshed, variances are declared
 # to silence the protocol variance checks. Maybe it is better to use type: ignore?
 
+class _Callable:
+    def __call__(self): pass
+class _NamedCallable(_Callable):
+    __name__: str
+    __qualname__: str
 class Sized(Protocol):
     def __len__(self) -> int: pass
 

--- a/test-data/unit/fixtures/typing-typeddict.pyi
+++ b/test-data/unit/fixtures/typing-typeddict.pyi
@@ -35,6 +35,11 @@ V = TypeVar('V')
 # Note: definitions below are different from typeshed, variances are declared
 # to silence the protocol variance checks. Maybe it is better to use type: ignore?
 
+class _Callable:
+    def __call__(self): pass
+class _NamedCallable(_Callable):
+    __name__: str
+    __qualname__: str
 class Sized(Protocol):
     def __len__(self) -> int: pass
 

--- a/test-data/unit/lib-stub/types.pyi
+++ b/test-data/unit/lib-stub/types.pyi
@@ -15,3 +15,9 @@ if sys.version_info >= (3, 10):
 
     class NoneType:
         ...
+
+class FunctionType:
+    def __call__(self): ...
+
+class MethodType:
+    pass

--- a/test-data/unit/lib-stub/typing.pyi
+++ b/test-data/unit/lib-stub/typing.pyi
@@ -37,6 +37,12 @@ T_co = TypeVar('T_co', covariant=True)
 U = TypeVar('U')
 V = TypeVar('V')
 
+
+class _Callable:
+    def __call__(self): pass
+class _NamedCallable(_Callable):
+    __name__: str
+    __qualname__: str
 class Iterable(Protocol[T_co]):
     def __iter__(self) -> Iterator[T_co]: pass
 

--- a/test-data/unit/typexport-basic.test
+++ b/test-data/unit/typexport-basic.test
@@ -157,6 +157,8 @@ import typing
 8 > 3
 4 < 6 > 2
 [file builtins.py]
+import typing
+
 class object:
     def __init__(self) -> None: pass
 class int:


### PR DESCRIPTION
- resolves #614
- resolves #80
- resolves #620
- resolves #624

```py
from __future__ import annotations
from typing import *
from types import FunctionType

some_callable: Callable[['C'], int]

class C:
    c1: Callable[['C'], int]  # callable attribute
    c2: FunctionType[['C'], int]  # callable attribute
    c3: Callable[['C'], int] = lambda x: 1  # error, too sus
    c4: FunctionType[['C'], int] = lambda x: 1  # error, too sus
    
    m1 = lambda x: 1  # method, because of assignment
    def m2(self) -> int: return 1
    m3 = some_callable  # method, because of assignment
    
    a1: ClassVar[Callable[['C'], int]]
    a2: ClassVar[FunctionType[['C'], int]]
    
    def __init__(self) -> None:
        self.c5: Callable[[], int]  # callable attribute
        self.c6 = lambda x: 1  # callable attribute
        self.m1 = lambda x: 1  # error can't assign to a method
   
C.c1 = lambda x: 1  # error, too sus
# same through c6

C.m1 = lambda x: 1
C.m2 = lambda x: 1  # error, can't assign to a method

C.a1 = lambda x: 1  # error, too sus
C.a1 = some_callable  # error, a little sus
C.a2 = lambda x: 1

c: C
reveal_type(c.c1)  # (C) -> int
reveal_type(c.c2)  # (C) -> int
reveal_type(c.c3)  # (C) -> int
reveal_type(c.c4)  # (C) -> int
reveal_type(c.c5)  # (C) -> int
reveal_type(c.c6)  # (C) -> int

reveal_type(c.m1)  # () -> int
reveal_type(c.m2)  # () -> int

reveal_type(c.a1)  # (C) -> int
reveal_type(c.a2)  # () -> int
```

```py
def dec(f: Callable[..., ...]) -> Callable[..., ...]: ...

class A:
    @dec  # error: FunctionType turned into Callable, use "basedtyping.function_type" or ignore if this is correct
    def f(): ...
    @function_type
    @dec
    def f(): ...
```