### PR TITLE
Fix grammar `it's` -> `its` for possessive `"its type"` usage

### DIFF
--- a/docs/source/based_inference.rst
+++ b/docs/source/based_inference.rst
@@ -41,7 +41,7 @@ Infer the type of a function parameter from its default value:
 Narrow On Initial Assignment
 ----------------------------
 
-When a variable definition has an explicit annotation, the initialization value will be used to narrow it's type:
+When a variable definition has an explicit annotation, the initialization value will be used to narrow its type:
 
 .. code-block:: python
 
@@ -52,7 +52,7 @@ When a variable definition has an explicit annotation, the initialization value 
 Unused Parameter Inferred
 -------------------------
 
-When a parameter is named `_`, it's type will be inferred as `object`:
+When a parameter is named `_`, its type will be inferred as `object`:
 
 .. code-block:: python
 

--- a/test-data/unit/check-flags.test
+++ b/test-data/unit/check-flags.test
@@ -1260,7 +1260,7 @@ def g(s: List[Any]) -> None:
 
 f(0)
 
-# type of list below is inferred with expected type of "List[Any]", so that becomes it's type
+# type of list below is inferred with expected type of "List[Any]", so that becomes its type
 # instead of List[str]
 g([''])  # E: Expression type contains "Any" (has type "List[Any]")
 [builtins fixtures/list.pyi]


### PR DESCRIPTION
![image](https://github.com/KotlinIsland/basedmypy/blob/master/.github/pull_request.png?raw=true)
hee haw