### PR TITLE
[`stubtest`] don't call the `__bool__` of default function params

### DIFF
--- a/.mypy/baseline.json
+++ b/.mypy/baseline.json
@@ -1867,7 +1867,7 @@
         "code": "no-any-expr",
         "column": 40,
         "message": "Expression type contains \"Any\" (has type \"(str, CacheMeta | None)\")",
-        "offset": 412,
+        "offset": 410,
         "src": "new_interface_hash, self.meta = write_cache(",
         "target": "mypy.build.State.write_cache"
       },
@@ -2029,7 +2029,7 @@
         "code": "redundant-expr",
         "column": 31,
         "message": "Condition is always true",
-        "offset": 499,
+        "offset": 504,
         "src": "if new_frame is None:",
         "target": "mypy.checker.TypeChecker.check_func_def"
       },
@@ -2927,7 +2927,7 @@
         "code": "explicit-override",
         "column": 4,
         "message": "Method \"visit_list_expr\" is not using @override but is overriding a method in class \"mypy.visitor.ExpressionVisitor\"",
-        "offset": 228,
+        "offset": 230,
         "src": "def visit_list_expr(self, e: ListExpr) -> Type:",
         "target": "mypy.checkexpr.ExpressionChecker.visit_list_expr"
       },
@@ -13543,7 +13543,7 @@
         "code": "explicit-override",
         "column": 4,
         "message": "Method \"__str__\" is not using @override but is overriding a method in class \"builtins.object\"",
-        "offset": 102,
+        "offset": 114,
         "src": "def __str__(self) -> str:",
         "target": "mypy.nodes.Node.__str__"
       },
@@ -17329,7 +17329,7 @@
         "code": "explicit-override",
         "column": 4,
         "message": "Method \"visit_func_def\" is not using @override but is overriding a method in class \"mypy.visitor.NodeVisitor\"",
-        "offset": 358,
+        "offset": 357,
         "src": "def visit_func_def(self, defn: FuncDef) -> None:",
         "target": "mypy.semanal.SemanticAnalyzer.visit_func_def"
       },
@@ -17465,7 +17465,7 @@
         "code": "explicit-override",
         "column": 4,
         "message": "Method \"visit_import\" is not using @override but is overriding a method in class \"mypy.visitor.NodeVisitor\"",
-        "offset": 428,
+        "offset": 430,
         "src": "def visit_import(self, i: Import) -> None:",
         "target": "mypy.semanal.SemanticAnalyzer.visit_import"
       },
@@ -25160,7 +25160,7 @@
         "column": 7,
         "message": "Expression has type \"Any\"",
         "offset": 45,
-        "src": "if runtime_arg.default != inspect.Parameter.empty:",
+        "src": "if runtime_arg.default is not inspect.Parameter.empty:",
         "target": "mypy.stubtest._verify_arg_default_value"
       },
       {
@@ -25328,7 +25328,7 @@
         "column": 28,
         "message": "Expression has type \"Any\"",
         "offset": 1,
-        "src": "return bool(arg.default != inspect.Parameter.empty)",
+        "src": "return bool(arg.default is not inspect.Parameter.empty)",
         "target": "mypy.stubtest.Signature.__str__"
       },
       {
@@ -26656,38 +26656,14 @@
         "column": 30,
         "message": "Expression has type \"Any\"",
         "offset": 18,
-        "src": "has_default = arg.default == inspect.Parameter.empty",
-        "target": "mypy.stubtest.get_mypy_type_of_runtime_value"
-      },
-      {
-        "code": "no-any-expr",
-        "column": 54,
-        "message": "Expression has type \"Any\"",
-        "offset": 2,
-        "src": "arg_kinds.append(nodes.ARG_POS if has_default else nodes.ARG_OPT)",
-        "target": "mypy.stubtest.get_mypy_type_of_runtime_value"
-      },
-      {
-        "code": "no-any-expr",
-        "column": 54,
-        "message": "Expression has type \"Any\"",
-        "offset": 2,
-        "src": "arg_kinds.append(nodes.ARG_POS if has_default else nodes.ARG_OPT)",
-        "target": "mypy.stubtest.get_mypy_type_of_runtime_value"
-      },
-      {
-        "code": "no-any-expr",
-        "column": 56,
-        "message": "Expression has type \"Any\"",
-        "offset": 2,
-        "src": "arg_kinds.append(nodes.ARG_NAMED if has_default else nodes.ARG_NAMED_OPT)",
+        "src": "has_default = arg.default is inspect.Parameter.empty",
         "target": "mypy.stubtest.get_mypy_type_of_runtime_value"
       },
       {
         "code": "redundant-expr",
         "column": 21,
         "message": "Condition is always true",
-        "offset": 3,
+        "offset": 9,
         "src": "elif arg.kind == inspect.Parameter.VAR_KEYWORD:",
         "target": "mypy.stubtest.get_mypy_type_of_runtime_value"
       },
@@ -28653,7 +28629,7 @@
         "code": "no-any-explicit",
         "column": 0,
         "message": "Explicit \"Any\" is not allowed",
-        "offset": 206,
+        "offset": 205,
         "src": "def collect_cases(fn: Callable[..., Iterator[Case]]) -> FunctionType[..., None]:",
         "target": "mypy.test.teststubtest.collect_cases"
       },
@@ -29378,10 +29354,26 @@
         "target": "mypy.test.teststubtest"
       },
       {
+        "code": "no-any-expr",
+        "column": 5,
+        "message": "Expression type contains \"Any\" (has type \"def (fn: (...) -> Iterator[Case]) -> def (...) -> None\")",
+        "offset": 65,
+        "src": "@collect_cases",
+        "target": "mypy.test.teststubtest"
+      },
+      {
+        "code": "no-any-decorated",
+        "column": 4,
+        "message": "Type of decorated function contains type \"Any\" (\"def (...) -> None\")",
+        "offset": 1,
+        "src": "def test_no_param_defaults_bool_eval(self) -> Iterator[Case]:",
+        "target": "mypy.test.teststubtest"
+      },
+      {
         "code": "no-any-explicit",
         "column": 8,
         "message": "Explicit \"Any\" is not allowed",
-        "offset": 225,
+        "offset": 176,
         "src": "def f(a: int, b: int, *, c: int, d: int = 0, **kwargs: Any) -> None:",
         "target": "mypy.test.teststubtest.StubtestMiscUnit.test_signature"
       },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 ### Added
 - `collections.User*` should have `__repr__`
+### Fixes
+- `stubtest`: the `__bool__` method of function parameter defaults will no longer be unnecessarily evaluated
 
 ## [2.8.0]
 ### Added

--- a/mypy/stubtest.py
+++ b/mypy/stubtest.py
@@ -661,7 +661,7 @@ def _verify_arg_default_value(
     stub_arg: nodes.Argument, runtime_arg: inspect.Parameter
 ) -> Iterator[str]:
     """Checks whether argument default values are compatible."""
-    if runtime_arg.default != inspect.Parameter.empty:
+    if runtime_arg.default is not inspect.Parameter.empty:
         if stub_arg.kind.is_required():
             yield (
                 f'runtime argument "{runtime_arg.name}" '
@@ -749,7 +749,7 @@ class Signature(Generic[T]):
 
         def has_default(arg: Any) -> bool:
             if isinstance(arg, inspect.Parameter):
-                return bool(arg.default != inspect.Parameter.empty)
+                return bool(arg.default is not inspect.Parameter.empty)
             if isinstance(arg, nodes.Argument):
                 return arg.kind.is_optional()
             raise AssertionError
@@ -1618,7 +1618,7 @@ def get_mypy_type_of_runtime_value(runtime: Any) -> mypy.types.Type | None:
                 arg_names.append(
                     None if arg.kind == inspect.Parameter.POSITIONAL_ONLY else arg.name
                 )
-                has_default = arg.default == inspect.Parameter.empty
+                has_default = arg.default is inspect.Parameter.empty
                 if arg.kind == inspect.Parameter.POSITIONAL_ONLY:
                     arg_kinds.append(nodes.ARG_POS if has_default else nodes.ARG_OPT)
                 elif arg.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:

--- a/mypy/test/teststubtest.py
+++ b/mypy/test/teststubtest.py
@@ -2411,6 +2411,23 @@ assert annotations
             error="func2",
         )
 
+    @collect_cases
+    def test_no_param_defaults_bool_eval(self) -> Iterator[Case]:
+        yield Case(
+            stub="""
+            class Censored:
+                def __bool__(self) -> bool: ...
+            def snowflaky(sensitive_do_not_touch: Censored = ...) -> None: ...
+            """,
+            runtime="""
+            class Censored:
+                def __bool__(self) -> bool:  # never try this at home, kids
+                    raise ValueError
+            def snowflaky(sensitive_do_not_touch: Censored = Censored()) -> None: ...
+            """,
+            error=None,
+        )
+
 
 def remove_color_code(s: str) -> str:
     return re.sub("\\x1b.*?m", "", s)  # this works!


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3875f46e-97ac-4c1a-bd22-7e83e9a6854d)
... not sure what happened here, but this baby platypus wanted to be in this PR for some reason 🤷🏻 

---

This is currently causing `stubtest` to crash when running it on `scipy-stubs` with the latest [`numpy==2.2.0`](https://github.com/numpy/numpy/releases/tag/v2.2.0) release:

```shell
$ stubtest --mypy-config-file=pyproject.toml --allowlist=.mypyignore --ignore-unused-allowlist scipy
Traceback (most recent call last):
  File "/home/runner/work/scipy-stubs/scipy-stubs/.venv/bin/stubtest", line [8](https://github.com/jorenham/scipy-stubs/actions/runs/12246812991/job/34163454128?pr=288#step:7:9), in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/runner/work/scipy-stubs/scipy-stubs/.venv/lib/python3.13/site-packages/mypy/stubtest.py", line 20[9](https://github.com/jorenham/scipy-stubs/actions/runs/12246812991/job/34163454128?pr=288#step:7:10)8, in main
    return test_stubs(parse_options(sys.argv[1:]))
  File "/home/runner/work/scipy-stubs/scipy-stubs/.venv/lib/python3.13/site-packages/mypy/stubtest.py", line 1971, in test_stubs
    for error in test_module(module):
                 ~~~~~~~~~~~^^^^^^^^
  File "/home/runner/work/scipy-stubs/scipy-stubs/.venv/lib/python3.13/site-packages/mypy/stubtest.py", line 247, in test_module
    yield from verify(stub, runtime, [module_name])
  File "/home/runner/work/scipy-stubs/scipy-stubs/.venv/lib/python3.13/site-packages/mypy/stubtest.py", line 423, in verify_mypyfile
    yield from verify(stub_entry, runtime_entry, object_path + [entry])
  File "/home/runner/work/scipy-stubs/scipy-stubs/.venv/lib/python3.13/site-packages/mypy/stubtest.py", line 578, in verify_typeinfo
    yield from verify(stub_to_verify, runtime_attr, object_path + [entry])
  File "/home/runner/work/scipy-stubs/scipy-stubs/.venv/lib/python3.13/site-packages/mypy/stubtest.py", line [10](https://github.com/jorenham/scipy-stubs/actions/runs/12246812991/job/34163454128?pr=288#step:7:11)64, in verify_funcitem
    for message in _verify_signature(stub_sig, runtime_sig, function_name=stub.name):
                   ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/scipy-stubs/scipy-stubs/.venv/lib/python3.[13](https://github.com/jorenham/scipy-stubs/actions/runs/12246812991/job/34163454128?pr=288#step:7:14)/site-packages/mypy/stubtest.py", line 902, in _verify_signature
    yield from _verify_arg_default_value(stub_arg, runtime_arg)
  File "/home/runner/work/scipy-stubs/scipy-stubs/.venv/lib/python3.13/site-packages/mypy/stubtest.py", line 664, in _verify_arg_default_value
    if runtime_arg.default != inspect.Parameter.empty:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: The truth value of an empty array is ambiguous. Use `array.size > 0` to check that an array is not empty.
Error: Process completed with exit code 1.
```

relevant [`scipy-stubs`](https://github.com/jorenham/scipy-stubs) PR: https://github.com/jorenham/scipy-stubs/pull/288