### PR TITLE
don't crash on windows

### DIFF
--- a/mypy/main.py
+++ b/mypy/main.py
@@ -64,7 +64,7 @@ def main(
     util.check_python_version("mypy")
     t0 = time.time()
     # To log stat() calls: os.stat = stat_proxy
-    sys.setrecursionlimit(2**14)
+    sys.setrecursionlimit(2600 if sys.platform == "win32" else 2**14)
     if args is None:
         args = sys.argv[1:]
 


### PR DESCRIPTION
- resolves #626

Okay, so basically: mypy rices the stack depth so that it can run on some kind of deeply nested code

The issue is that if the stack runs out of memory, it won't raise an exception, python will just crash outright. On windows the stack memory is much smaller that lignux et al, so the solution is to set it to a smaller amount that will crash gracefully(🤣).

Another alternative would be to not rice the stack size if `--traceback` is provided.